### PR TITLE
Add interface to exclude images from experiments and reflections

### DIFF
--- a/test/util/test_exclude_images.py
+++ b/test/util/test_exclude_images.py
@@ -1,0 +1,87 @@
+"""
+tests for functions in dials.util.exclude_images.py
+"""
+import copy
+import pytest
+from libtbx.utils import Sorry
+from dxtbx.model import Experiment, Scan, ExperimentList
+from dials.array_family import flex
+from dials.util.exclude_images import _parse_exclude_images_commands, \
+  set_initial_valid_image_ranges, get_valid_image_ranges, exclude_image_ranges_from_scans,\
+  get_selection_for_valid_image_ranges, exclude_image_ranges_for_scaling
+
+def make_scan_experiment(image_range=(1,100), expid="0"):
+  """Make an experiment with a scan"""
+  return Experiment(scan=Scan(image_range, (0.0, 1.0)), identifier=expid)
+
+def make_scanless_experiment(expid="1"):
+  """Make an experiment without a scan i.e. single-image dataset"""
+  return Experiment(identifier=expid)
+
+def test_parse_exclude_images_commands():
+  """Test for namesake function"""
+  commands = [['1:101:200'], ['0:201:300']]
+  ranges = _parse_exclude_images_commands(commands)
+  assert ranges == [('1', (101, 200)), ('0', (201, 300))]
+  with pytest.raises(Sorry):
+    _ = _parse_exclude_images_commands([['1:101-200']])
+  with pytest.raises(Sorry):
+     _ = _parse_exclude_images_commands([['1:101']])
+  with pytest.raises(ValueError):
+    _ = _parse_exclude_images_commands([['1:101:a']])
+
+def test_set_get_initial_valid_image_ranges():
+  """Test for get/set valid_image_ranges functions"""
+  explist = ExperimentList([make_scan_experiment(), make_scanless_experiment()])
+  explist = set_initial_valid_image_ranges(explist)
+  assert list(explist[0].scan.get_valid_image_ranges("0")) == [1, 100]
+  ranges = get_valid_image_ranges(explist)
+  assert len(ranges) == 2
+  assert list(ranges[0]) == [1, 100]
+  assert ranges[1] is None
+
+def test_exclude_image_ranges_from_scans():
+  """Test for namesake function"""
+  explist = ExperimentList([make_scan_experiment(expid="0"),
+    make_scan_experiment(expid="1")])
+  exclude_images = [["0:81:100"], ["1:61:80"]]
+  explist = exclude_image_ranges_from_scans(explist, exclude_images)
+  assert list(explist[0].scan.get_valid_image_ranges("0")) == [1, 80]
+  assert list(explist[1].scan.get_valid_image_ranges("1")) == [1, 60, 81, 100]
+  # Try excluding a range that already has been excluded
+  explist = exclude_image_ranges_from_scans(explist, [["1:70:80"]])
+  assert list(explist[0].scan.get_valid_image_ranges("0")) == [1, 80]
+  assert list(explist[1].scan.get_valid_image_ranges("1")) == [1, 60, 81, 100]
+  scanlessexplist = ExperimentList([make_scanless_experiment()])
+  with pytest.raises(Sorry):
+    _ = exclude_image_ranges_from_scans(scanlessexplist, [["0:1:100"]])
+
+def test_get_selection_for_valid_image_ranges():
+  """Test for namesake function"""
+  exp = make_scan_experiment()
+  exp.scan.set_valid_image_ranges("0", [2, 10])
+  refl = flex.reflection_table()
+  refl['xyzobs.px.value'] = flex.vec3_double(
+    [(0, 0, 0.5), (0, 0, 1.5), (0, 0, 5.5), (0, 0, 9.5), (0, 0, 10.5)])
+  sel = get_selection_for_valid_image_ranges(refl, exp)
+  assert list(sel) == [False, True, True, True, False]
+  exp = make_scanless_experiment()
+  assert list(get_selection_for_valid_image_ranges(refl, exp)) == [True] * 5
+
+def test_exclude_image_ranges_for_scaling():
+  """Test for namesake function."""
+  refl1 = flex.reflection_table()
+  refl1['xyzobs.px.value'] = flex.vec3_double(
+    [(0, 0, 0.5), (0, 0, 1.5), (0, 0, 5.5), (0, 0, 9.5), (0, 0, 10.5)])
+  refl1.set_flags(flex.bool(5, False), refl1.flags.user_excluded_in_scaling)
+  refl2 = copy.deepcopy(refl1)
+  explist = ExperimentList([make_scan_experiment(image_range=(2, 20), expid="0"),
+    make_scan_experiment(image_range=(2, 20), expid="1")])
+  refls, exps = exclude_image_ranges_for_scaling([refl1, refl2], explist, [["1:11:20"]])
+  assert list(explist[0].scan.get_valid_image_ranges("0")) == [2, 20]
+  assert list(explist[1].scan.get_valid_image_ranges("1")) == [2, 10]
+  assert list(refls[0].get_flags(refls[0].flags.user_excluded_in_scaling)) == [
+    True, False, False, False, False]
+  assert list(refls[1].get_flags(refls[0].flags.user_excluded_in_scaling)) == [
+    True, False, False, False, True]
+  

