### PR TITLE
Move some reflection table manipulation functionality to flex

### DIFF
--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -12,6 +12,7 @@
 
 from __future__ import absolute_import, division
 from __future__ import print_function
+import copy
 import math
 import logging
 logger = logging.getLogger(__name__)
@@ -706,10 +707,9 @@ class indexer_base(object):
     for i, expt in enumerate(self.experiments):
       if 'imageset_id' not in reflections_input:
         reflections_input['imageset_id'] = reflections_input['id']
-      sel = (reflections_input['imageset_id'] == i)
-      self.reflections.extend(self.map_spots_pixel_to_mm_rad(
-        reflections_input.select(sel),
-        expt.detector, expt.scan))
+      refl = reflections_input.select(reflections_input['imageset_id'] == i)
+      refl.centroid_px_to_mm(expt.detector, expt.scan)
+      self.reflections.extend(refl)
     self.filter_reflections_by_scan_range()
     if len(self.reflections) == 0:
       raise Sorry("No reflections left to index!")

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -381,8 +381,8 @@ class stills_indexer(indexer_base):
         self.reflections = flex.reflection_table()
         for i, expt in enumerate(self.experiments):
           spots_sel = spots_mm.select(spots_mm['imageset_id'] == i)
-          self.map_centroids_to_reciprocal_space(
-            spots_sel, expt.detector, expt.beam, expt.goniometer)
+          spots_sel.map_centroids_to_reciprocal_space(
+            expt.detector, expt.beam, expt.goniometer)
           self.reflections.extend(spots_sel)
 
       # update for next cycle

--- a/algorithms/spot_finding/per_image_analysis.py
+++ b/algorithms/spot_finding/per_image_analysis.py
@@ -80,8 +80,7 @@ def map_to_reciprocal_space(reflections, imageset):
   beam = imageset.get_beam()
 
   from dials.algorithms.indexing import indexer
-  reflections = indexer.indexer_base.map_spots_pixel_to_mm_rad(
-    reflections, detector, scan)
+  reflections.centroid_px_to_mm(detector, scan)
   indexer.indexer_base.map_centroids_to_reciprocal_space(
   reflections, detector, beam, goniometer)
 

--- a/algorithms/spot_finding/per_image_analysis.py
+++ b/algorithms/spot_finding/per_image_analysis.py
@@ -79,10 +79,9 @@ def map_to_reciprocal_space(reflections, imageset):
   goniometer = imageset.get_goniometer()
   beam = imageset.get_beam()
 
-  from dials.algorithms.indexing import indexer
   reflections.centroid_px_to_mm(detector, scan)
-  indexer.indexer_base.map_centroids_to_reciprocal_space(
-  reflections, detector, beam, goniometer)
+  reflections.map_centroids_to_reciprocal_space(
+    detector, beam, goniometer)
 
   return reflections
 

--- a/command_line/augment_spots.py
+++ b/command_line/augment_spots.py
@@ -54,15 +54,13 @@ def add_resolution_to_reflections(reflections, experiments):
   if 'imageset_id' not in reflections:
     reflections['imageset_id'] = reflections['id']
 
-  spots_mm = indexer_base.map_spots_pixel_to_mm_rad(
-    spots=reflections, detector=imageset.get_detector(),
-    scan=imageset.get_scan())
+  reflections.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
 
   indexer_base.map_centroids_to_reciprocal_space(
-    spots_mm, detector=imageset.get_detector(), beam=imageset.get_beam(),
+    reflections, detector=imageset.get_detector(), beam=imageset.get_beam(),
     goniometer=imageset.get_goniometer())
 
-  d_spacings = 1/spots_mm['rlp'].norms()
+  d_spacings = 1/reflections['rlp'].norms()
 
   reflections['d'] = d_spacings
 

