### PR TITLE
Radial average should take the number of summed images into account

### DIFF
--- a/command_line/make_radial_average.py
+++ b/command_line/make_radial_average.py
@@ -156,7 +156,7 @@ class Script(object):
     from dials.algorithms.background import RadialAverage
     radial_average = RadialAverage(beam, detector, vmin, vmax, num_bins)
     for d, m in zip(summed_data, summed_mask):
-      radial_average.add(d.as_double(), m)
+      radial_average.add(d.as_double() / (scan_range[1] - scan_range[0]), m)
     mean = radial_average.mean()
     reso = radial_average.inv_d2()
 


### PR DESCRIPTION
Dear James,

I hope you enjoyed CCP4 school (and Kyoto). As we talked there, `dev.dials.make_radial_average` should take the number of summed images into account.