### PR TITLE
rs_mapper: change box size ("cell parameters")

### DIFF
--- a/command_line/rs_mapper.py
+++ b/command_line/rs_mapper.py
@@ -111,7 +111,12 @@ class Script(object):
                 self.process_imageset(imageset)
 
         recviewer.normalize_voxels(self.grid, self.cnts)
-        uc = uctbx.unit_cell((self.grid_size, self.grid_size, self.grid_size, 90, 90, 90))
+        # Let's use 1/(100A) as the unit so that the absolute numbers in the
+        # "cell dimensions" field of the ccp4 map are typical for normal
+        # MX maps. The values in 1/A would give the "cell dimensions" around
+        # or below 1 and some MX programs would not handle it well.
+        box_size = 100 * 2.0 / self.max_resolution
+        uc = uctbx.unit_cell((box_size, box_size, box_size, 90, 90, 90))
         ccp4_map.write_ccp4_map(self.map_file, uc, sgtbx.space_group("P1"),
                                 (0, 0, 0), self.grid.all(), self.grid,
                                 flex.std_string(["cctbx.miller.fft_map"]))


### PR DESCRIPTION
Andrey tested a reciprocal map in 1/A in coot and it didn't work well.
Coot is not expecting so small cells and can't show them well.
We didn't try PyMOL, but we thought it's better to scale the "cell parameters" by 100.
So the unit used is actually (100A)^-1.

Fixes #261

It can be tested in Reciprocal UM here:
http://uglymol.github.io/reciprocal.html
The spots there are from Dials tutorial data (th_8_2).
To add a map, use rs_mapper (after applying this patch) on the same data and then drag and drop the resulting ccp4 file to that page. The result should look like https://github.com/dials/dials/issues/261#issuecomment-274152537 (use '-' to decrease isolevel to around 0.02 rmsd).
