### PR TITLE
Define observer/subject pattern and use in scaling to make html report

### DIFF
--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -28,9 +28,6 @@ def register_default_scaling_observers(script):
     script.scaler.register_observer(
         event="performed_outlier_rejection", observer=ScalingOutlierObserver()
     )
-    script.scaler.register_observer(
-        event="performed_error_analysis", observer=ErrorModelObserver()
-    )
 
 @singleton
 class ScalingHTMLGenerator(Observer):

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -1,0 +1,175 @@
+"""
+Observers for the scaling algorithm.
+"""
+from collections import OrderedDict
+from dials.util.observer import Observer, singleton
+from dials.algorithms.scaling.plots import (
+    plot_scaling_models,
+    statistics_tables,
+    plot_outliers,
+    normal_probability_plot,
+)
+from jinja2 import Environment, ChoiceLoader, PackageLoader
+
+
+def register_default_scaling_observers(script):
+    """Register the standard observers to the scaling script."""
+    script.register_observer(
+        event="merging_statistics", observer=MergingStatisticsObserver()
+    )
+    script.register_observer(
+        event="run_script",
+        observer=ScalingHTMLGenerator(),
+        callback="make_scaling_html",
+    )
+    script.scaler.register_observer(
+        event="performed_scaling", observer=ScalingModelObserver()
+    )
+    script.scaler.register_observer(
+        event="performed_outlier_rejection", observer=ScalingOutlierObserver()
+    )
+    script.scaler.register_observer(
+        event="performed_error_analysis", observer=ErrorModelObserver()
+    )
+
+@singleton
+class ScalingHTMLGenerator(Observer):
+
+    """
+    Observer to make a html report
+    """
+
+    def make_scaling_html(self, scaling_script):
+        """Collect data from the individual observers and write the html."""
+        self.data.update(ScalingModelObserver().make_plots())
+        self.data.update(ScalingOutlierObserver().make_plots())
+        self.data.update(ErrorModelObserver().make_plots())
+        self.data.update(MergingStatisticsObserver().make_plots())
+        filename = scaling_script.params.output.html
+        print("Writing html report to: %s" % filename)
+        loader = ChoiceLoader(
+            [
+                PackageLoader("dials", "templates"),
+                PackageLoader("dials", "static", encoding="utf-8"),
+            ]
+        )
+        env = Environment(loader=loader)
+        template = env.get_template("scaling_report.html")
+        html = template.render(
+            page_title="DIALS scaling report",
+            scaling_model_graphs=self.data["scaling_model"],
+            scaling_tables=self.data["scaling_tables"],
+            scaling_outlier_graphs=self.data["outlier_plots"],
+            normal_prob_plot=self.data["normal_prob_plot"],
+        )
+        with open(filename, "wb") as f:
+            f.write(html.encode("ascii", "xmlcharrefreplace"))
+
+
+@singleton
+class ScalingModelObserver(Observer):
+
+    """
+    Observer to record scaling model data and make model plots.
+    """
+
+    def update(self, scaler):
+        """Update the data in the observer."""
+        active_scalers = getattr(scaler, "active_scalers", False)
+        if not active_scalers:
+            active_scalers = [scaler]
+        for s in active_scalers:
+            id_ = s.experiment.identifier
+            self.data[id_] = s.experiment.scaling_model.to_dict()
+
+    def make_plots(self):
+        """Generate scaling model component plot data."""
+        d = OrderedDict()
+        for key in sorted(self.data.keys()):
+            scaling_model_plots = plot_scaling_models(self.data[key])
+            for name, plot in scaling_model_plots.iteritems():
+                d.update({name + "_" + str(key): plot})
+        graphs = {"scaling_model": d}
+        return graphs
+
+
+@singleton
+class ScalingOutlierObserver(Observer):
+
+    """
+    Observer to record scaling outliers and make outlier plots.
+    """
+
+    def update(self, scaler):
+        active_scalers = getattr(scaler, "active_scalers", False)
+        if not active_scalers:
+            active_scalers = [scaler]
+        for scaler in active_scalers:
+            id_ = scaler.experiment.identifier
+            outlier_isel = scaler.suitable_refl_for_scaling_sel.iselection().select(
+                scaler.outliers
+            )
+            x, y, z = (
+                scaler.reflection_table["xyzobs.px.value"].select(outlier_isel).parts()
+            )
+            self.data[id_] = {
+                "x": list(x),
+                "y": list(y),
+                "z": list(z),
+                "image_size": scaler.experiment.detector[0].get_image_size(),
+                "z_range": [
+                    i / scaler.experiment.scan.get_oscillation()[1]
+                    for i in scaler.experiment.scan.get_oscillation_range()
+                ],
+            }
+
+    def make_plots(self):
+        """Generate plot data of outliers on the detector and vs z."""
+        d = OrderedDict()
+        for key in sorted(self.data.keys()):
+            outlier_plots = plot_outliers(self.data[key])
+            d.update(
+                {"outlier_plot_" + str(key): outlier_plots["outlier_xy_positions"]}
+            )
+            d.update({"outlier_plot_z" + str(key): outlier_plots["outliers_vs_z"]})
+        graphs = {"outlier_plots": d}
+        return graphs
+
+
+@singleton
+class ErrorModelObserver(Observer):
+
+    """
+    Observer to record scaling error model data and make a plot.
+    """
+
+    def update(self, scaler):
+        self.data["delta_hl"] = list(
+            scaler.experiment.scaling_model.error_model.delta_hl
+        )
+
+    def make_plots(self):
+        """Generate normal probability plot data."""
+        d = {"normal_prob_plot": {}}
+        if "delta_hl" in self.data:
+            d["normal_prob_plot"] = normal_probability_plot(self.data)
+        return d
+
+
+@singleton
+class MergingStatisticsObserver(Observer):
+
+    """
+    Observer to record merging statistics data and make tables.
+    """
+
+    def update(self, scaling_script):
+        if scaling_script.merging_statistics_result:
+            self.data = {"statistics": scaling_script.merging_statistics_result}
+
+    def make_plots(self):
+        """Generate tables of overall and resolution-binned merging statistics."""
+        d = {"scaling_tables": [[], []]}
+        if "statistics" in self.data:
+            d["scaling_tables"] = statistics_tables(self.data["statistics"])
+        return d

