### PR TITLE
OpenMP broken on Windows

### DIFF
--- a/algorithms/indexing/SConscript
+++ b/algorithms/indexing/SConscript
@@ -23,7 +23,17 @@ env_etc.include_registry.append(
 
 sources = [
     'boost_python/fft3d.cc',
-    'boost_python/indexing_ext.cc']
+    'boost_python/indexing_ext.cc'
+    ]
+
+# Since this code is not using OpenMP a bug in the Microsoft VS2008 compiler means that
+# any /openmp flag must be removed in order to avoid creating a broken library
+if env_etc.compiler == "win32_cl" and "/openmp" in env["SHCCFLAGS"]:
+  ccflags_without_omp = []
+  for f in env["SHCCFLAGS"]:
+    if "/openmp" != f:
+      ccflags_without_omp.append( f )
+  env["SHCCFLAGS"] = ccflags_without_omp
 
 env.SharedLibrary(target='#/lib/dials_algorithms_indexing_ext',
     source=sources,


### PR DESCRIPTION
Hi @jmp1985, @rjgildea 
Could you have a look if this change makes sense?

If happy, could you please click on the green triangle next to _"Merge pull request"_ and choose _"Rebase and merge"_? Thanks :)

This is @oeffner's comment:

> I switched on openmp for nightly builds on windows yesterday. It turns out that the dials.algorithms.indexing module then no longer can be loaded from python. As far as I can see this is a compiler bug. OpenMP is not used anywhere in the dials code unless I'm mistaken. But the linker still tries to include the library at link time but doesn't do it correctly. Trying to load dials.algorithms.indexing then fails.
> 
> A quick and dirty way to rectify this is to #include <omp.h> say in dials\algorithms\indexing\index.h. Instead I tinkered with the dials\algorithms\indexing\SConscript to create a dummy source file that does the same and is linked to the dials.algorithms.indexing module whenever Dials is built on Windows.
> 
> If you think the attached SConscript is OK it would be great if you could commit it to your repo so that libtbx.import_all_ext test will pass without failure again on Windows.