### PR TITLE
Fix for #258, making deepcopy of experiments in refiner optional.

### DIFF
--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -68,7 +68,7 @@ def e_refine(params, experiments, reflections, graph_verbose=False):
 
     from dials.algorithms.refinement.refiner import RefinerFactory
     refiner = RefinerFactory.from_parameters_data_experiments(params,
-      reflections, experiments, verbosity=1)
+      reflections, experiments, verbosity=1, copy_experiments=False)
 
     history = refiner.run()
 

--- a/algorithms/refinement/refiner.py
+++ b/algorithms/refinement/refiner.py
@@ -428,7 +428,8 @@ class RefinerFactory(object):
                                        params,
                                        reflections,
                                        experiments,
-                                       verbosity=None):
+                                       verbosity=None,
+                                       copy_experiments=True):
 
     #TODO Checks on the input
     #E.g. does every experiment contain at least one overlapping model with at
@@ -439,9 +440,10 @@ class RefinerFactory(object):
     if verbosity is None:
       verbosity = params.refinement.verbosity
 
-    # copy the experiments
-    import copy
-    experiments = copy.deepcopy(experiments)
+    if copy_experiments:
+      # copy the experiments
+      import copy
+      experiments = copy.deepcopy(experiments)
 
     # copy and filter the reflections
     reflections = cls._filter_reflections(reflections)
@@ -449,11 +451,12 @@ class RefinerFactory(object):
     return cls._build_components(params,
                                  reflections,
                                  experiments,
-                                 verbosity=verbosity)
+                                 verbosity=verbosity,
+                                 copy_experiments=copy_experiments)
 
   @classmethod
   def _build_components(cls, params, reflections, experiments,
-                        verbosity):
+                        verbosity, copy_experiments=True):
     """low level build"""
 
     # Currently a refinement job can only have one parameterisation of the
@@ -542,7 +545,7 @@ class RefinerFactory(object):
     # build refiner interface and return
     return Refiner(reflections, experiments,
                     pred_param, param_reporter, refman, target, refinery,
-                    verbosity=verbosity)
+                    verbosity=verbosity, copy_experiments=copy_experiments)
 
   @staticmethod
   def config_sparse(params, experiments):
@@ -1554,7 +1557,7 @@ class Refiner(object):
 
   def __init__(self, reflections, experiments,
                pred_param, param_reporter, refman, target, refinery,
-               verbosity=0):
+               verbosity=0, copy_experiments=True):
     """
     Mandatory arguments:
       reflections - Input ReflectionList data
@@ -1588,8 +1591,11 @@ class Refiner(object):
 
   def get_experiments(self):
 
-    from copy import deepcopy
-    return deepcopy(self._experiments)
+    if self.copy_experiments:
+      from copy import deepcopy
+      return deepcopy(self._experiments)
+    else:
+      return self._experiments
 
   def rmsds(self):
     """Return rmsds of the current model"""

--- a/algorithms/refinement/refiner.py
+++ b/algorithms/refinement/refiner.py
@@ -1575,6 +1575,7 @@ class Refiner(object):
 
     # the experimental models
     self._experiments = experiments
+    self.copy_experiments = copy_experiments
 
     # refinement module main objects
     self._pred_param = pred_param


### PR DESCRIPTION
Add copy_experiments parameter to from_parameters_data_experiments, _build_components and the Refiner constructor.  Default preserves current behavior of deepcopy of experiments during from_parameters_data_experiments and get_experiments.  Change stills indexer to set this to False to speed processing large Eiger datasets.