### PR TITLE
Changes to integrate.py to handle memory issues

### DIFF
--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -271,6 +271,7 @@ class Script(object):
     # Match reference with predicted
     if reference:
       all_reference = flex.reflection_table()
+      all_predicted = flex.reflection_table()
       for ii in range(len(experiments)):
         preds = predicted.select(predicted['id']==ii)
         refs = reference.select(reference['id']==ii)
@@ -292,6 +293,8 @@ class Script(object):
           logger.info('')
         rubbish.extend(unmatched)
         all_reference.extend(refs)
+        all_predicted.extend(preds)
+      predicted=all_predicted
       reference=all_reference
 
       if len(experiments) > 1:


### PR DESCRIPTION
The work in this pull request stemmed from our failure to use **cctbx.xfel.stripe_experiments** during our recent LU34 beamtime at LCLS. The protein studied, PSII, with it's large unit cell and spots to be integrated to the edges creates a huge number of reflections to be handled by the integration program. **cctbx.xfel.stripe_experiments** refines an experimentlist and the reintegrates the data. During the reintegration step, the experimentlist/reflection table when passed to *integrate.py* is integrated all at once in the current form on the master. This creates a memory problem when there are multiple experiments in the experimentlist, each with 1000s of reflections and cause the program to fail.

  To address this issue, we propose in this pull request to break up the integration into a couple of *for loops* and integrate each experiment separately. In the process, we are able to delete the shoeboxes as we go along which is the biggest memory consumer. This fix allowed us to use stripe_experiments on PSII data. Note that this problem is different from the memory errors sometimes seen when integrating sweeps with high mosaicity. Here we are trying to integrate thousands of stills simultaneously and they can be split trivially. 

Work by Asmit Bhowmick and Aaron Brewster