--- a/test/util/test_exclude_images.py
+++ b/test/util/test_exclude_images.py
@@ -34,10 +34,10 @@ def test_set_get_initial_valid_image_ranges():
   """Test for get/set valid_image_ranges functions"""
   explist = ExperimentList([make_scan_experiment(), make_scanless_experiment()])
   explist = set_initial_valid_image_ranges(explist)
-  assert list(explist[0].scan.get_valid_image_ranges("0")) == [1, 100]
+  assert list(explist[0].scan.get_valid_image_ranges("0")) == [(1, 100)]
   ranges = get_valid_image_ranges(explist)
   assert len(ranges) == 2
-  assert list(ranges[0]) == [1, 100]
+  assert list(ranges[0]) == [(1, 100)]
   assert ranges[1] is None
 
 def test_exclude_image_ranges_from_scans():
@@ -46,20 +46,24 @@ def test_exclude_image_ranges_from_scans():
     make_scan_experiment(expid="1")])
   exclude_images = [["0:81:100"], ["1:61:80"]]
   explist = exclude_image_ranges_from_scans(explist, exclude_images)
-  assert list(explist[0].scan.get_valid_image_ranges("0")) == [1, 80]
-  assert list(explist[1].scan.get_valid_image_ranges("1")) == [1, 60, 81, 100]
+  assert list(explist[0].scan.get_valid_image_ranges("0")) == [(1, 80)]
+  assert list(explist[1].scan.get_valid_image_ranges("1")) == [(1, 60), (81, 100)]
   # Try excluding a range that already has been excluded
   explist = exclude_image_ranges_from_scans(explist, [["1:70:80"]])
-  assert list(explist[0].scan.get_valid_image_ranges("0")) == [1, 80]
-  assert list(explist[1].scan.get_valid_image_ranges("1")) == [1, 60, 81, 100]
+  assert list(explist[0].scan.get_valid_image_ranges("0")) == [(1, 80)]
+  assert list(explist[1].scan.get_valid_image_ranges("1")) == [(1, 60), (81, 100)]
   scanlessexplist = ExperimentList([make_scanless_experiment()])
   with pytest.raises(Sorry):
     _ = exclude_image_ranges_from_scans(scanlessexplist, [["0:1:100"]])
+  # Now try excluding everything, should set an empty array
+  explist = exclude_image_ranges_from_scans(explist, [["1:1:100"]])
+  assert list(explist[0].scan.get_valid_image_ranges("0")) == [(1, 80)]
+  assert list(explist[1].scan.get_valid_image_ranges("1")) == []
 
 def test_get_selection_for_valid_image_ranges():
   """Test for namesake function"""
   exp = make_scan_experiment()
-  exp.scan.set_valid_image_ranges("0", [2, 10])
+  exp.scan.set_valid_image_ranges("0", [(2, 10)])
   refl = flex.reflection_table()
   refl['xyzobs.px.value'] = flex.vec3_double(
     [(0, 0, 0.5), (0, 0, 1.5), (0, 0, 5.5), (0, 0, 9.5), (0, 0, 10.5)])
@@ -78,8 +82,8 @@ def test_exclude_image_ranges_for_scaling():
   explist = ExperimentList([make_scan_experiment(image_range=(2, 20), expid="0"),
     make_scan_experiment(image_range=(2, 20), expid="1")])
   refls, exps = exclude_image_ranges_for_scaling([refl1, refl2], explist, [["1:11:20"]])
