### PR TITLE
Modify the DIALS license so that it is correctly detected

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2015 Diamond Light Source, Lawrence Berkeley National Laboratory
-and the Science and Technology Facilities Council, All rights reserved.
+Copyright (c) 2015 Diamond Light Source, Lawrence Berkeley National Laboratory, and the Science and Technology Facilities Council.
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -11,10 +11,9 @@ Redistributions in binary form must reproduce the above copyright notice, this
 list of conditions and the following disclaimer in the documentation and/or
 other materials provided with the distribution.
 
-Neither the name of the Diamond Light Source, Lawrence Berkeley National
-Laboratory or the Science and Technology Facilities Council, nor the names of
-its contributors may be used to endorse or promote products derived from this
-software without specific prior written permission.
+Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED


### PR DESCRIPTION
as BSD 3-clause license by license-detecting software.

Unfortunately this includes a change in the wording in the 3rd condition from a list of involved companies to "the copyright holder".

Can we do this?