--- a/command_line/augment_spots.py
+++ b/command_line/augment_spots.py
@@ -48,7 +48,6 @@ def add_resolution_to_reflections(reflections, experiments):
   # will assume everything from the first detector at the moment - clearly this
   # could be incorrect, will have to do something a little smarter, later
 
-  from dials.algorithms.indexing.indexer import indexer_base
   imageset = experiments.imagesets()[0]
 
   if 'imageset_id' not in reflections:
@@ -56,8 +55,8 @@ def add_resolution_to_reflections(reflections, experiments):
 
   reflections.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
 
-  indexer_base.map_centroids_to_reciprocal_space(
-    reflections, detector=imageset.get_detector(), beam=imageset.get_beam(),
+  reflections.map_centroids_to_reciprocal_space(
+    detector=imageset.get_detector(), beam=imageset.get_beam(),
     goniometer=imageset.get_goniometer())
 
   d_spacings = 1/reflections['rlp'].norms()

--- a/command_line/griddex.py
+++ b/command_line/griddex.py
@@ -24,11 +24,10 @@ def test_index(experiment, reflections):
 
   # map reflections to reciprocal space from image space
 
-  refl = indexer.indexer_base.map_spots_pixel_to_mm_rad(
-    reflections, experiment.detector, experiment.scan)
+  reflections.centroid_px_to_mm(experiment.detector, experiment.scan)
 
   indexer.indexer_base.map_centroids_to_reciprocal_space(
-    refl, experiment.detector, experiment.beam, experiment.goniometer)
+    reflections, experiment.detector, experiment.beam, experiment.goniometer)
 
   # now compute fractional indices - in Python rather than trying to push
   # everything to C++ for the moment

--- a/command_line/griddex.py
+++ b/command_line/griddex.py
@@ -20,14 +20,13 @@ phil_scope = libtbx.phil.parse("""
 """)
 
 def test_index(experiment, reflections):
-  from dials.algorithms.indexing import indexer
 
   # map reflections to reciprocal space from image space
 
   reflections.centroid_px_to_mm(experiment.detector, experiment.scan)
 
-  indexer.indexer_base.map_centroids_to_reciprocal_space(
-    reflections, experiment.detector, experiment.beam, experiment.goniometer)
+  reflections.map_centroids_to_reciprocal_space(
+    experiment.detector, experiment.beam, experiment.goniometer)
 
   # now compute fractional indices - in Python rather than trying to push
   # everything to C++ for the moment

--- a/command_line/reciprocal_lattice_viewer.py
+++ b/command_line/reciprocal_lattice_viewer.py
@@ -139,9 +139,8 @@ class render_3d(object):
 
       # 155 handle data from predictions *only* if that is what we have
       if 'xyzobs.px.value' in self.reflections_input:
-        refl = indexer.indexer_base.map_spots_pixel_to_mm_rad(
-          self.reflections_input.select(sel),
-          imageset.get_detector(), imageset.get_scan())
+        refl = copy.deepcopy(self.reflections_input)
+        refl.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
 
         goniometer = copy.deepcopy(imageset.get_goniometer())
         if self.settings.reverse_phi:

--- a/command_line/reciprocal_lattice_viewer.py
+++ b/command_line/reciprocal_lattice_viewer.py
@@ -125,7 +125,6 @@ class render_3d(object):
 
   def map_points_to_reciprocal_space(self):
 
-    from dials.algorithms.indexing import indexer
     import copy
 
     reflections = flex.reflection_table()
@@ -146,9 +145,8 @@ class render_3d(object):
         if self.settings.reverse_phi:
           goniometer.set_rotation_axis(
             [-i for i in goniometer.get_rotation_axis()])
-        indexer.indexer_base.map_centroids_to_reciprocal_space(
-          refl, imageset.get_detector(), imageset.get_beam(),
-          goniometer)
+        refl.map_centroids_to_reciprocal_space(
+          imageset.get_detector(), imageset.get_beam(), goniometer)
 
       else:
         # work on xyzcal.mm