-  assert list(explist[0].scan.get_valid_image_ranges("0")) == [2, 20]
-  assert list(explist[1].scan.get_valid_image_ranges("1")) == [2, 10]
+  assert list(explist[0].scan.get_valid_image_ranges("0")) == [(2, 20)]
+  assert list(explist[1].scan.get_valid_image_ranges("1")) == [(2, 10)]
   assert list(refls[0].get_flags(refls[0].flags.user_excluded_in_scaling)) == [
     True, False, False, False, False]
   assert list(refls[1].get_flags(refls[0].flags.user_excluded_in_scaling)) == [

--- a/util/exclude_images.py
+++ b/util/exclude_images.py
@@ -1,0 +1,122 @@
+"""
+Functions for handling exclusion of images ranges from scans based on a
+command line option, as well as obtaining a selection to use for selecting
+the corresponding reflections.
+"""
+import copy as copy
+from dials.array_family import flex
+from libtbx.utils import Sorry
+from libtbx.containers import OrderedSet
+import iotbx.phil
+
+phil_scope = iotbx.phil.parse('''
+  exclude_images = None
+    .type = strings
+    .multiple = True
+    .help = "Input in the format exp:start:end"
+            "Exclude a range of images (start, stop) from the dataset with"
+            "experiment identifier exp  (inclusive of frames start, stop)."
+    .expert_level = 1
+''')
+
+def exclude_image_ranges_from_scans(experiments, exclude_images):
+  """Using an exclude_images phil option, modify the valid image ranges for each
+  experiment in the scan (if it exists). Requires experiment identifiers to be
+  set already."""
+  experiments = set_initial_valid_image_ranges(experiments)
+  ranges_to_remove = _parse_exclude_images_commands(exclude_images)
+  experiments = _remove_ranges_from_valid_image_ranges(experiments, ranges_to_remove)
+  return experiments
+
+def get_valid_image_ranges(experiments):
+  """Extract valid image ranges from experiments, returning None if no scan"""
+  valid_images_ranges = []
+  for exp in experiments:
+    if exp.scan:
+      valid_images_ranges.append(exp.scan.get_valid_image_ranges(exp.identifier))
+    else:
+      valid_images_ranges.append(None)
+  return valid_images_ranges
+
+def set_initial_valid_image_ranges(experiments):
+  """Set the valid_image_range for each experiment to be the scan image range.
+  Kept separate from dxtbx.scan object as requires experiment indentifiers.
+  Also this function can be called for a mix of sweeps and scanless experiments.
+  """
+  for exp in experiments:
+    if exp.scan:
+      if not exp.scan.get_valid_image_ranges(exp.identifier):
+        exp.scan.set_valid_image_ranges(exp.identifier, exp.scan.get_image_range())
+  return experiments
+
+def get_selection_for_valid_image_ranges(reflection_table, experiment):
+  """Determine a selection for the reflection table corresponding to reflections
+  that are located in valid image ranges (according to zobs.px.value)."""
+  if experiment.scan:
+    valid_ranges = experiment.scan.get_valid_image_ranges(experiment.identifier)
+    if valid_ranges:
+      valid_mask = flex.bool(reflection_table.size(), False)
+      z = reflection_table['xyzobs.px.value'].parts()[2]
+      for i in range(0, len(valid_ranges), 2):
+        mask1 = (z >= valid_ranges[i] - 1.0) # -1.0 as image valid_ranges[i] \
+        #has z is valid_ranges[i] - 1 to valid_ranges[i]
+        mask2 = (z <= valid_ranges[i+1])
+        valid_mask.set_selected(mask1 & mask2, True)
+      return valid_mask
+  return flex.bool(reflection_table.size(), True) # else say all valid
+
+def _parse_exclude_images_commands(commands):
+  """Parse a list of list of command line options.
+  e.g. commands = [['1:101:200'], ['0:201:300']]
+  builds and returns a list of tuples (exp_id, (start, stop))"""
+  ranges_to_remove = []
+  for com in commands:
+    vals = com[0].split(':')
+    if len(vals) != 3:
+      raise Sorry("Exclude images must be input in the form exp:start:stop ")
+    ranges_to_remove.append((vals[0], (int(vals[1]), int(vals[2]))))
+  return ranges_to_remove
+
+def _remove_ranges_from_valid_image_ranges(experiments, ranges_to_remove):
+  """Update the valid_image_ranges for each experiment in the scans. Uses set
+  arithmetic to determine image ranges to keep and sets a new list of ranges in
+  the scan.valid_image_ranges dict."""
+  for r in ranges_to_remove:
+    exp = experiments[experiments.find(r[0])]
+    if not exp.scan:
+      raise Sorry("Trying to exclude a scanless experiment")
+    current_range = exp.scan.get_valid_image_ranges(exp.identifier) #list of start:stop values
+    # use set arithmetic on image numbers to work out images to keep
+    exclude = OrderedSet(range(r[1][0], r[1][1]+1))
+    current_sets = [OrderedSet(range(current_range[i], current_range[i+1]+1)) for \
+      i in range(0, len(current_range), 2)]
+    current_images = OrderedSet()
+    for s in current_sets:
+      current_images = current_images | s
+    new_valid_images = list(current_images - exclude)
+    # now convert images to ranges for storing in the scan
+    new_valid_ranges = [new_valid_images[0]]
+    previous = new_valid_images[0]
+    for i in new_valid_images[1:]:
+      if i - previous > 1:
+        new_valid_ranges.append(previous)
+        new_valid_ranges.append(i)
+      previous = i
+    if new_valid_ranges[-1] != new_valid_images[-1]:
+      new_valid_ranges.append(new_valid_images[-1])
+    assert len(new_valid_ranges) % 2 == 0
+    exp.scan.set_valid_image_ranges(exp.identifier, flex.int(new_valid_ranges))
+  return experiments
+
+"""
+Functions for scaling
+"""
+
+def exclude_image_ranges_for_scaling(reflections, experiments, exclude_images):
+  """Set the initial valid ranges, then exclude in the exp.scan and set
+  user_excluded_in_scaling flags."""
+  experiments = exclude_image_ranges_from_scans(experiments, exclude_images)
+  for refl, exp in zip(reflections, experiments):
+    sel = get_selection_for_valid_image_ranges(refl, exp)
+    refl.set_flags(~sel, refl.flags.user_excluded_in_scaling)
+  return reflections, experiments


### PR DESCRIPTION
For reference, here are the accompanying additions to my pull request in cctbx_project, which define an interface for excluding image ranges based on a command line option (as discussed in #650)
This needs to wait for my dxtbx changes to be merged in before it can be included.
Closes (#650)