### PR TITLE
Don't override n_macro_cycles

### DIFF
--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -250,8 +250,11 @@ indexing {
       .help = "refine_shells: refine in increasing resolution cutoffs after indexing."
               "repredict_only: do not refine after indexing, just update spot"
               "predictions."
-    n_macro_cycles = Auto
+    n_macro_cycles = 5
       .type = int(value_min=1)
+      .help = "Maximum number of macro cycles of refinement, reindexing all"
+              "reflections using updated geometry at the beginning of each"
+              "cycle. Does not apply to stills.indexer=stills."
     d_min_step = Auto
       .type = float(value_min=0.0)
       .help = "Reduction per step in d_min for reflections to include in refinement."
@@ -485,12 +488,6 @@ class indexer_base(object):
         # different default to dials.refine
         # tukey is faster and more appropriate at the indexing step
         self.all_params.refinement.reflections.outlier.algorithm = 'tukey'
-
-    if self.params.refinement_protocol.n_macro_cycles in ('auto', libtbx.Auto):
-      if self.imagesets[0].get_goniometer() is None:
-        self.params.refinement_protocol.n_macro_cycles = 1
-      else:
-        self.params.refinement_protocol.n_macro_cycles = 5
 
     for imageset in imagesets[1:]:
       if imageset.get_detector().is_similar_to(self.imagesets[0].get_detector()):

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -117,8 +117,6 @@ class stills_indexer(indexer_base):
     # specific modifications (don't re-index after choose best orientation matrix, but use the indexing from
     # choose best orientation matrix, also don't use macrocycles) of refinement after indexing.
     # 2017 update: do accept multiple lattices per shot
-    if self.params.refinement_protocol.n_macro_cycles > 1:
-      raise Sorry("For stills, please set refinement_protocol.n_macro_cycles = 1")
 
     experiments = ExperimentList()
 


### PR DESCRIPTION
Don't override n_macro_cycles depending on presence/absence of a goniometer object.

Since stills_indexer doesn't do macro_cycles then simply ignore this
parameter rather than bombing out with an error message. Update help
message to make it clear that this parameter isn't used by still_indexer.
Fixes #707.