### PR TITLE
Enforce stills symmetry

### DIFF
--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -1559,6 +1559,7 @@ class indexer_base(object):
     c = matrix.col(direct_matrix[6:9])
     model = Crystal(
       a, b, c, space_group=target_sg_best)
+    assert target_sg_best.is_compatible_unit_cell(model.get_unit_cell())
 
     model = model.change_basis(cb_op_best_primitive)
     return model, cb_op_inp_primitive

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -164,37 +164,6 @@ class stills_indexer(indexer_base):
         # no more lattices found
         break
 
-      ### TODO verify things don't need to be re-indexed if a target is provided
-      if False: #self.params.known_symmetry.space_group is not None:
-        # now apply the space group symmetry only after the first indexing
-        # need to make sure that the symmetrized orientation is similar to the P1 model
-        target_space_group = self.target_symmetry_primitive.space_group()
-        for i_cryst, cryst in enumerate(experiments.crystals()):
-          if i_cryst >= n_lattices_previous_cycle:
-            new_cryst, cb_op_to_primitive = self.apply_symmetry(
-              cryst, target_space_group)
-            if self.cb_op_primitive_inp is not None:
-              new_cryst = new_cryst.change_basis(self.cb_op_primitive_inp)
-              logger.info(new_cryst.get_space_group().info())
-            cryst.update(new_cryst)
-            cryst.set_space_group(
-              self.params.known_symmetry.space_group.group())
-            for i_expt, expt in enumerate(experiments):
-              if expt.crystal is not cryst:
-                continue
-              if not cb_op_to_primitive.is_identity_op():
-                miller_indices = self.reflections['miller_index'].select(
-                  self.reflections['id'] == i_expt)
-                miller_indices = cb_op_to_primitive.apply(miller_indices)
-                self.reflections['miller_index'].set_selected(
-                  self.reflections['id'] == i_expt, miller_indices)
-              if self.cb_op_primitive_inp is not None:
-                miller_indices = self.reflections['miller_index'].select(
-                  self.reflections['id'] == i_expt)
-                miller_indices = self.cb_op_primitive_inp.apply(miller_indices)
-                self.reflections['miller_index'].set_selected(
-                  self.reflections['id'] == i_expt, miller_indices)
-
       # discard nearly overlapping lattices on the same shot
       if len(experiments) > 1:
         from dials.algorithms.indexing.compare_orientation_matrices \

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -432,7 +432,7 @@ class stills_indexer(indexer_base):
       indexed = refl.select(refl['id'] >= 0)
       indexed = indexed.select(indexed.get_flags(indexed.flags.indexed))
 
-      # If target symmetry applied, try to apply it.  Then, apply the change of basis to the reflections
+      # If target symmetry supplied, try to apply it.  Then, apply the change of basis to the reflections
       # indexed in P1 to the target setting
       if self.params.known_symmetry.space_group is not None:
         target_space_group = self.target_symmetry_primitive.space_group()

--- a/test/command_line/tst_stills_process.py
+++ b/test/command_line/tst_stills_process.py
@@ -127,9 +127,13 @@ class Test(object):
     #                            "idx-run266702-0-subset_00003_integrated.pickle"],
     #                            [range(600,610),range(505,520)]): # large ranges to handle platform-specific differences
     # 04/25/17 Changes after reverting sign_error_27Feb2014_through_15Feb2017 in xfel/mono_simulation/max_like.py
+    #for result, n_refls in zip(["idx-run266702-0-subset_00001_integrated.pickle",
+    #                            "idx-run266702-0-subset_00003_integrated.pickle"],
+    #                            [range(565,580),range(495,510)]): # large ranges to handle platform-specific differences
+    # 09/20/17 Changes to still indexer: refine candidate basis vectors in target symmetry if supplied
     for result, n_refls in zip(["idx-run266702-0-subset_00001_integrated.pickle",
                                 "idx-run266702-0-subset_00003_integrated.pickle"],
-                                [range(565,580),range(495,510)]): # large ranges to handle platform-specific differences
+                                [range(100,115),range(155,165)]): # large ranges to handle platform-specific differences
       table = pickle.load(open(result, 'rb'))
       assert len(table) in n_refls, len(table)
       assert 'id' in table


### PR DESCRIPTION
Update the stills indexer, changing how it applies the input known symmetry while choosing candidate basis vectors.

Old behavior: index the reflections in P1 and refine candidates in P1.  Pick the best candidate based on RMSD.  Apply target symmetry to crystal model and apply a change of basis to the miller indices.

New behavior: index the reflections in P1, then apply target symmetry to crystal model and change of basis to miller indices.  Refine each candidate using the known symmetry.  Pick the best candidate based on RMSD.

Seems to improve RMSDs based on my tests.