--- a/algorithms/scaling/plots.py
+++ b/algorithms/scaling/plots.py
@@ -1,0 +1,357 @@
+"""
+Make plotly plots for html output by dials.scale, dials.report or xia2.report.
+"""
+import math as pymath
+import numpy as np
+from scitbx import math as scitbxmath
+from scitbx.math import distributions
+from dials.array_family import flex
+from dials.algorithms.scaling.model.model import PhysicalScalingModel
+
+
+def plot_scaling_models(scaling_model_dict):
+    d = {}
+    if scaling_model_dict["__id__"] == "physical":
+        model = PhysicalScalingModel.from_dict(scaling_model_dict)
+        d.update(_plot_smooth_scales(model))
+        if "absorption" in model.components:
+            d.update(plot_absorption_surface(model))
+    return d
+
+
+def _get_smooth_plotting_data_from_model(physical_model, component="scale"):
+    """Return a tuple of phis, parameters, parameter esds,
+    sample positions for plotting and sample scale values."""
+    configdict = physical_model.configdict
+    valid_osc = configdict["valid_osc_range"]
+    sample_values = flex.double(
+        np.linspace(
+            valid_osc[0],
+            valid_osc[1],
+            int(((valid_osc[1] - valid_osc[0]) / 0.1)) + 1,
+            endpoint=True,
+        )
+    )  # Make a grid of
+    # points with 10 points per degree.
+    if component == "scale":
+        if "scale" in configdict["corrections"]:
+            scale_SF = physical_model.components["scale"]
+            norm_vals = sample_values / physical_model.configdict["scale_rot_interval"]
+            scale_SF.data = {"x": norm_vals}
+            scale_SF.update_reflection_data()
+            s = scale_SF.calculate_scales()
+            smoother_phis = [
+                (i * configdict["scale_rot_interval"]) + valid_osc[0]
+                for i in scale_SF.smoother.positions()
+            ]
+        return (
+            smoother_phis,
+            scale_SF.parameters,
+            scale_SF.parameter_esds,
+            sample_values,
+            s,
+        )
+    if component == "decay":
+        if "decay" in configdict["corrections"]:
+            decay_SF = physical_model.components["decay"]
+            norm_vals = sample_values / physical_model.configdict["decay_rot_interval"]
+            decay_SF.data = {"x": norm_vals, "d": flex.double(norm_vals.size(), 1.0)}
+            decay_SF.update_reflection_data()
+            s = decay_SF.calculate_scales()
+            smoother_phis = [
+                (i * configdict["decay_rot_interval"]) + valid_osc[0]
+                for i in decay_SF._smoother.positions()
+            ]
+        return (
+            smoother_phis,
+            decay_SF.parameters,
+            decay_SF.parameter_esds,
+            sample_values,
+            s,
+        )
+
+
+def _plot_smooth_scales(physical_model):
+    """Plot smooth scale factors for the physical model."""
+
+    d = {
+        "smooth_scale_model": {
+            "data": [],
+            "layout": {
+                "title": "Smoothly varying corrections",
+                "xaxis": {
+                    "domain": [0, 1],
+                    "anchor": "y",
+                    "title": "rotation angle (degrees)",
+                },
+                "yaxis": {
+                    "domain": [0, 0.45],
+                    "anchor": "x",
+                    "title": "relative B-factor",
+                },
+                "yaxis2": {
+                    "domain": [0.5, 0.95],
+                    "anchor": "x",
+                    "title": "inverse <br> scale factor",
+                },
+            },
+        }
+    }
+
+    data = []
+
+    if "scale" in physical_model.components:
+        smoother_phis, parameters, parameter_esds, sample_values, sample_scales = _get_smooth_plotting_data_from_model(
+            physical_model, component="scale"
+        )
+
+        data.append(
+            {
+                "x": list(sample_values),
+                "y": list(sample_scales),
+                "type": "line",
+                "name": "smooth scale term",
+                "xaxis": "x",
+                "yaxis": "y2",
+            }
+        )
+        data.append(
+            {
+                "x": list(smoother_phis),
+                "y": list(parameters),
+                "type": "scatter",
+                "mode": "markers",
+                "name": "scale term parameters",
+                "xaxis": "x",
+                "yaxis": "y2",
+            }
+        )
+        if parameter_esds:
+            data[-1]["error_y"] = {"type": "data", "array": list(parameter_esds)}
+
+    if "decay" in physical_model.components:
+        smoother_phis, parameters, parameter_esds, sample_values, sample_scales = _get_smooth_plotting_data_from_model(
+            physical_model, component="decay"
+        )
+
+        data.append(
+            {
+                "x": list(sample_values),
+                "y": list(np.log(sample_scales) * 2.0),
+                "type": "line",
+                "name": "smooth decay term",
+                "xaxis": "x",
+                "yaxis": "y",
+            }
+        )
+        data.append(
+            {
+                "x": list(smoother_phis),
+                "y": list(parameters),
+                "type": "scatter",
+                "mode": "markers",
+                "name": "decay term parameters",
+                "xaxis": "x",
+                "yaxis": "y",
+            }
+        )
+        if parameter_esds:
+            data[-1]["error_y"] = {"type": "data", "array": list(parameter_esds)}
+    d["smooth_scale_model"]["data"].extend(data)
+    return d
+
+
+def plot_absorption_surface(physical_model):
+    """Plot an absorption surface for a physical scaling model."""
+
+    d = {
+        "absorption_surface": {
+            "data": [],
+            "layout": {
+                "title": "Absorption correction surface",
+                "xaxis": {"domain": [0, 1], "anchor": "y", "title": "theta (degrees)"},
+                "yaxis": {"domain": [0, 1], "anchor": "x", "title": "phi (degrees)"},
+            },
+        }
+    }
+
+    params = physical_model.components["absorption"].parameters
+
+    order = int(-1.0 + ((1.0 + len(params)) ** 0.5))
+    lfg = scitbxmath.log_factorial_generator(2 * order + 1)
+    STEPS = 50
+    phi = np.linspace(0, 2 * np.pi, 2 * STEPS)
+    theta = np.linspace(0, np.pi, STEPS)
+    THETA, _ = np.meshgrid(theta, phi)
+    lmax = int(-1.0 + ((1.0 + len(params)) ** 0.5))
+    Intensity = np.ones(THETA.shape)
+    counter = 0
+    sqrt2 = pymath.sqrt(2)
+    nsssphe = scitbxmath.nss_spherical_harmonics(order, 50000, lfg)
+    for l in range(1, lmax + 1):
+        for m in range(-l, l + 1):
+            for it, t in enumerate(theta):
+                for ip, p in enumerate(phi):
+                    Ylm = nsssphe.spherical_harmonic(l, abs(m), t, p)
+                    if m < 0:
+                        r = sqrt2 * ((-1) ** m) * Ylm.imag
+                    elif m == 0:
+                        assert Ylm.imag == 0.0
+                        r = Ylm.real
+                    else:
+                        r = sqrt2 * ((-1) ** m) * Ylm.real
+                    Intensity[ip, it] += params[counter] * r
+            counter += 1
+    d["absorption_surface"]["data"].append(
+        {
+            "x": list(theta * 180.0 / np.pi),
+            "y": list(phi * 180.0 / np.pi),
+            "z": list(Intensity.T.tolist()),
+            "type": "heatmap",
+            "colorscale": "Viridis",
+            "colorbar": {"title": "inverse <br>scale factor"},
+            "name": "absorption surface",
+            "xaxis": "x",
+            "yaxis": "y",
+        }
+    )
+    return d
+
+
+def statistics_tables(dataset_statistics):
+    result = dataset_statistics
+    resolution_binned_table = [
+        (
+            "d_max",
+            "d_min",
+            "n_obs",
+            "n_uniq",
+            "mult",
+            "comp",
+            "&ltI&gt",
+            "&ltI/sI&gt",
+            "r_merge",
+            "r_meas",
+            "r_pim",
+            "cc1/2",
+            "cc_anom",
+        )
+    ]
+    for bin_stats in result.bins:
+        resolution_binned_table.append(tuple(bin_stats.format().split()))
+    result = result.overall
+    summary_table = [
+        ("Resolution", "{0:.3f} - {1:.3f}".format(result.d_max, result.d_min)),
+        ("Observations", result.n_obs),
+        ("Unique Reflections", result.n_uniq),
+        ("Redundancy", "{:.2f}".format(result.mean_redundancy)),
+        ("Completeness", "{:.2f}".format(result.completeness * 100)),
+        ("Mean intensity", "{:.1f}".format(result.i_mean)),
+        ("Mean I/sigma(I)", "{:.1f}".format(result.i_over_sigma_mean)),
+        ("R-merge", "{:.4f}".format(result.r_merge)),
+        ("R-meas", "{:.4f}".format(result.r_meas)),
+        ("R-pim", "{:.4f}".format(result.r_pim)),
+    ]
+    return (summary_table, resolution_binned_table)
+
+
+def plot_outliers(data):
+    """plots positions of outliers"""
+
+    if not data["z"]:
+        return {"outlier_xy_positions": {}, "outliers_vs_z": {}}
+
+    hist = flex.histogram(
+        flex.double(data["z"]), n_slots=min(100, int(len(data["z"]) * 10))
+    )
+
+    d = {
+        "outlier_xy_positions": {
+            "data": [
+                {
+                    "x": data["x"],
+                    "y": data["y"],
+                    "type": "scatter",
+                    "mode": "markers",
+                    "xaxis": "x",
+                    "yaxis": "y",
+                }
+            ],
+            "layout": {
+                "title": "Outlier x-y positions",
+                "xaxis": {
+                    "anchor": "y",
+                    "title": "x (px)",
+                    "range": [0, data["image_size"][0]],
+                },
+                "yaxis": {
+                    "anchor": "x",
+                    "title": "y (px)",
+                    "range": [0, data["image_size"][1]],
+                },
+            },
+        },
+        "outliers_vs_z": {
+            "data": [
+                {
+                    "x": list(hist.slot_centers()),
+                    "y": list(hist.slots()),
+                    "type": "bar",
+                    "name": "outliers vs rotation",
+                }
+            ],
+            "layout": {
+                "title": "Outlier distribution across frames",
+                "xaxis": {"title": "frame"},
+                "yaxis": {"title": "count"},
+                "bargap": 0,
+            },
+        },
+    }
+
+    return d
+
+
+def normal_probability_plot(data):
+    ##FIXME this plot become very large/slow for a big dataset - can
+    ##we make this just a static image?
+    norm = distributions.normal_distribution()
+
+    n = len(data["delta_hl"])
+    if n <= 10:
+        a = 3 / 8
+    else:
+        a = 0.5
+
+    sorted_data = flex.sorted(flex.double(data["delta_hl"]))
+    rankits = [norm.quantile((i + 1 - a) / (n + 1 - (2 * a))) for i in xrange(n)]
+
+    d = {
+        "normal_distribution_plot": {
+            "data": [
+                {
+                    "x": rankits,
+                    "y": list(sorted_data),
+                    "type": "scatter",
+                    "mode": "markers",
+                    "xaxis": "x",
+                    "yaxis": "y",
+                    "name": "normalised deviations",
+                },
+                {
+                    "x": [-5, 5],
+                    "y": [-5, 5],
+                    "type": "scatter",
+                    "mode": "lines",
+                    "name": "z = m",
+                },
+            ],
+            "layout": {
+                "title": "Normal probability plot with error model applied",
+                "xaxis": {"anchor": "y", "title": "Order statistic medians, m"},
+                "yaxis": {"anchor": "x", "title": "Ordered responses, z"},
+            },
+        }
+    }
+
+    return d

