### PR TITLE
DIALS 1.11.4

### DIFF
--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -520,6 +520,9 @@ class indexer_base(object):
     if known_crystal_models is not None:
       from dials.algorithms.indexing.known_orientation \
            import indexer_known_orientation
+      if params.indexing.known_symmetry.space_group is None:
+        params.indexing.known_symmetry.space_group \
+          = known_crystal_models[0].get_space_group().info()
       idxr = indexer_known_orientation(
         reflections, imagesets, params, known_crystal_models)
     else:

--- a/command_line/background.py
+++ b/command_line/background.py
@@ -57,7 +57,7 @@ def run(args):
   experiments = flatten_experiments(params.input.experiments)
   datablocks = flatten_datablocks(params.input.datablock)
   if [len(datablocks), len(experiments)].count(1) != 1:
-      self.parser.print_help()
+      parser.print_help()
       print("Please pass either a datablock or an experiment list\n")
       return
 

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -385,7 +385,7 @@ def run(args):
         refl = reflections[dataset_selection[dataset_id]]
         reindexed_expt = copy.deepcopy(expt)
         refl_reindexed = copy.deepcopy(refl)
-        cb_op_this = cb_op * change_of_basis_ops[dataset_id]
+        cb_op_this = cb_op * change_of_basis_ops[dataset_id].inverse()
         reindexed_expt.crystal = reindexed_expt.crystal.change_basis(cb_op_this)
         refl_reindexed['miller_index'] = cb_op_this.apply(
           refl_reindexed['miller_index'])


### PR DESCRIPTION
* Fix maths in ```dials.cosym```
* ```dials.index```:  if indexing from known orientation then use provided space group setting unless specified
* Fix rare ```dials.symmetry``` crash (#619)
* Fix ```dials.background``` crash when run without parameters