@@ -159,8 +157,8 @@ class render_3d(object):
           goniometer.set_rotation_axis(
             [-i for i in goniometer.get_rotation_axis()])
 
-        indexer.indexer_base.map_centroids_to_reciprocal_space(
-          refl, imageset.get_detector(), imageset.get_beam(),
+        refl.map_centroids_to_reciprocal_space(
+          imageset.get_detector(), imageset.get_beam(),
           goniometer, calculated=True)
 
       reflections.extend(refl)

--- a/command_line/reindex.py
+++ b/command_line/reindex.py
@@ -224,7 +224,6 @@ experiments file must also be specified with the option: reference= """)
       assert len(reflections) == 1
 
       # always re-map reflections to reciprocal space
-      from dials.algorithms.indexing import indexer
       refl_copy = flex.reflection_table()
       for i, imageset in enumerate(experiments.imagesets()):
         if 'imageset_id' in reflections[0]:
@@ -233,9 +232,8 @@ experiments file must also be specified with the option: reference= """)
           sel = (reflections[0]['id'] == i)
         refl = reflections[0].select(sel)
         refl.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
-
-        indexer.indexer_base.map_centroids_to_reciprocal_space(
-          refl, imageset.get_detector(), imageset.get_beam(),
+        refl.map_centroids_to_reciprocal_space(
+          imageset.get_detector(), imageset.get_beam(),
           imageset.get_goniometer())
         refl_copy.extend(refl)
 

--- a/command_line/reindex.py
+++ b/command_line/reindex.py
@@ -231,9 +231,8 @@ experiments file must also be specified with the option: reference= """)
           sel = (reflections[0]['imageset_id'] == i)
         else:
           sel = (reflections[0]['id'] == i)
-        refl = indexer.indexer_base.map_spots_pixel_to_mm_rad(
-          reflections[0].select(sel),
-          imageset.get_detector(), imageset.get_scan())
+        refl = reflections[0].select(sel)
+        refl.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
 
         indexer.indexer_base.map_centroids_to_reciprocal_space(
           refl, imageset.get_detector(), imageset.get_beam(),

--- a/command_line/rl_csv.py
+++ b/command_line/rl_csv.py
@@ -81,14 +81,13 @@ def run(args):
     if 'imageset_id' not in refl:
       refl['imageset_id'] = refl['id']
 
-    reflmm = indexer_base.map_spots_pixel_to_mm_rad(
-      spots=refl, detector=imageset.get_detector(), scan=imageset.get_scan())
+    refl.centroid_px_to_mm(imageset.get_detector(), scan=imageset.get_scan())
 
     indexer_base.map_centroids_to_reciprocal_space(
-      reflmm, detector=imageset.get_detector(), beam=imageset.get_beam(),
+      refl, detector=imageset.get_detector(), beam=imageset.get_beam(),
       goniometer=imageset.get_goniometer())
 
-    rlp = reflmm['rlp']
+    rlp = refl['rlp']
 
     for _rlp in rlp:
       fout.write(fmt % (_rlp[0], _rlp[1], _rlp[2], k, k))

--- a/command_line/rl_csv.py
+++ b/command_line/rl_csv.py
@@ -6,8 +6,7 @@ from scitbx.array_family import flex
 from scitbx import matrix
 from dials.util.options import OptionParser
 from dials.util.options import flatten_experiments, flatten_reflections
-from dials.algorithms.indexing.indexer \
-     import indexer_base, filter_reflections_by_scan_range
+from dials.algorithms.indexing.indexer import filter_reflections_by_scan_range
 
 import libtbx.load_env
 
@@ -82,9 +81,8 @@ def run(args):
       refl['imageset_id'] = refl['id']
 
     refl.centroid_px_to_mm(imageset.get_detector(), scan=imageset.get_scan())
-
-    indexer_base.map_centroids_to_reciprocal_space(
-      refl, detector=imageset.get_detector(), beam=imageset.get_beam(),
+    refl.map_centroids_to_reciprocal_space(
+      detector=imageset.get_detector(), beam=imageset.get_beam(),
       goniometer=imageset.get_goniometer())
 
     rlp = refl['rlp']

--- a/command_line/rl_png.py
+++ b/command_line/rl_png.py
@@ -203,25 +203,25 @@ def run(args):
     if 'imageset_id' not in reflections:
       reflections['imageset_id'] = reflections['id']
 
-    spots_mm = indexer_base.map_spots_pixel_to_mm_rad(
-      spots=reflections, detector=imageset.get_detector(), scan=imageset.get_scan())
+    reflections.centroid_px_to_mm(
+      imageset.get_detector(), scan=imageset.get_scan())
 
     indexer_base.map_centroids_to_reciprocal_space(
-      spots_mm, detector=imageset.get_detector(), beam=imageset.get_beam(),
+      reflections, detector=imageset.get_detector(), beam=imageset.get_beam(),
       goniometer=imageset.get_goniometer())
 
     if params.d_min is not None:
-      d_spacings = 1/spots_mm['rlp'].norms()
+      d_spacings = 1/reflections['rlp'].norms()
       sel = d_spacings > params.d_min
-      spots_mm = spots_mm.select(sel)
+      reflections = reflections.select(sel)
 
     # derive a max_cell from mm spots
 
     from dials.algorithms.indexing.indexer import find_max_cell
-    max_cell = find_max_cell(spots_mm, max_cell_multiplier=1.3,
+    max_cell = find_max_cell(reflections, max_cell_multiplier=1.3,
                              step_size=45).max_cell
 
-    result = run_dps((imageset, spots_mm, max_cell, hardcoded_phil))
+    result = run_dps((imageset, reflections, max_cell, hardcoded_phil))
     solutions = [matrix.col(v) for v in result['solutions']]
     for i in range(min(n_solutions, len(solutions))):
       v = solutions[i]

--- a/command_line/rl_png.py
+++ b/command_line/rl_png.py
@@ -198,7 +198,6 @@ def run(args):
     hardcoded_phil.d_min = params.d_min
 
     imageset = imagesets[0]
-    from dials.algorithms.indexing.indexer import indexer_base
 
     if 'imageset_id' not in reflections:
       reflections['imageset_id'] = reflections['id']
@@ -206,8 +205,8 @@ def run(args):
     reflections.centroid_px_to_mm(
       imageset.get_detector(), scan=imageset.get_scan())
 
-    indexer_base.map_centroids_to_reciprocal_space(
-      reflections, detector=imageset.get_detector(), beam=imageset.get_beam(),
+    reflections.map_centroids_to_reciprocal_space(
+      detector=imageset.get_detector(), beam=imageset.get_beam(),
       goniometer=imageset.get_goniometer())
 
     if params.d_min is not None:

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 # LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
 # LIBTBX_PRE_DISPATCHER_INCLUDE_SH export BOOST_ADAPTBX_FPE_DEFAULT=1
+import copy
 import math
 import iotbx.phil
 from scitbx import matrix
@@ -343,10 +344,6 @@ def discover_better_experimental_model(
   assert len(imagesets) > 0
   # XXX should check that all the detector and beam objects are the same
   from dials.algorithms.indexing.indexer import indexer_base
-  spot_lists_mm = [
-    indexer_base.map_spots_pixel_to_mm_rad(
-      spots, imageset.get_detector(), imageset.get_scan())
-    for spots, imageset in zip(spot_lists, imagesets)]
 
   spot_lists_mm = []
   max_cell_list = []
@@ -364,8 +361,9 @@ def discover_better_experimental_model(
     if 'imageset_id' not in spots:
       spots['imageset_id'] = spots['id']
 
-    spots_mm = indexer_base.map_spots_pixel_to_mm_rad(
-      spots=spots, detector=imageset.get_detector(), scan=imageset.get_scan())
+    spots_mm = copy.deepcopy(spots)
+    spots_mm.centroid_px_to_mm(
+      imageset.get_detector(), scan=imageset.get_scan())
 
     indexer_base.map_centroids_to_reciprocal_space(
       spots_mm, detector=imageset.get_detector(), beam=imageset.get_beam(),

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -237,15 +237,14 @@ class better_experimental_model_discovery(object):
     from rstbx.indexing_api import dps_extended
     trial_detector = dps_extended.get_new_detector(imageset.get_detector(), trial_origin_offset)
 
-    from dials.algorithms.indexing.indexer import indexer_base
     # Key point for this is that the spots must correspond to detector
     # positions not to the correct RS position => reset any fixed rotation
     # to identity - copy in case called from elsewhere
     import copy
     gonio = copy.deepcopy(imageset.get_goniometer())
     gonio.set_fixed_rotation((1, 0, 0, 0, 1, 0, 0, 0, 1))
-    indexer_base.map_centroids_to_reciprocal_space(
-      spots_mm, trial_detector, imageset.get_beam(), gonio)
+    spots_mm.map_centroids_to_reciprocal_space(
+      trial_detector, imageset.get_beam(), gonio)
 
     return self.sum_score_detail(spots_mm['rlp'], solutions, amax=amax)
 
@@ -365,8 +364,8 @@ def discover_better_experimental_model(
     spots_mm.centroid_px_to_mm(
       imageset.get_detector(), scan=imageset.get_scan())
 
-    indexer_base.map_centroids_to_reciprocal_space(
-      spots_mm, detector=imageset.get_detector(), beam=imageset.get_beam(),
+    spots_mm.map_centroids_to_reciprocal_space(
+      detector=imageset.get_detector(), beam=imageset.get_beam(),
       goniometer=imageset.get_goniometer())
 
     if dps_params.d_min is not None:

--- a/command_line/spot_resolution_shells.py
+++ b/command_line/spot_resolution_shells.py
@@ -32,9 +32,8 @@ def spot_resolution_shells(imagesets, reflections, params):
       sel = (reflections['id'] == i)
     if isinstance(reflections['id'], flex.size_t):
       reflections['id'] = reflections['id'].as_int()
-    refl = indexer.indexer_base.map_spots_pixel_to_mm_rad(
-      reflections.select(sel),
-      imageset.get_detector(), imageset.get_scan())
+    refl = reflections.select(sel)
+    refl.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
 
     indexer.indexer_base.map_centroids_to_reciprocal_space(
       refl, imageset.get_detector(), imageset.get_beam(),

--- a/command_line/spot_resolution_shells.py
+++ b/command_line/spot_resolution_shells.py
@@ -22,7 +22,6 @@ def settings():
 
 def spot_resolution_shells(imagesets, reflections, params):
   goniometer = imagesets[0].get_goniometer()
-  from dials.algorithms.indexing import indexer
   from dials.array_family import flex
   mapped_reflections = flex.reflection_table()
   for i, imageset in enumerate(imagesets):
@@ -34,10 +33,8 @@ def spot_resolution_shells(imagesets, reflections, params):
       reflections['id'] = reflections['id'].as_int()
     refl = reflections.select(sel)
     refl.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
-
-    indexer.indexer_base.map_centroids_to_reciprocal_space(
-      refl, imageset.get_detector(), imageset.get_beam(),
-      imageset.get_goniometer())
+    refl.map_centroids_to_reciprocal_space(
+      imageset.get_detector(), imageset.get_beam(), imageset.get_goniometer())
     mapped_reflections.extend(refl)
   reflections = mapped_reflections
   two_theta_array = reflections['rlp'].norms()

--- a/command_line/stills_detector_hybrid_refine.py
+++ b/command_line/stills_detector_hybrid_refine.py
@@ -472,8 +472,7 @@ class Script(object):
         nrefs_per_exp.append(len(sub_ref))
 
         # obtain mm positions on the reference detector
-        sub_ref = indexer_base.map_spots_pixel_to_mm_rad(sub_ref,
-          combined_exp.detector, combined_exp.scan)
+        sub_ref.centroid_px_to_mm(combined_exp.detector, combined_exp.scan)
 
         # extend refl and experiments lists
         reflections.extend(sub_ref)

--- a/test/algorithms/indexing/test_assign_indices.py
+++ b/test/algorithms/indexing/test_assign_indices.py
@@ -15,7 +15,6 @@ from dxtbx.model import Crystal
 from dials.array_family import flex
 from dials.algorithms.indexing \
      import index_reflections, index_reflections_local
-from dials.algorithms.indexing.indexer import indexer_base
 
 
 def random_rotation(angle_min=0, angle_max=360):
@@ -75,9 +74,8 @@ def test_assign_indices(dials_regression, space_group_symbol):
     crystal_symmetry, miller_indices, anomalous_flag=True)
   predicted_reflections['xyzobs.mm.value'] = predicted_reflections['xyzcal.mm']
   predicted_reflections['id'] = flex.int(len(predicted_reflections), 0)
-  indexer_base.map_centroids_to_reciprocal_space(
-    predicted_reflections, sweep.get_detector(), sweep.get_beam(),
-    sweep.get_goniometer())
+  predicted_reflections.map_centroids_to_reciprocal_space(
+    sweep.get_detector(), sweep.get_beam(), sweep.get_goniometer())
 
   # check that local and global indexing worked equally well in absence of errors
   result = compare_global_local(experiment, predicted_reflections,

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -104,7 +104,6 @@ class SpotFrame(XrayFrame) :
       self.reflections = self.predict()
 
     if self.params.d_min is not None and len(self.reflections):
-      from dials.algorithms.indexing import indexer
       reflections = [flex.reflection_table() for i in range(len(self.reflections))]
       for i_ref_list in range(len(self.reflections)):
         if 'rlp' in self.reflections[i_ref_list]:
@@ -127,8 +126,8 @@ class SpotFrame(XrayFrame) :
               refl.centroid_px_to_mm(
                 imageset.get_detector(), imageset.get_scan())
 
-            indexer.indexer_base.map_centroids_to_reciprocal_space(
-              refl, imageset.get_detector(), imageset.get_beam(),
+            refl.map_centroids_to_reciprocal_space(
+              imageset.get_detector(), imageset.get_beam(),
               imageset.get_goniometer())
             reflections[i_ref_list].extend(refl)
 

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -123,8 +123,8 @@ class SpotFrame(XrayFrame) :
                   = self.reflections[i_ref_list]['xyzcal.px']
                 self.reflections[i_ref_list]['xyzobs.px.variance'] \
                   = flex.vec3_double(len(self.reflections[i_ref_list]), (1,1,1))
-              refl = indexer.indexer_base.map_spots_pixel_to_mm_rad(
-                self.reflections[i_ref_list].select(sel),
+              refl = self.reflections[i_ref_list].select(sel)
+              refl.centroid_px_to_mm(
                 imageset.get_detector(), imageset.get_scan())
 
             indexer.indexer_base.map_centroids_to_reciprocal_space(


### PR DESCRIPTION
Move two widely used static functions from the indexing code to flex.reflection_table() to remove the dependency on indexing code in various parts of the codebase.

- dials.algorithms.indexing.indexer.indexer_base.map_spots_pixel_to_mm_rad() replaced by dials.array_family.flex.reflection_table.centroid_px_to_mm()
- dials.algorithms.indexing.indexer.indexer_base.map_centroids_to_reciprocal_space() replaced by dials.array_family.flex.reflection_table.map_centroids_to_reciprocal_space()