### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,67 @@
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libjpeg62
+
+language: python
+python:
+  - "2.7"
+
+cache:
+  directories:
+    - $HOME/build_dials
+
+jobs:
+  include:
+    - stage: build
+      install:
+         # Setup a base installation
+         - ./.travis/setup-base
+
+         # Inject DIALS
+         - rm -rf $HOME/build_dials/modules/dials
+         - mv $HOME/build/dials/dials $HOME/build_dials/modules/dials
+
+         # Update CCTBX
+         - $HOME/build_dials/modules/dials/.travis/clean-cctbx
+         - $HOME/build_dials/modules/dials/.travis/update-cctbx
+
+      before_script:
+         # Enter CCTBX environment
+         - cat $HOME/build_dials/build/setpaths.sh
+         - cd $HOME/build_dials/build
+         - . setpaths.sh
+
+         # Prepare for the build step
+         - libtbx.configure .
+
+      script:
+         # Parallel builds do not work. Only spend at most 40 minutes on a build.
+         # This allows incremental building, so if the build can't be finished within the allotted time
+         # it will be resumed from that point in the next build.
+         - $HOME/build_dials/modules/dials/.travis/build-for 40m
+
+    - stage: test
+      before_script:
+         # Inject DIALS. Again.
+         - rm -rf $HOME/build_dials/modules/dials
+         - mv $HOME/build/dials/dials $HOME/build_dials/modules/dials
+
+         # Enter CCTBX environment
+         - cd $HOME/build_dials/build
+         - . setpaths.sh
+
+         # If needed allow up to further 30 minutes worth of building time
+         - $HOME/build_dials/modules/dials/.travis/build-for 30m if_required
+
+      script:
+         # Finally. Do what we are here for. Run tests. Yay.
+         - cd $HOME/build_dials/modules/dials
+         - pytest -ra -n 2
+
+before_cache:
+  - $HOME/build_dials/modules/dials/.travis/clean-cctbx
+  - cd $HOME
+  - rm -rf $HOME/build_dials/modules/dials

--- a/.travis/build-for
+++ b/.travis/build-for
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ "$2" == "if_required" ] && [ -e $HOME/build_dials/.build_complete ]; then
+  echo Build step not required, skipping.
+  exit 0
+fi
+cd $HOME/build_dials/build
+timeout $1 libtbx.scons -j 1
+exit_status=$?
+if [ $exit_status -eq 124 ]; then
+  echo Timeout encountered.
+  rm -f $HOME/build_dials/.build_complete
+  exit 0
+fi
+touch $HOME/build_dials/.build_complete
+exit $exit_status

--- a/.travis/clean-cctbx
+++ b/.travis/clean-cctbx
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -e $HOME/build_dials/modules/cctbx_project/.git ]; then
+  echo Cleaning cctbx_project repository
+  cd $HOME/build_dials/modules/cctbx_project || exit 1
+  git reset --hard HEAD
+  git clean -dffx
+fi

--- a/.travis/setup-base
+++ b/.travis/setup-base
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+  echo -e "\e[31;1mCron job build detected. Invalidating cache.\e[0m"
+  rm -f $HOME/build_dials/.cache_valid
+  rm -f $HOME/build_dials/.build_complete
+fi
+
+if [ -f $HOME/build_dials/.cache_valid ]; then
+  echo -e "\e[1mCache probably valid\e[0m"
+else
+  echo -e "\e[31;1mThis is not the cache you are looking for: Starting from scratch\e[0m"
+  cd $HOME
+  wget http://dials.diamond.ac.uk/diamond_builds/dials-linux-x86_64.tar.xz -O - | tar xJ
+  cd dials-installer-dev
+  ./install --nopycompile --verbose --prefix=..
+  cd ..
+
+  # Destroy existing cache
+  rm -rf build_dials
+
+  # Fix up build path
+  mv dials-dev* build_dials
+  sed -i -e 's/dials-dev[0-9]\+/build_dials/g' $HOME/build_dials/build/setpaths.sh
+
+  # Define this as a valid base install
+  touch $HOME/build_dials/.cache_valid
+fi

--- a/.travis/update-cctbx
+++ b/.travis/update-cctbx
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -e $HOME/build_dials/modules/cctbx_project ] && [ ! -e $HOME/build_dials/modules/cctbx_project/.git ]; then
+  echo Cleaning existing cctbx_project directory
+  rm -rf $HOME/build_dials/modules/cctbx_project
+fi
+
+if [ ! -e $HOME/build_dials/modules/cctbx_project ]; then
+  echo Cloning cctbx_project from scratch
+  git clone https://github.com/cctbx/cctbx_project.git --depth=1 $HOME/build_dials/modules/cctbx_project
+fi
+
+echo Checking out latest cctbx_project commit
+cd $HOME/build_dials/modules/cctbx_project || exit 1
+git fetch origin master --depth=1 || exit 2
+git checkout FETCH_HEAD || exit 3
+echo CCTBX is at commit:
+git show --oneline -s --no-abbrev-commit || exit 4


### PR DESCRIPTION
Initial build and one build per week (triggered per cron job) takes ~80 minutes
Subsequent builds will then speed up to approx ~15 minutes.
Runs on every branch, every pull request. Including this one.
Runs all dials tests that are not marked as slow, and do not depend on any *_regression repository
Uses cctbx master branch. Whenever that is broken it may affect builds here.
Changes in the base build can take up to one week to propagate here.

So do we want this? 😄 