--- a/algorithms/scaling/scaler_factory.py
+++ b/algorithms/scaling/scaler_factory.py
@@ -214,9 +214,11 @@ class MultiScalerFactory(object):
             # scaler.select_reflections_for_scaling(for_multi=True)
             single_scalers.append(scaler)
         single_scalers.extend(targetscaler.single_scalers)
-        return MultiScaler(
+        multiscaler = MultiScaler(
             targetscaler.params, [targetscaler.experiment], single_scalers
         )
+        multiscaler.observers = targetscaler.observers
+        return multiscaler
 
 
 class TargetScalerFactory(object):

--- a/algorithms/scaling/test_observers.py
+++ b/algorithms/scaling/test_observers.py
@@ -1,0 +1,223 @@
+import os
+import mock
+from collections import OrderedDict
+from dials.array_family import flex
+from dials.algorithms.scaling.model.model import KBScalingModel
+from dxtbx.model import Experiment
+from dials.util.observer import Subject
+from dials.algorithms.scaling.observers import (
+    register_default_scaling_observers,
+    ScalingModelObserver,
+    ScalingOutlierObserver,
+    ScalingHTMLGenerator,
+    ErrorModelObserver,
+    MergingStatisticsObserver,
+)
+
+
+def test_register_scaling_observers():
+    """Test the registering of the standard scaling observers."""
+
+    class Scaler(Subject):
+
+        """Test scaler class"""
+
+        def __init__(self):
+            super(Scaler, self).__init__(
+                events=[
+                    "performed_scaling",
+                    "performed_outlier_rejection",
+                    "performed_error_analysis",
+                ]
+            )
+
+    class TestScript(Subject):
+
+        """Test script class"""
+
+        def __init__(self):
+            super(TestScript, self).__init__(
+                events=["merging_statistics", "run_script"]
+            )
+            self.scaler = Scaler()
+
+    script = TestScript()
+    register_default_scaling_observers(script)
+    assert script.get_observers("merging_statistics") == {
+        MergingStatisticsObserver(): MergingStatisticsObserver().update
+    }
+    assert script.get_observers("run_script") == {
+        ScalingHTMLGenerator(): ScalingHTMLGenerator().make_scaling_html
+    }
+    assert script.scaler.get_observers("performed_scaling") == {
+        ScalingModelObserver(): ScalingModelObserver().update
+    }
+    assert script.scaler.get_observers("performed_outlier_rejection") == {
+        ScalingOutlierObserver(): ScalingOutlierObserver().update
+    }
+    assert script.scaler.get_observers("performed_error_analysis") == {
+        ErrorModelObserver(): ErrorModelObserver().update
+    }
+
+
+def test_ScalingHTMLGenerator(run_in_tmpdir):
+    """Test the scaling html generator."""
+    script = mock.Mock()
+    script.params.output.html = "test.html"
+
+    # Test that ScalingHTMLGenerator works if all data is empty.
+    observer = ScalingHTMLGenerator()
+    observer.make_scaling_html(script)
+    assert os.path.exists("test.html")
+
+
+def test_ScalingModelObserver():
+    """Test that the observer correctly logs data when passed a scaler."""
+
+    KB_dict = {
+        "__id__": "KB",
+        "is_scaled": True,
+        "scale": {"n_parameters": 1, "parameters": [0.5], "est_standard_devs": [0.05]},
+        "configuration_parameters": {"corrections": ["scale"]},
+    }
+
+    KBmodel = KBScalingModel.from_dict(KB_dict)
+    experiment = Experiment()
+    experiment.scaling_model = KBmodel
+    experiment.identifier = "0"
+
+    scaler1 = mock.Mock()
+    scaler1.experiment = experiment
+    scaler1.active_scalers = None
+
+    observer = ScalingModelObserver()
+    observer.update(scaler1)
+    assert observer.data["0"] == KB_dict
+
+    mock_func = mock.Mock()
+    mock_func.return_value = {"plot": {}}
+
+    with mock.patch(
+        "dials.algorithms.scaling.observers.plot_scaling_models", new=mock_func
+    ):
+        observer.make_plots()
+        assert mock_func.call_count == 1
+        assert mock_func.call_args_list == [mock.call(KB_dict)]
+
+    experiment2 = Experiment()
+    experiment2.scaling_model = KBmodel
+    experiment2.identifier = "1"
+    scaler2 = mock.Mock()
+    scaler2.experiment = experiment2
+    scaler2.active_scalers = None
+
+    multiscaler = mock.Mock()
+    multiscaler.active_scalers = [scaler1, scaler2]
+    observer.data = {}
+    observer.update(multiscaler)
+    assert observer.data["0"] == KB_dict
+    assert observer.data["1"] == KB_dict
+
+    mock_func = mock.Mock()
+    mock_func.return_value = {"plot": {}}
+
+    with mock.patch(
+        "dials.algorithms.scaling.observers.plot_scaling_models", new=mock_func
+    ):
+        r = observer.make_plots()
+        assert mock_func.call_count == 2
+        assert mock_func.call_args_list == [mock.call(KB_dict), mock.call(KB_dict)]
+        assert r == {"scaling_model": {"plot_0": {}, "plot_1": {}}}
+
+
+def test_ScalingOutlierObserver():
+    """Test that the observer correctly logs data when passed a scaler."""
+
+    mock_detector = mock.Mock()
+    mock_detector.get_image_size.return_value = [100.0, 200.0]
+    mock_scan = mock.Mock()
+    mock_scan.get_oscillation.return_value = [0.0, 1.0]
+    mock_scan.get_oscillation_range.return_value = [0.0, 4.0]
+
+    scaler = mock.Mock()
+    scaler.suitable_refl_for_scaling_sel = flex.bool(4, True)
+    scaler.outliers = flex.bool([False, True, False, False])
+    scaler.reflection_table = {
+        "xyzobs.px.value": flex.vec3_double(
+            [(0, 1, 2), (10, 11, 12), (20, 21, 22), (30, 31, 32)]
+        )
+    }
+    scaler.experiment.identifier = "0"
+    scaler.experiment.detector = [mock_detector]
+    scaler.experiment.scan = mock_scan
+    scaler.active_scalers = None
+
+    observer = ScalingOutlierObserver()
+    observer.update(scaler)
+    assert observer.data == {
+        "0": {
+            "x": [10],
+            "y": [11],
+            "z": [12],
+            "image_size": [100.0, 200.0],
+            "z_range": [0.0, 4.0],
+        }
+    }
+
+    mock_func = mock.Mock()
+    mock_func.return_value = {"outlier_xy_positions": {}, "outliers_vs_z": {}}
+
+    with mock.patch("dials.algorithms.scaling.observers.plot_outliers", new=mock_func):
+        r = observer.make_plots()
+        assert mock_func.call_count == 1
+        assert mock_func.call_args_list == [mock.call(observer.data["0"])]
+        assert r == {
+            "outlier_plots": OrderedDict(
+                [("outlier_plot_0", {}), ("outlier_plot_z0", {})]
+            )
+        }
+
+
+def test_ErrorModelObserver():
+    """Test that the observer correctly logs data when passed a scaler."""
+    delta_hl = flex.double(range(10))
+
+    scaler = mock.Mock()
+    scaler.experiment.scaling_model.error_model.delta_hl = delta_hl
+    scaler.active_scalers = None
+
+    observer = ErrorModelObserver()
+    observer.update(scaler)
+    assert observer.data["delta_hl"] == list(delta_hl)
+    mock_func = mock.Mock()
+    mock_func.return_value = {"plot": {}}
+
+    with mock.patch(
+        "dials.algorithms.scaling.observers.normal_probability_plot", new=mock_func
+    ):
+        r = observer.make_plots()
+        assert mock_func.call_count == 1
+        assert mock_func.call_args_list == [mock.call(observer.data)]
+        assert r == {"normal_prob_plot": {"plot": {}}}
+
+
+def test_MergingStatisticsObserver():
+    """Test that the observer correctly logs data when passed a script."""
+    script = mock.Mock()
+    script.merging_statistics_result = "result"
+
+    observer = MergingStatisticsObserver()
+    observer.update(script)
+
+    assert observer.data == {"statistics": "result"}
+
+    mock_func = mock.Mock()
+    mock_func.return_value = "return_tables"
+
+    with mock.patch(
+        "dials.algorithms.scaling.observers.statistics_tables", new=mock_func
+    ):
+        r = observer.make_plots()
+        assert mock_func.call_count == 1
+        assert mock_func.call_args_list == [mock.call(observer.data["statistics"])]
+        assert r == {"scaling_tables": "return_tables"}

--- a/algorithms/scaling/test_observers.py
+++ b/algorithms/scaling/test_observers.py
@@ -55,9 +55,6 @@ def test_register_scaling_observers():
     assert script.scaler.get_observers("performed_outlier_rejection") == {
         ScalingOutlierObserver(): ScalingOutlierObserver().update
     }
-    assert script.scaler.get_observers("performed_error_analysis") == {
-        ErrorModelObserver(): ErrorModelObserver().update
-    }
 
 
 def test_ScalingHTMLGenerator(run_in_tmpdir):

--- a/algorithms/scaling/test_plots.py
+++ b/algorithms/scaling/test_plots.py
@@ -1,0 +1,85 @@
+from scitbx.array_family import flex
+from iotbx.merging_statistics import dataset_statistics
+from dials.algorithms.scaling.plots import (
+    plot_scaling_models,
+    plot_outliers,
+    statistics_tables,
+    normal_probability_plot,
+)
+
+
+def test_plot_scaling_models():
+
+    physical_dict = {
+        "__id__": "physical",
+        "is_scaled": True,
+        "scale": {
+            "n_parameters": 2,
+            "parameters": [0.5, 1.0],
+            "est_standard_devs": [0.05, 0.1],
+        },
+        "configuration_parameters": {
+            "corrections": ["scale", "decay", "absorption"],
+            "s_norm_fac": 0.1,
+            "d_norm_fac": 0.1,
+            "scale_rot_interval": 10.0,
+            "decay_rot_interval": 10.0,
+            "decay_restaint": 1e-1,
+            "valid_osc_range": [0.0, 2.0],
+        },
+        "decay": {
+            "n_parameters": 2,
+            "parameters": [0.5, 1.0],
+            "est_standard_devs": [0.05, 0.1],
+        },
+        "absorption": {
+            "n_parameters": 4,
+            "parameters": [0.1, -0.1, 0.05, -0.05],
+            "est_standard_devs": [0.005, 0.005, 0.005, 0.005],
+        },
+    }
+    d = plot_scaling_models(physical_dict)
+    assert "smooth_scale_model" in d
+    assert "absorption_surface" in d
+
+
+def test_normal_probability_plot():
+    data = {"delta_hl": range(20)}
+    d = normal_probability_plot(data)
+    assert "normal_distribution_plot" in d
+
+
+def test_plot_outliers():
+    """Test outlier plot, for standard and null data."""
+    data = {"x": [1.0, 2.0], "y": [0.0, 1.0], "z": [1.0, 1.0], "image_size": [100, 200]}
+    d = plot_outliers(data)
+    assert "outliers_vs_z" in d
+    assert "outlier_xy_positions" in d
+
+    data = {"x": [], "y": [], "z": [], "image_size": [100, 200]}
+    d = plot_outliers(data)
+    assert "outliers_vs_z" in d
+    assert "outlier_xy_positions" in d
+
+
+def test_statistics_tables():
+    """Test generation of statistics tables"""
+    import random
+    from cctbx import miller
+    from cctbx import crystal
+
+    ms = miller.build_set(
+        crystal_symmetry=crystal.symmetry(
+            space_group_symbol="P1", unit_cell=(6, 6, 6, 90, 90, 90)
+        ),
+        anomalous_flag=True,
+        d_min=1.0,
+    )
+    data = flex.double(float(random.randrange(0, 100)) for _ in range(ms.size()))
+    iobs = miller.array(ms, data, sigmas=data)
+    iobs.change_symmetry(space_group_symbol="P222", merge_non_unique=False)
+    iobs.set_info(miller.array_info(source="DIALS", source_type="reflection_tables"))
+    iobs.set_observation_type_xray_intensity()
+    result = dataset_statistics(iobs, assert_is_not_unique_set_under_symmetry=False)
+    tables = statistics_tables(result)
+    assert len(tables) == 2  # overall and per resolution

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -53,6 +53,7 @@ class run_one_scaling(object):
         _ = easy_run.fully_buffered(command=command).raise_if_errors()
         assert os.path.exists("scaled_experiments.json")
         assert os.path.exists("scaled.pickle")
+        assert os.path.exists("scaling.html")
 
         with open("scaled.pickle", "rb") as fh:
             table = pickle.load(fh)
@@ -201,7 +202,9 @@ def test_scale_merging_stats():
     reflections.set_flags(flex.bool(4, False), reflections.flags.bad_for_scaling)
     params.output.merging.nbins = 1
     scaled_array = Script.scaled_data_as_miller_array([reflections], exp)
-    merging_statistics_result = Script.merging_stats(scaled_array, params)
+    merging_statistics_result = Script.merging_stats_from_scaled_array(
+        scaled_array, params
+    )
     assert merging_statistics_result is not None
 
     # test for sensible return if small dataset with no equivalent reflections
@@ -209,7 +212,9 @@ def test_scale_merging_stats():
         [(0, 0, 1), (0, 0, 2), (0, 0, 3), (0, 0, 4)]
     )
     scaled_array = Script.scaled_data_as_miller_array([reflections], exp)
