### PR TITLE
Import experiments

### DIFF
--- a/algorithms/spot_finding/factory.py
+++ b/algorithms/spot_finding/factory.py
@@ -455,7 +455,7 @@ class SpotFinderFactory(object):
   '''
 
   @staticmethod
-  def from_parameters(params=None, datablock=None):
+  def from_parameters(params=None, experiments=None):
     '''
     Given a set of parameters, construct the spot finder
 
@@ -473,11 +473,11 @@ class SpotFinderFactory(object):
 
     if params.spotfinder.force_2d and params.output.shoeboxes is False:
       no_shoeboxes_2d = True
-    elif datablock is not None and params.output.shoeboxes is False:
+    elif experiments is not None and params.output.shoeboxes is False:
       no_shoeboxes_2d = False
       all_stills = True
-      for imageset in datablock.extract_imagesets():
-        if isinstance(imageset, ImageSweep):
+      for experiment in experiments:
+        if isinstance(experiment.imageset, ImageSweep):
           all_stills = False
           break
       if all_stills:
@@ -494,7 +494,7 @@ class SpotFinderFactory(object):
 
     # Create the threshold strategy
     threshold_function = SpotFinderFactory.configure_threshold(params,
-                                                               datablock)
+                                                               experiments)
 
     # Configure the mask generator
     mask_generator = MaskGenerator(params.spotfinder.filter)
@@ -525,7 +525,7 @@ class SpotFinderFactory(object):
       min_chunksize             = params.spotfinder.mp.min_chunksize)
 
   @staticmethod
-  def configure_threshold(params, datablock):
+  def configure_threshold(params, experiments):
     '''
     Get the threshold strategy
 

--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -749,7 +749,7 @@ class SpotFinder(object):
     self.no_shoeboxes_2d = no_shoeboxes_2d
     self.min_chunksize = min_chunksize
 
-  def __call__(self, datablock):
+  def __call__(self, experiments):
     '''
     Do the spot finding.
 
@@ -763,7 +763,9 @@ class SpotFinder(object):
 
     # Loop through all the imagesets and find the strong spots
     reflections = flex.reflection_table()
-    for i, imageset in enumerate(datablock.extract_imagesets()):
+    for i, experiment in enumerate(experiments):
+
+      imageset = experiment.imageset
 
       # Find the strong spots in the sweep
       logger.info('-' * 80)
@@ -795,7 +797,7 @@ class SpotFinder(object):
       reflections.flags.strong)
 
     # Check for overloads
-    reflections.is_overloaded(datablock)
+    reflections.is_overloaded(experiments)
 
     # Return the reflections
     return reflections

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -152,11 +152,11 @@ class reflection_table_aux(boost.python.injector, reflection_table):
     return result
 
   @staticmethod
-  def from_observations(datablock, params=None):
+  def from_observations(experiments, params=None):
     '''
     Construct a reflection table from observations.
 
-    :param datablock: The datablock
+    :param experiments: The experiments
     :param params: The input parameters
     :return: The reflection table of observations
 
@@ -171,7 +171,7 @@ class reflection_table_aux(boost.python.injector, reflection_table):
       params = phil_scope.fetch(source=parse("")).extract()
 
     if params.spotfinder.filter.min_spot_size is Auto:
-      detector = datablock.extract_imagesets()[0].get_detector()
+      detector = experiments[0].imageset.get_detector()
       if detector[0].get_type() == 'SENSOR_PAD':
         # smaller default value for pixel array detectors
         params.spotfinder.filter.min_spot_size = 3
@@ -183,11 +183,11 @@ class reflection_table_aux(boost.python.injector, reflection_table):
     # Get the integrator from the input parameters
     logger.info('Configuring spot finder from input parameters')
     find_spots = SpotFinderFactory.from_parameters(
-      datablock=datablock,
+      experiments=experiments,
       params=params)
 
     # Find the spots
-    return find_spots(datablock)
+    return find_spots(experiments)
 
   @staticmethod
   def from_pickle(filename):

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -543,6 +543,10 @@ class MetaDataUpdater(object):
 
       # Append to new imageset list
       experiment.imageset = imageset
+      experiment.beam = imageset.get_beam()
+      experiment.detector = imageset.get_detector()
+      experiment.goniometer = imageset.get_goniometer()
+      experiment.scan = imageset.get_scan()
 
     # Return the datablock
     return experiments

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -759,9 +759,9 @@ class Script(object):
     logger.info("-" * 80)
     for f in format_list:
       logger.info("  format: %s" % f)
+    logger.info("  num images: %d" % num_images)
     logger.info("  num sweeps: %d" % num_sweeps)
     logger.info("  num stills: %d" % num_stills)
-    logger.info("  num images: %d" % num_images)
 
     # Print out info for all experiments
     for experiment in experiments:


### PR DESCRIPTION
I've added functionality to import images directly to experiments.

Currently, dials.import stills saves by default datablock.json but, perhaps confusingly, the contents of this is an experiment list! I couldn't really call it experiments.json because that is what dials.index outputs. If we are going to go for a big change then perhaps we should rethink what files should be called by default?

dials.find_spots also now accepts experiments.json files. 

So I guess now indexing should do the same which I guess is a job for @rjgildea 

Since this is a change to user face code any comments on what I've currently done or what you would like to see done would be welcome!