### PR TITLE
Xtc speedup

### DIFF
--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -308,7 +308,6 @@ class ManualGeometryUpdater(object):
     Override the parameters
 
     '''
-    from dxtbx.imageset import ImageSet
     from dxtbx.imageset import ImageSweep
     from dxtbx.model import BeamFactory
     from dxtbx.model import DetectorFactory
@@ -316,7 +315,7 @@ class ManualGeometryUpdater(object):
     from dxtbx.model import ScanFactory
     from copy import deepcopy
     if self.params.geometry.convert_sweeps_to_stills:
-      imageset = ImageSet(data=imageset.data())
+      imageset = imageset.__class__(data=imageset.data())
     if not isinstance(imageset, ImageSweep):
       if self.params.geometry.convert_stills_to_sweeps:
         imageset = self.convert_stills_to_sweep(imageset)

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -308,14 +308,14 @@ class ManualGeometryUpdater(object):
     Override the parameters
 
     '''
-    from dxtbx.imageset import ImageSweep
+    from dxtbx.imageset import ImageSweep, ImageSetFactory
     from dxtbx.model import BeamFactory
     from dxtbx.model import DetectorFactory
     from dxtbx.model import GoniometerFactory
     from dxtbx.model import ScanFactory
     from copy import deepcopy
     if self.params.geometry.convert_sweeps_to_stills:
-      imageset = imageset.__class__(data=imageset.data())
+      imageset = ImageSetFactory.imageset_from_anyset(imageset)
     if not isinstance(imageset, ImageSweep):
       if self.params.geometry.convert_stills_to_sweeps:
         imageset = self.convert_stills_to_sweep(imageset)

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -336,7 +336,7 @@ class Script(object):
             for imageset in item[1].extract_imagesets():
               update_geometry(imageset)
           except RuntimeError as e:
-            logger.info("Error updating geometry on item %s, %s"%(str(item[0]), str(e)))
+            logger.warning("Error updating geometry on item %s, %s"%(str(item[0]), str(e)))
             continue
 
           if self.reference_detector is not None:
@@ -379,7 +379,7 @@ class Script(object):
           try:
             update_geometry(imagesets[0])
           except RuntimeError as e:
-            logger.info("Error updating geometry on item %s, %s"%(tag, str(e)))
+            logger.warning("Error updating geometry on item %s, %s"%(tag, str(e)))
             continue
 
           if self.reference_detector is not None:

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -195,8 +195,9 @@ def do_import(filename):
   # Ensure the indexer and downstream applications treat this as set of stills
   reset_sets = []
 
+  from dxtbx.imageset import ImageSetFactory
   for imageset in datablocks[0].extract_imagesets():
-    imageset = imageset.__class__(imageset.data(), imageset.indices())
+    imageset = ImageSetFactory.imageset_from_anyset(imageset)
     imageset.set_scan(None)
     imageset.set_goniometer(None)
     reset_sets.append(imageset)

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -344,7 +344,7 @@ class Script(object):
           try:
             for imageset in item[1].extract_imagesets():
               update_geometry(imageset)
-          except Exception as e:
+          except RuntimeError as e:
             logger.info("Error updating geometry on item %s, %s"%(str(item[0]), str(e)))
             continue
 
@@ -384,7 +384,7 @@ class Script(object):
 
           try:
             update_geometry(imagesets[0])
-          except Exception as e:
+          except RuntimeError as e:
             logger.info("Error updating geometry on item %s, %s"%(tag, str(e)))
             continue
 

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -341,8 +341,13 @@ class Script(object):
         processor = Processor(copy.deepcopy(params), composite_tag = "%04d"%i)
 
         for item in item_list:
-          for imageset in item[1].extract_imagesets():
-            update_geometry(imageset)
+          try:
+            for imageset in item[1].extract_imagesets():
+              update_geometry(imageset)
+          except Exception as e:
+            logger.info("Error updating geometry on item %s, %s"%(str(item[0]), str(e)))
+            continue
+
           processor.process_datablock(item[0], item[1])
         processor.finalize()
 
@@ -377,7 +382,11 @@ class Script(object):
             from dxtbx.model import Detector
             imagesets[0].set_detector(Detector.from_dict(self.reference_detector.to_dict()))
 
-          update_geometry(imagesets[0])
+          try:
+            update_geometry(imagesets[0])
+          except Exception as e:
+            logger.info("Error updating geometry on item %s, %s"%(tag, str(e)))
+            continue
 
           processor.process_datablock(tag, datablock)
         processor.finalize()

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -309,15 +309,6 @@ class Script(object):
 
       datablocks = [do_import(path) for path in all_paths]
 
-      if self.reference_detector is not None:
-        from dxtbx.model import Detector
-        for datablock in datablocks:
-          for imageset in datablock.extract_imagesets():
-            for i in range(len(imageset)):
-              imageset.set_detector(
-                Detector.from_dict(self.reference_detector.to_dict()),
-                index=i)
-
       indices = []
       basenames = []
       split_datablocks = []
@@ -347,6 +338,13 @@ class Script(object):
           except RuntimeError as e:
             logger.info("Error updating geometry on item %s, %s"%(str(item[0]), str(e)))
             continue
+
+          if self.reference_detector is not None:
+            from dxtbx.model import Detector
+            for i in range(len(imageset)):
+              imageset.set_detector(
+                Detector.from_dict(self.reference_detector.to_dict()),
+                index=i)
 
           processor.process_datablock(item[0], item[1])
         processor.finalize()
@@ -378,15 +376,15 @@ class Script(object):
           if len(imagesets[0]) > 1:
             raise Abort("Found a multi-image file. Run again with pre_import=True")
 
-          if self.reference_detector is not None:
-            from dxtbx.model import Detector
-            imagesets[0].set_detector(Detector.from_dict(self.reference_detector.to_dict()))
-
           try:
             update_geometry(imagesets[0])
           except RuntimeError as e:
             logger.info("Error updating geometry on item %s, %s"%(tag, str(e)))
             continue
+
+          if self.reference_detector is not None:
+            from dxtbx.model import Detector
+            imagesets[0].set_detector(Detector.from_dict(self.reference_detector.to_dict()))
 
           processor.process_datablock(tag, datablock)
         processor.finalize()


### PR DESCRIPTION
Changes in dials sources using features introduced in cctbx/cctbx_project#179

1. imageset is setup using the __class__ method. This helps Just-in-Time reading of the models instead of instantiating all of them at the beginning. 

2. User can specify reference_geometry, which applies geometry from a phil file, or can specify geometry manually using the geometry phil options.  This commit swaps the order these are applied to match the order in xtc_process.  A positive side effect is faster performance since applying the reference geometry now is in the do_work function for composite files, so each image only has the geometry applied once, instead of once per process.

By 
Aaron Brewster and Asmit Bhowmick