-    merging_statistics_result = Script.merging_stats(scaled_array, params)
+    merging_statistics_result = Script.merging_stats_from_scaled_array(
+        scaled_array, params
+    )
     assert merging_statistics_result is None
 
 

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -83,6 +83,8 @@ from dials.algorithms.scaling.algorithm import (
 from dials.algorithms.scaling.reflection_selection import (
     determine_reflection_selection_parameters,
 )
+from dials.util.observer import Subject
+from dials.algorithms.scaling.observers import register_default_scaling_observers
 
 
 logger = logging.getLogger("dials")
@@ -114,6 +116,9 @@ phil_scope = phil.parse(
       .type = str
       .help = "Option to set filepath for output pickle file of scaled
                intensities."
+    html = "scaling.html"
+      .type = str
+      .help = "Filename for html report."
     unmerged_mtz = None
       .type = path
       .help = "Filename to export an unmerged_mtz, calls dials.export internally."
@@ -150,10 +155,11 @@ phil_scope = phil.parse(
 )
 
 
-class Script(object):
+class Script(Subject):
     """Main script to run the scaling algorithm."""
 
     def __init__(self, params, experiments, reflections):
+        super(Script, self).__init__(events=["merging_statistics", "run_script"])
         self.scaler = None
         self.scaled_miller_array = None
         self.merging_statistics_result = None
@@ -161,6 +167,8 @@ class Script(object):
             params, experiments, reflections
         )
         self._create_model_and_scaler()
+        logger.debug("Initialised scaling script object")
+        log_memory_usage()
 
     def _create_model_and_scaler(self):
         """Create the scaling models and scaler."""
@@ -178,20 +186,19 @@ class Script(object):
         self.experiments = set_image_ranges_in_scaling_models(self.experiments)
 
         self.scaler = create_scaler(self.params, self.experiments, self.reflections)
-        logger.debug("Initialised scaling script object")
-        log_memory_usage()
 
+    @Subject.notify_event(event="run_script")
     def run(self, save_data=True):
         """Run the scaling script."""
         start_time = time.time()
         self.scale()
         self.remove_unwanted_datasets()
         print_scaling_model_error_info(self.experiments)
-        self.prepare_scaled_miller_array()
+        self.scaled_miller_array = self.scaled_data_as_miller_array(
+            self.reflections, self.experiments, anomalous_flag=False
+        )
         try:
-            self.merging_statistics_result = self.merging_stats(
-                self.scaled_miller_array, self.params
-            )
+            self.calculate_merging_stats()
         except DialsMergingStatisticsError as e:
             logger.info(e)
 
@@ -380,12 +387,6 @@ will not be used for calculating merging statistics"""
         )
         return i_obs
 
-    def prepare_scaled_miller_array(self):
-        """Calculate a scaled miller array from the dataset."""
-        self.scaled_miller_array = self.scaled_data_as_miller_array(
-            self.reflections, self.experiments, anomalous_flag=False
-        )
-
     @staticmethod
     def stats_only(reflections, experiments, params):
         """Calculate and print merging stats."""
@@ -396,12 +397,18 @@ will not be used for calculating merging statistics"""
             reflections, experiments, best_unit_cell=best_unit_cell
         )
         try:
-            _ = Script.merging_stats(scaled_miller_array, params)
+            _ = Script.merging_stats_from_scaled_array(scaled_miller_array, params)
         except DialsMergingStatisticsError as e:
             logger.info(e)
 
+    @Subject.notify_event(event="merging_statistics")
+    def calculate_merging_stats(self):
+        self.merging_statistics_result = self.merging_stats_from_scaled_array(
+            self.scaled_miller_array, self.params
+        )
+
     @staticmethod
-    def merging_stats(scaled_miller_array, params):
+    def merging_stats_from_scaled_array(scaled_miller_array, params):
         """Calculate and print the merging statistics."""
         logger.info("%s %s %s", "\n", "=" * 80, "\n")
 
@@ -426,14 +433,15 @@ will not be used for calculating merging statistics"""
                 eliminate_sys_absent=False,
                 use_internal_variance=params.output.use_internal_variance,
             )
-            show_merging_summary(result.overall)
-            show_merging_stats_by_resolution(result)
-            show_estimated_cutoffs(result)
-            return result
         except RuntimeError:
             raise DialsMergingStatisticsError(
                 "Failure during merging statistics calculation"
             )
+        else:
+            show_merging_summary(result.overall)
+            show_merging_stats_by_resolution(result)
+            show_estimated_cutoffs(result)
+            return result
 
     def delete_datastructures(self):
         """Delete the data in the scaling datastructures to save RAM before
