### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/algorithms/indexing/fft3d.h
+++ b/algorithms/indexing/fft3d.h
@@ -104,7 +104,7 @@ namespace dials { namespace algorithms {
   Högbom, J. A. 1974, A&AS, 15, 417.
 
   See also:
-    http://dx.doi.org/10.1051/0004-6361/200912148
+    https://doi.org/10.1051/0004-6361/200912148
   */
   af::shared<vec3<int> > clean_3d(
     af::const_ref<double, af::c_grid<3> > const & dirty_beam,

--- a/algorithms/refinement/outlier_detection/outlier_base.py
+++ b/algorithms/refinement/outlier_detection/outlier_base.py
@@ -343,7 +343,7 @@ outlier
 
   sauter_poon
     .help = "Options for the outlier rejector described in Sauter & Poon (2010)"
-            "(http://dx.doi.org/10.1107/S0021889810010782)"
+            "(https://doi.org/10.1107/S0021889810010782)"
     .expert_level = 1
   {
     px_sz = Auto

--- a/algorithms/refinement/outlier_detection/sauter_poon.py
+++ b/algorithms/refinement/outlier_detection/sauter_poon.py
@@ -17,7 +17,7 @@ from dials.array_family import flex
 
 class SauterPoon(CentroidOutlier):
   """Implementation of the CentroidOutlier class using the algorithm of
-  Sauter & Poon (2010) (http://dx.doi.org/10.1107/S0021889810010782)."""
+  Sauter & Poon (2010) (https://doi.org/10.1107/S0021889810010782)."""
 
   def __init__(self, cols=None,
                min_num_obs=20,

--- a/algorithms/spot_finding/per_image_analysis.py
+++ b/algorithms/spot_finding/per_image_analysis.py
@@ -331,7 +331,7 @@ def estimate_resolution_limit_distl_method1(
   # Implementation of Method 1 (section 2.4.4) of:
   # Z. Zhang, N. K. Sauter, H. van den Bedem, G. Snell and A. M. Deacon
   # J. Appl. Cryst. (2006). 39, 112-119
-  # http://dx.doi.org/10.1107/S0021889805040677
+  # https://doi.org/10.1107/S0021889805040677
 
   if ice_sel is None:
     ice_sel = flex.bool(len(reflections), False)
@@ -437,7 +437,7 @@ def estimate_resolution_limit_distl_method2(
   # Implementation of Method 2 (section 2.4.4) of:
   # Z. Zhang, N. K. Sauter, H. van den Bedem, G. Snell and A. M. Deacon
   # J. Appl. Cryst. (2006). 39, 112-119
-  # http://dx.doi.org/10.1107/S0021889805040677
+  # https://doi.org/10.1107/S0021889805040677
 
   if ice_sel is None:
     ice_sel = flex.bool(len(reflections), False)

--- a/command_line/stereographic_projection.py
+++ b/command_line/stereographic_projection.py
@@ -104,7 +104,7 @@ def reference_poles_crystal(crystal_model, plane_normal=(0,0,1)):
   return tuple((B * h).normalize() for h in (h0, h1, h2))
 
 def stereographic_projection(points, reference_poles):
-  # http://dx.doi.org/10.1107/S0021889868005029
+  # https://doi.org/10.1107/S0021889868005029
   # J. Appl. Cryst. (1968). 1, 68-70
   # The construction of stereographic projections by computer
   # G. K. Stokes, S. R. Keown and D. J. Dyson

--- a/doc/sphinx/documentation/tutorials/correcting_poor_initial_geometry_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/correcting_poor_initial_geometry_tutorial.rst
@@ -11,7 +11,7 @@ was collected at beamline 19-ID at the APS. This dataset is available for
 download from |DPF3|.
 
 .. |DPF3| image:: https://zenodo.org/badge/doi/10.5281/zenodo.45756.svg
-          :target: http://dx.doi.org/10.5281/zenodo.45756
+          :target: https://doi.org/10.5281/zenodo.45756
 
 This is a challenging dataset to process. There are a combination of problems,
 including:
@@ -203,7 +203,7 @@ to refine compatible Bravais lattices::
 It turns out that quite a few lattices can be forced to fit the putative
 indexing solution, but again there are warnings everywhere that imply none
 of these are right. First look at the ``Metric fit`` column. This value is
-the `Le Page <http://dx.doi.org/10.1107/S0021889882011959>`_ :math:`\delta`
+the `Le Page <https://doi.org/10.1107/S0021889882011959>`_ :math:`\delta`
 value. For a correct indexing solution with a good dataset this should be a
 small number, less than 0.1 say, such as in the
 :doc:`processing_in_detail_tutorial` tutorial. The ``rmsd`` column reports an
@@ -285,7 +285,7 @@ mis-indexed solution. The typical culprit in such cases is a badly wrong
 beam centre. DIALS provides the
 :program:`dials.search_beam_position`, which can help out
 here. This performs a grid search to improve the direct beam position using
-the `methods <http://dx.doi.org/10.1107%2FS0021889804005874>`_ also
+the `methods <https://doi.org/10.1107%2FS0021889804005874>`_ also
 implemented in :program:`LABELIT`.
 
 This sits in between the spot finding and the indexing operations, so that

--- a/doc/sphinx/documentation/tutorials/multi_lattice_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/multi_lattice_tutorial.rst
@@ -14,7 +14,7 @@ datasets which are contained in the file `semisynthetic_multilattice_data_2.tar.
 .. _semisynthetic_multilattice_data_2.tar.bz2: https://zenodo.org/record/10820/files/semisynthetic_multilattice_data_2.tar.bz2
 
 .. |semisynthetic| image:: https://zenodo.org/badge/doi/10.5281/zenodo.10820.svg
-               :target: http://dx.doi.org/10.5281/zenodo.10820
+               :target: https://doi.org/10.5281/zenodo.10820
 
 Import
 ^^^^^^

--- a/doc/sphinx/documentation/tutorials/processing_in_detail_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/processing_in_detail_tutorial.rst
@@ -19,7 +19,7 @@ The following example uses a Thaumatin dataset collected using beamline I04
 at Diamond Light Source, which is available for download from |thaumatin|.
 
 .. |thaumatin| image:: https://zenodo.org/badge/doi/10.5281/zenodo.10271.svg
-               :target: http://dx.doi.org/10.5281/zenodo.10271
+               :target: https://doi.org/10.5281/zenodo.10271
 
 Import
 ^^^^^^

--- a/test/algorithms/indexing/test_index_synthetic.py
+++ b/test/algorithms/indexing/test_index_synthetic.py
@@ -39,7 +39,7 @@ def any_compatible_unit_cell(space_group, volume=None, asu_volume=None):
     gamma = random.uniform(0, 180)
 
     # Allowed combinations of angles for a triclinic cell:
-    #   http://dx.doi.org/10.1107/S0108767310044296
+    #   https://doi.org/10.1107/S0108767310044296
     if ((alpha + beta + gamma) > 0 and
         (alpha + beta + gamma) < 360 and
         (alpha + beta - gamma) > 0 and

--- a/test/algorithms/scaling/test_HRS_derivatives.py
+++ b/test/algorithms/scaling/test_HRS_derivatives.py
@@ -1,5 +1,5 @@
 """Test derivatives of the Hamilton, Rollett and Sparks least-squares target
-(http://doi.org/10.1107/S0365110X65000233)"""
+(https://doi.org/10.1107/S0365110X65000233)"""
 
 from __future__ import absolute_import, division, print_function
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!