### PR TITLE
Enable post-integration filtering of overlapping reflections.

### DIFF
--- a/algorithms/integration/overlaps_filter.py
+++ b/algorithms/integration/overlaps_filter.py
@@ -1,0 +1,163 @@
+from __future__ import division
+from libtbx.phil import parse
+from dials.array_family import flex
+
+phil_scope = parse("""
+overlaps_filter {
+  foreground_foreground {
+    enable = False
+      .type = bool
+      .help = "Remove all spots in which neighbors' foreground"
+              "impinges on the spot's foreground"
+  }
+  foreground_background {
+    enable = False
+      .type = bool
+      .help = "Remove all spots in which neighbors' foreground"
+              "impinges on the spot's background"
+  }
+}
+""", process_includes=True)
+
+class OverlapsFilter(object):
+  from dials.algorithms.shoebox import MaskCode
+  code_fgd = MaskCode.Foreground | MaskCode.Valid
+  code_bgd = MaskCode.Background | MaskCode.Valid
+
+  def is_fgd(self, code):
+    return (code & self.code_fgd) == self.code_fgd
+  def is_bgd(self, code):
+    return (code & self.code_bgd) == self.code_bgd
+
+  def __init__(self, refl, expt):
+    self.refl = refl
+    self.expt = expt
+    self.masks = {}
+    det = self.expt.detector
+    assert len(det) == 1 # for now
+    self.size_fast, self.size_slow = det[0].get_image_size()
+    self.array_size = self.size_fast*self.size_slow
+
+  def create_simple_mask(self):
+    self.masks['simple_mask'] = flex.size_t(self.array_size)
+    for obs in self.refl:
+      shoebox = obs['shoebox']
+      fast_coords = xrange(shoebox.xsize())
+      slow_coords = xrange(shoebox.ysize())
+      for f, s in zip(fast_coords, slow_coords):
+        f_abs = f + shoebox.bbox[0] # relative to detector
+        s_abs = s + shoebox.bbox[2] # relative to detector
+        posn = f_abs + s_abs*self.size_fast # position in mask array
+        posn_in_shoebox = f + shoebox.xsize()*s # position in shoebox
+        try:
+          self.masks['simple_mask'][posn] |= shoebox.mask[posn_in_shoebox]
+        except IndexError: # bbox may extend past detector limits
+          continue
+
+  def create_referenced_mask(self, test_code, mask_name):
+    self.masks[mask_name] = [flex.size_t() for _ in xrange(self.array_size)]
+    for idx in xrange(len(self.refl)):
+      obs = self.refl[idx]
+      shoebox = obs['shoebox']
+      fast_coords = xrange(shoebox.xsize())
+      slow_coords = xrange(shoebox.ysize())
+      for f, s in zip(fast_coords, slow_coords):
+        f_abs = f + shoebox.bbox[0] # relative to detector
+        s_abs = s + shoebox.bbox[2] # relative to detector
+        posn = f_abs + s_abs*self.size_fast # position in mask array
+        posn_in_shoebox = f + shoebox.xsize()*s # position in shoebox
+        if (shoebox.mask[posn_in_shoebox] & test_code) == test_code:
+          try:
+            self.masks[mask_name][posn].append(idx)
+          except IndexError: # bbox may extend past detector limits
+            continue
+
+  def filter_using_simple_mask(self, mask_lambda, shoebox_lambda=lambda x:True):
+    """At each pixel, examine the simple mask to determine if contributing
+    observations should be excluded. When this condition mask_lambda is met,
+    for each contributing observation, use optional condition shoebox_lambda
+    to determine if the observation should be excluded (e.g. to exclude only
+    those reflections contributing foreground). Return the mask reflecting
+    this filter.
+    """
+    keep_refl_bool = flex.bool(len(self.refl), True)
+    for idx in xrange(len(self.refl)):
+      obs = self.refl[idx]
+      shoebox = obs['shoebox']
+      fast_coords = xrange(shoebox.xsize())
+      slow_coords = xrange(shoebox.ysize())
+      for f, s in zip(fast_coords, slow_coords):
+        f_abs = f + shoebox.bbox[0] # relative to detector
+        s_abs = s + shoebox.bbox[2] # relative to detector
+        posn = f_abs + s_abs*self.size_fast # position in mask array
+        posn_in_shoebox = f + shoebox.xsize()*s # position in shoebox
+        try:
+          if mask_lambda(self.masks['simple_mask'][posn]): # condition met in simple mask
+            if shoebox_lambda(shoebox.mask[posn_in_shoebox]): # condition met in shoebox
+              keep_refl_bool[idx] = False
+        except IndexError: # bbox may extend past detector limits
+          continue
+    return keep_refl_bool
+
+  def filter_all_using_referenced_mask(self, mask_name):
+    """Return the mask reflecting the exclusion of any reflections for which the
+    mask condition is true (e.g. untrusted pixels).
+    """
+    keep_refl_bool = flex.bool(len(self.refl), True)
+    for i in self.masks[mask_name]:
+      if len(i) > 0:
+        for ref in i:
+          keep_refl_bool[ref] = False
+    return keep_refl_bool
+
+  def filter_overlaps_using_referenced_mask(self, mask_name):
+    """At each pixel, define an overlap to be more than one reference (to an
+    observation) indicated in the mask. Return the mask reflecting the exclusion
+    of any overlaps (e.g. foreground with foreground).
+    """
+    keep_refl_bool = flex.bool(len(self.refl), True)
+    for i in self.masks[mask_name]:
+      if len(i) > 1:
+        for ref in i:
+          keep_refl_bool[ref] = False
+    return keep_refl_bool
+
+  def remove_foreground_foreground_overlaps(self):
+    self.create_referenced_mask(self.code_fgd, "foreground")
+    self.refl = self.refl.select(self.filter_overlaps_using_referenced_mask("foreground"))
+
+  def remove_foreground_background_overlaps(self):
+    self.create_simple_mask()
+    def is_overlap(code):
+      return self.is_fgd(code) and self.is_bgd(code)
+    self.refl = self.refl.select(self.filter_using_simple_mask(mask_lambda=is_overlap))
+
+class OverlapsFilterMultiExpt(object):
+
+  def __init__(self, refl, expt):
+    self.filters = [OverlapsFilter(r, e) for (r, e) in zip(refl.split_by_experiment_id(), expt)]
+
+  def remove_foreground_foreground_overlaps(self):
+    for f in self.filters:
+      f.remove_foreground_foreground_overlaps()
+
+  def remove_foreground_background_overlaps(self):
+    for f in self.filters:
+      f.remove_foreground_background_overlaps()
+
+  @property
+  def refl(self):
+    rlist = [f.refl for f in self.filters]
+    r0 = flex.reflection_table()
+    for r in rlist:
+      r0.extend(r)
+    return r0
+
+  @property
+  def expt(self):
+    elist = [f.expt for f in self.filters]
+    from dxtbx.model.experiment_list import ExperimentList
+    e0 = ExperimentList()
+    for e in elist:
+      e0.append(e)
+    return e0

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,6 +32,7 @@ tst_list = (
     "$D/test/algorithms/integration/tst_interface.py",
     "$D/test/algorithms/integration/tst_profile_fitting_rs.py",
     "$D/test/algorithms/integration/tst_summation.py",
+    "$D/test/algorithms/integration/tst_filter_overlaps.py",
     "$D/test/algorithms/polygon/clip/tst_clipping.py",
     "$D/test/algorithms/polygon/tst_spatial_interpolation.py",
     "$D/test/algorithms/profile_model/tst_profile_model.py",

--- a/test/algorithms/integration/tst_filter_overlaps.py
+++ b/test/algorithms/integration/tst_filter_overlaps.py
@@ -1,0 +1,105 @@
+from __future__ import division
+from cctbx.array_family import flex
+
+class TestForOverlaps(object):
+  from dials.algorithms.shoebox import MaskCode
+
+  code_fgd = MaskCode.Foreground | MaskCode.Valid
+  @staticmethod
+  def is_fgd(code):
+    return (code & TestForOverlaps.code_fgd) == TestForOverlaps.code_fgd
+
+  code_bgd = MaskCode.Background | MaskCode.Valid
+  @staticmethod
+  def is_bgd(code):
+    return (code & TestForOverlaps.code_bgd) == TestForOverlaps.code_bgd
+
+  code_overlap = code_fgd | code_bgd
+  @staticmethod
+  def is_overlap(code):
+    return (code & TestForOverlaps.code_overlap) == TestForOverlaps.code_overlap
+
+  def __init__(self):
+    '''Initialise the script.'''
+    from dials.util.options import OptionParser, Importer, flatten_experiments, flatten_reflections
+    import libtbx.load_env
+
+    # The script usage
+    usage = "usage: %s experiments.json reflections.pickle" \
+            % libtbx.env.dispatcher_name
+
+    # Initialise the base class
+    self.parser = OptionParser(
+      usage=usage,
+      read_experiments=True,
+      read_reflections=True)
+
+    # Parse the command line
+    params, options = self.parser.parse_args(show_diff_phil=False)
+
+    self.experiments = flatten_experiments(params.input.experiments)
+    self.reflections = flatten_reflections(params.input.reflections)
+
+  def run(self):
+    for expt, refl in zip(self.experiments, self.reflections):
+      det = expt.detector
+      size_fast, size_slow = det[0].get_image_size()
+      mask_array = flex.size_t(size_fast*size_slow)
+      for obs in refl:
+        shoebox = obs['shoebox']
+        fast_coords = xrange(shoebox.xsize())
+        slow_coords = xrange(shoebox.ysize())
+        for f, s in zip(fast_coords, slow_coords):
+          f_abs = f + shoebox.bbox[0] # relative to detector
+          s_abs = s + shoebox.bbox[2] # relative to detector
+          posn = f_abs + s_abs*size_fast # position in mask_array
+          posn_in_shoebox = f + shoebox.xsize()*s # position in shoebox
+          if self.is_fgd(shoebox.mask[posn_in_shoebox]) and self.is_fgd(mask_array[posn]):
+            print "Overlapping foreground found at indexed position (%d, %d), " % (f_abs, s_abs) \
+            + "observed centroid (%d, %d)" % (obs['xyzcal.px'][0], obs['xyzcal.px'][1])
+            assert False
+          try:
+            mask_array[posn] |= shoebox.mask[posn_in_shoebox]
+          except IndexError:
+            continue
+      for i in xrange(len(mask_array)):
+        this_code = mask_array[i]
+        if self.is_overlap(this_code):
+          f = i % shoebox.xsize()
+          s = i // shoebox.xsize()
+          print "Overlapping foreground and background found at (%d, %d)" % (f, s)
+          assert False
+    print "OK"
+
+class Test(TestForOverlaps):
+
+  def __init__(self):
+    from dials.util.options import Importer, flatten_experiments, flatten_reflections
+    import libtbx.load_env
+    try:
+      dials_regression = libtbx.env.dist_path('dials_regression')
+    except KeyError, e:
+      print 'SKIP: dials_regression not configured'
+      exit(0)
+
+    # test data
+    import os
+    refl_path = os.path.join(dials_regression,
+      'integration_test_data', 'stills_PSII', 'idx-20161021225550223_integrated.pickle')
+    expt_path = os.path.join(dials_regression,
+      'integration_test_data', 'stills_PSII', 'idx-20161021225550223_refined_experiments.json')
+
+    importer = Importer([refl_path, refl_path, expt_path, expt_path], read_experiments=True, read_reflections=True, check_format=False)
+
+    self.reflections = flatten_reflections(importer.reflections)
+    self.experiments = flatten_experiments(importer.experiments)
+
+    from dials.algorithms.integration.overlaps_filter import OverlapsFilterMultiExpt
+    overlaps_filter = OverlapsFilterMultiExpt(self.reflections[0], self.experiments)
+    overlaps_filter.remove_foreground_foreground_overlaps()
+    overlaps_filter.remove_foreground_background_overlaps()
+    self.reflections = [overlaps_filter.refl]
+
+if __name__ == '__main__':
+  test = Test()
+  test.run()


### PR DESCRIPTION
In the final step of integration, check for overlapping foreground between multiple spots or overlapping foreground with neighboring spots' background, if requested, and remove these reflections from the final result. (Default: off.)