@@ -788,6 +796,9 @@ if __name__ == "__main__":
                 logger.info(diff_phil)
 
             script = Script(params, experiments, reflections)
+            # Register the observers at the highest level
+            if params.output.html:
+                register_default_scaling_observers(script)
             script.run()
 
     except Exception as e:

--- a/templates/scaling_report.html
+++ b/templates/scaling_report.html
@@ -1,0 +1,21 @@
+{% extends "report_base.html" %}
+{% block content %}
+<div class="page-header">
+    <h1>{{ page_title }}</h1>
+</div>
+
+<div>
+  <div class="panel-group">
+      <div class="panel-body">
+          <p><b>Summary of merging statistics</b></p>
+          {{ macros.table(scaling_tables[0]) }}
+          <p><b>Merging statistics by resolution bin</b></p>
+          {{ macros.table(scaling_tables[1]) }}
+      </div>
+      {{ macros.panel('Scaling model plots', 'scaling_model', scaling_model_graphs) }}
+      {{ macros.panel('Scaling outlier plots', 'outlier_plots', scaling_outlier_graphs) }}
+      {{ macros.panel('Normal probability plots', 'normal_prob_plot', normal_prob_plot) }}
+  </div>
+</div>
+
+{% endblock %}

--- a/test/util/test_observer.py
+++ b/test/util/test_observer.py
@@ -1,0 +1,95 @@
+"""
+Test the observer module.
+"""
+from dials.util.observer import singleton, Observer, Subject
+
+
+def test_singleton_decorator():
+    """Test the singleton class decorator."""
+
+    class TestClass(object):
+        """Simplest class."""
+
+        pass
+
+    singleton_class = singleton(TestClass)
+
+    c1 = singleton_class()
+    c2 = singleton_class()
+
+    assert c1 is c2
+
+    c1 = TestClass()
+    c2 = TestClass()
+
+    assert c1 is not c2
+
+
+def test_Observer():
+    """Test for expected properties of the general observer."""
+
+    observer = Observer()
+    assert hasattr(observer, "data")
+    observer.update([])
+
+
+def test_Subject():
+    """Test the subject class."""
+
+    # First register events
+    subject = Subject(events=["event1", "event2"])
+    assert "event1" in subject.observers
+    assert "event2" in subject.observers
+
+    # Test the get_observers and register_observer and unregister_observer method
+    observer = Observer()
+    assert subject.get_observers("event1") == {}
+    assert subject.get_observers("event2") == {}
+    subject.register_observer("event1", observer)
+    assert subject.get_observers("event1") == {observer: observer.update}
+    assert subject.get_observers("event2") == {}
+    subject.unregister_observer("event1", observer)
+    assert subject.get_observers("event1") == {}
+    assert subject.get_observers("event2") == {}
+
+    # Try registering the observer with a different callback
+    class MyObserver(Observer):
+        """Test observer implementation class."""
+
+        def __init__(self):
+            self.count = 0
+
+        def mycallback(self, _):
+            """Custom callback method."""
+            self.count += 1
+
+    observer = MyObserver()
+    subject = Subject(events=["event1", "event2"])
+    subject.register_observer("event1", observer, callback="mycallback")
+    assert subject.get_observers("event1") == {observer: observer.mycallback}
+    assert subject.get_observers("event2") == {}
+
+    # Now test call to nofity.
+    subject.notify("event1")
+    assert observer.count == 1
+    subject.notify("event2")
+    assert observer.count == 1
+
+    # Now test the notify decorator
+    class MySubject(Subject):
+        """Test subject implementation class."""
+
+        def __init__(self):
+            super(MySubject, self).__init__(events=["event1"])
+
+        @Subject.notify_event("event1")
+        def test_method(self):
+            """Test method for warpping."""
+            return "test_return_value"
+
+    mysubject = MySubject()
+    myobserver = MyObserver()
+    mysubject.register_observer("event1", myobserver, callback="mycallback")
+    x = mysubject.test_method()
+    assert myobserver.count == 1
+    assert x == "test_return_value"

