### PR TITLE
dials.reindex: adding reindexing against a reference reflection file

### DIFF
--- a/algorithms/symmetry/reindex_to_reference.py
+++ b/algorithms/symmetry/reindex_to_reference.py
@@ -1,0 +1,62 @@
+"""
+Functions to help with reindexing against a reference dataset
+"""
+from libtbx.utils import Sorry
+from cctbx import sgtbx
+from mmtbx.scaling.twin_analyses import twin_laws
+
+def determine_reindex_operator_against_reference(test_miller_set,
+  reference_miller_set):
+  """This function takes two miller arrays, a reference and a test array. The
+  space group is checked to see if any reindexing may be required to give
+  consistent indexing between both datasets. If possible twin operators exist,
+  the different indexing options are tested against the reference set, using
+  the correlation between datasets as the test.
+  An sgtbx.change_of_basis_op is returned, which should be applied to the
+  test dataset to give consistent indexing with the reference."""
+
+  if reference_miller_set.space_group().type().number() != \
+    test_miller_set.space_group().type().number():
+    raise Sorry("""Space groups are not equal. Can only reindex against a
+reference dataset if both dataset are in the same spacegroup.""")
+
+  twin_ops = twin_laws(miller_array=test_miller_set).operators
+  twin_ops = [sgtbx.change_of_basis_op(op.operator.as_xyz()) for op in twin_ops]
+
+  if twin_ops:
+    correlations = []
+    print("Possible twin operators identified for space group %s:" \
+      % test_miller_set.space_group().info())
+    for op in twin_ops:
+      print(op)
+    # Loop through twin operators, calculating cc between two datasets
+    cc = test_miller_set.correlation(reference_miller_set)
+    correlations.append(cc.coefficient())
+    for op in twin_ops:
+      reindexed = test_miller_set.change_basis(op)
+      cc = reindexed.correlation(reference_miller_set)
+      correlations.append(cc.coefficient())
+
+    #print out table of results and choose best
+    from libtbx.table_utils import simple_table
+    header = ['Reindex op', 'CC to reference']
+    rows = [['a, b, c (no reindex)', '%.5f' % correlations[0]]]
+    for i, op in enumerate(twin_ops):
+      rows.append([str(op), '%.5f' % correlations[i+1]])
+    st = simple_table(rows, header)
+    print(st.format())
+
+    best_solution_idx = correlations.index(max(correlations))
+    print("\nOutcome of analysis against reference dataset:")
+    if best_solution_idx == 0:
+      print('No reindexing required \n')
+      change_of_basis_op = sgtbx.change_of_basis_op("a,b,c")
+    else:
+      print('Reindexing required with the twin operator:',
+        twin_ops[best_solution_idx-1], '\n')
+      change_of_basis_op = twin_ops[best_solution_idx-1]
+  else:
+    print("No twin operators found, no reindexing required \n")
+    change_of_basis_op = sgtbx.change_of_basis_op("a,b,c")
+
+  return change_of_basis_op

--- a/algorithms/symmetry/test_reindex_to_reference.py
+++ b/algorithms/symmetry/test_reindex_to_reference.py
@@ -1,0 +1,44 @@
+"""
+Tests for the reindex_to_reference module.
+"""
+import pytest
+from libtbx.utils import Sorry
+
+from cctbx import sgtbx
+
+from dials.algorithms.symmetry.cosym.generate_test_data import generate_test_data
+from dials.algorithms.symmetry.reindex_to_reference import \
+  determine_reindex_operator_against_reference
+
+def test_determine_reindex_operator_against_reference():
+  """Test that the correct reindex operator is returned by the function."""
+
+  # create a test dataset of random intensities
+  data, _ = generate_test_data(
+    space_group=sgtbx.space_group_info(symbol='P4').group(), sample_size=1)
+
+  # reindexing operator is a,-b,-c
+  op = 'a,-b,-c'
+  # reindex the data into a new array, so that the function should determine
+  # that the same change of basis operator should be applied to give consistent
+  # indexing back to the original data.
+  reindexed_data = data[0].change_basis(op)
+
+  cb_op = determine_reindex_operator_against_reference(data[0], reindexed_data)
+  assert cb_op.as_abc() == 'a,-b,-c'
+
+  # Repeat but with no reindexing
+  cb_op = determine_reindex_operator_against_reference(data[0], data[0])
+  assert cb_op.as_abc() == 'a,b,c'
+
+  #Test that a Sorry is raised if inconsistent indexing
+  data_2, _ = generate_test_data(
+    space_group=sgtbx.space_group_info(symbol='P1').group(), sample_size=1)
+  with pytest.raises(Sorry):
+    cb_op = determine_reindex_operator_against_reference(data[0], data_2[0])
+
+  # Test case for a simple space group with no ambiguity
+  data, _ = generate_test_data(
+    space_group=sgtbx.space_group_info(symbol='P1').group(), sample_size=1)
+  cb_op = determine_reindex_operator_against_reference(data[0], data[0])
+  assert cb_op.as_abc() == 'a,b,c'

--- a/test/command_line/test_reindex.py
+++ b/test/command_line/test_reindex.py
@@ -69,7 +69,7 @@ def test_reindex(dials_regression, tmpdir):
   commands = ["dials.reindex",
               "P4.json",
               "change_of_basis_op=auto",
-              "reference=P4_reindexed.json",
+              "reference.experiments=P4_reindexed.json",
               "output.experiments=P4_reindexed2.json"]
   command = " ".join(commands)
   print(command)
@@ -141,7 +141,7 @@ def test_reindex_against_reference(dials_regression, tmpdir):
 
   # now run reference reindexing
   commands = ["dials.reindex", "P4_reflections.pickle", 'P4_experiments.json',
-    "reference=P4_reindexed.json", "reference_reflections=P4_reindexed.pickle"]
+    "reference.experiments=P4_reindexed.json", "reference.reflections=P4_reindexed.pickle"]
   command = " ".join(commands)
   print(command)
   _ = easy_run.fully_buffered(command=command).raise_if_errors()


### PR DESCRIPTION
This pull request aims to introduce additional functionality to dials.reindex,
allowing reindexing against a reference dataset in the case of twinning.
Made a pull request to allow people the chance to give feedback
before merging.

If a reference reflections.pickle and experiments.json are given, the
space group (must be same for both datasets) is tested for potential
twinning operators. If these exist, the test dataset is reindexed to all
possible settings, and the reindexing that gives the best correlation to
the reference is used to reindex the data. The 'correlation' is simply the
correlation coefficient between the datasets (no renormalisation yet,
could be implemented to improve in future).

The naming of the command line options is a little unsatisfying, as there
already exists a `reference=` option to specify an experiments file, so I've
just added a `reference_reflections=` option. Would it be better to add
another parameter `reference_experiments=` and make a clear distinction
between the two types of reference reindexing?

I've added a trivial command line dataset test, but will look for a better
example when adding scaling test datasets.