--- a/util/observer.py
+++ b/util/observer.py
@@ -4,6 +4,7 @@ Define an interface for observers and subjects.
 A singleton decorator is also defined.
 """
 
+import functools
 
 def singleton(cls):
     instances = {}
@@ -36,6 +37,7 @@ class Subject(object):
         """Define a decorator for notifying of a specific event."""
 
         def wrap(method):
+            @functools.wraps(method)
             def notify(self, *args, **kwargs):
                 r = method(self, *args, **kwargs)
                 self.notify(event)

--- a/util/observer.py
+++ b/util/observer.py
@@ -1,0 +1,63 @@
+"""
+Define an interface for observers and subjects.
+
+A singleton decorator is also defined.
+"""
+
+
+def singleton(cls):
+    instances = {}
+
+    def getinstance():
+        if cls not in instances:
+            instances[cls] = cls()
+        return instances[cls]
+
+    return getinstance
+
+
+class Observer(object):
+    def __init__(self):
+        self.data = {}
+
+    def update(self, subject):
+        """Extract the relevant state information by inspecting the subject."""
+        pass
+
+
+class Subject(object):
+    def __init__(self, events):
+        self.observers = {}
+        for event in events:
+            self.observers[event] = {}
+
+    @staticmethod
+    def notify_event(event):
+        """Define a decorator for notifying of a specific event."""
+
+        def wrap(method):
+            def notify(self, *args, **kwargs):
+                r = method(self, *args, **kwargs)
+                self.notify(event)
+                return r
+
+            return notify
+
+        return wrap
+
+    def get_observers(self, event):
+        return self.observers[event]
+
+    def register_observer(self, event, observer, callback=None):
+        if callback is None:
+            callback = getattr(observer, "update")
+        else:
+            callback = getattr(observer, callback)
+        self.get_observers(event)[observer] = callback
+
+    def unregister_observer(self, event, observer):
+        del self.get_observers(event)[observer]
+
+    def notify(self, event):
+        for callback in self.get_observers(event).itervalues():
+            callback(self)


### PR DESCRIPTION
This pull request introduces Subject and Observer classes, based on the observer design pattern, defined in dials.util.observer.py. Creating a pull request to allow people who might have thoughts for general design improvement to offer feedback @ndevenish @Anthchirp .

A subject is an object that can register observers, to be notified in the case of an 'event' of interest. When notified, the observer can inspect the subject to update its state. This can facilitate a range of use cases. My present use case is to facilitate the generation of an html report in dials.scale. I have included the changes to dials.scale code as an example of how this functionality can be used. With this change, dials.scale now also outputs a scaling.html

Details : In my use case, the dials.scale Script class and Scaler class inherit from Subject (see the changes in dials.algorithms.scaler.py) and the scaling observers are only registered at the highest level (in ```if __name__ == "__main__":``` in dials.scale).
If the observers are not registered on the script, then nothing happens, so a different process using the dials.scale Script class is unaffected (e.g. dials.scale_and_filter).

These changes will also allow much of the scaling plotting code to be removed from dials.report and allow the removal of several dials.plot_scaling_* scripts that I have added over time, but I will enact that once merged.

Cheers,
James