### PR TITLE
Convert dials.generate_mask to functional interface

### DIFF
--- a/command_line/generate_mask.py
+++ b/command_line/generate_mask.py
@@ -75,7 +75,7 @@ phil_scope = parse(
 )
 
 
-def script(experiments, params):
+def generate_mask(experiments, params):
     """
     Generate a pixel mask for each image in an experiment.
 
@@ -109,12 +109,12 @@ def script(experiments, params):
         beams = experiments.beams()
         for d in detectors[1:]:
             if not d.is_similar_to(detectors[0]):
-                raise ValueError(
+                sys.exit(
                     "Multiple imagesets are present, but their detector models differ."
                 )
         for b in beams[1:]:
             if not b.is_similar_to(beams[0]):
-                raise ValueError(
+                sys.exit(
                     "Multiple imagesets are present, but their beam models differ."
                 )
 
@@ -178,7 +178,7 @@ def run(phil=phil_scope, args=None):
         sys.exit("Exactly 1 experiment must be specified.")
 
     # Run the script
-    script(experiments, params)
+    generate_mask(experiments, params)
 
 
 if __name__ == "__main__":

--- a/command_line/generate_mask.py
+++ b/command_line/generate_mask.py
@@ -32,19 +32,20 @@ Examples::
 
 from __future__ import absolute_import, division, print_function
 
-import sys
 import logging
+import sys
+
 import six.moves.cPickle as pickle
 
 import dials.util
 import dials.util.log
-from scitbx.array_family import flex
-import libtbx.phil as phil
 import libtbx.load_env
-from dials.util.options import OptionParser, flatten_experiments
+import libtbx.phil as phil
 from dials.util.masking import MaskGenerator
+from dials.util.options import OptionParser, flatten_experiments
 from dxtbx.format.image import ImageBool
-from dxtbx.model.experiment_list import ExperimentListDumper, ExperimentList
+from dxtbx.model.experiment_list import ExperimentList, ExperimentListDumper
+from scitbx.array_family import flex
 
 try:
     from typing import List, Optional, Tuple
@@ -53,7 +54,7 @@ try:
 except ImportError:
     pass
 
-log = logging.getLogger('dials.generate_mask')
+log = logging.getLogger("dials.generate_mask")
 
 phil_scope = phil.parse(
     """
@@ -64,7 +65,7 @@ phil_scope = phil.parse(
         experiments = None
             .type = path
             .help = "Name of output experiment list file.  If this is set, a copy of "
-                    "the experiments, modified with the generated pixel masks, " 
+                    "the experiments, modified with the generated pixel masks, "
                     "will be saved to this location."
         log = 'dials.generate_masks.log'
             .type = str
@@ -72,7 +73,7 @@ phil_scope = phil.parse(
     }
 
     include scope dials.util.masking.phil_scope
-    
+
     verbosity = 1
         .type = int(value_min=0)
         .help = "The verbosity level."

--- a/command_line/generate_mask.py
+++ b/command_line/generate_mask.py
@@ -113,16 +113,18 @@ def generate_mask(experiments, params):
     imagesets = experiments.imagesets()
     masks = []
 
-    # Specify the formatting of the output filenames
+    # Create output mask filenames
     num_imagesets = len(imagesets)
-    pad = len("{:d}".format(num_imagesets))
-    # If there is more than one imageset, append a number to each output mask filename
-    filenames = [
-        "_{:0{:d}d}".format(i + 1, pad).join(os.path.splitext(params.output.mask))
-        if num_imagesets > 1
-        else params.output.mask
-        for i in range(num_imagesets)
-    ]
+    if num_imagesets == 1:
+        filenames = [params.output.mask]
+    else:
+        # If there is more than one imageset, append a number to each output filename
+        name, ext = os.path.splitext(params.output.mask)
+        pad = len(str(num_imagesets))
+        filenames = [
+            "{name}_{num:0{pad}}{ext}".format(name=name, num=i + 1, pad=pad, ext=ext)
+            for i in range(num_imagesets)
+        ]
 
     # Generate the mask
     generator = MaskGenerator(params)

--- a/command_line/generate_mask.py
+++ b/command_line/generate_mask.py
@@ -88,7 +88,7 @@ def generate_mask(experiments, params):
     Generate a pixel mask for each image in an experiment.
 
     Use the masking parameters :param:`params` and an experiment in the experiment
-    list :param:`experiments` to define pixel masks for the associated imagesets.
+    list :param:`experiments` to define pixel masks for the associated imageset.
     The masks are generated using :mod:`dials.util.masking`.
 
     The masks will be saved to disk at the location specified by
@@ -97,7 +97,7 @@ def generate_mask(experiments, params):
     with the masks applied will be saved to that location.
 
     Args:
-        experiments: An experiment list containing only one experiment.
+        experiments: An experiment list containing only one imageset.
         params: Masking parameters, having the structure defined in
             :data:`phil_scope`.
 
@@ -108,21 +108,7 @@ def generate_mask(experiments, params):
         only returned if :attr:`params.output.experiments` is set).
     """
     imagesets = experiments.imagesets()
-    if len(imagesets) > 1:
-        # Check beams (for resolution) and detectors are equivalent in each case
-        # otherwise the mask may not be appropriate across all imagesets
-        detectors = experiments.detectors()
-        beams = experiments.beams()
-        for d in detectors[1:]:
-            if not d.is_similar_to(detectors[0]):
-                sys.exit(
-                    "Multiple imagesets are present, but their detector models differ."
-                )
-        for b in beams[1:]:
-            if not b.is_similar_to(beams[0]):
-                sys.exit(
-                    "Multiple imagesets are present, but their beam models differ."
-                )
+    assert len(imagesets) == 1, "Only single imagesets supported"
 
     imageset = imagesets[0]
 

--- a/command_line/generate_mask.py
+++ b/command_line/generate_mask.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-#
+# -*- coding: utf-8 -*-
+
 # generate_mask.py
 #
 #  Copyright (C) 2013 Diamond Light Source
@@ -9,11 +10,8 @@
 #  This code is distributed under the BSD license, a copy of which is
 #  included in the root directory of this package.
 
-from __future__ import absolute_import, division, print_function
-
-from iotbx.phil import parse
-
-help_message = """
+"""
+Mask images to remove unwanted pixels.
 
 This program is used to generate mask to specify which pixels should be
 considered "invalid" during spot finding and integration. It provides a few
@@ -32,108 +30,157 @@ Examples::
 
 """
 
+from __future__ import absolute_import, division, print_function
+
+import sys
+import logging
+import six.moves.cPickle as pickle
+
+import dials.util
+import dials.util.log
+from iotbx.phil import parse
+import libtbx.load_env
+from dials.util.options import OptionParser, flatten_experiments
+from dials.util.masking import MaskGenerator
+from dxtbx.format.image import ImageBool
+from dxtbx.model.experiment_list import ExperimentListDumper
+
+help_message = __doc__
+
+log = logging.getLogger('dials.generate_mask')
+
 phil_scope = parse(
     """
-  output {
-    mask = mask.pickle
-      .type = path
-      .help = "Name of output mask file"
-    experiments = None
-      .type = path
-      .help = "Save the modified experiments. (usually only modified with the"
-              "generated pixel mask)"
-  }
+    output {
+        mask = mask.pickle
+            .type = path
+            .help = "Name of output mask file."
+        experiments = None
+            .type = path
+            .help = "Name of output experiment list file.  If this is set, a copy of "
+                    "the experiments, modified with the generated pixel masks, " 
+                    "will be saved to this location."
+        log = 'dials.generate_masks.log'
+            .type = str
+            .help = "The log filename."
+    }
 
-  include scope dials.util.masking.phil_scope
-""",
+    include scope dials.util.masking.phil_scope
+    
+    verbosity = 1
+        .type = int(value_min=0)
+        .help = "The verbosity level."
+    """,
     process_includes=True,
 )
 
 
-class Script(object):
-    """ A class to encapsulate the script. """
+def script(experiments, params):
+    """
+    Generate a pixel mask for each image in an experiment.
 
-    def __init__(self):
-        """ Initialise the script. """
-        from dials.util.options import OptionParser
-        import libtbx.load_env
+    Use the masking parameters :param:`params` and an experiment in the experiment
+    list :param:`experiments` to define pixel masks for the associated imagesets.
+    The masks are generated using :mod:`dials.util.masking`.
 
-        # Create the parser
-        usage = "usage: %s [options] experiments.json" % libtbx.env.dispatcher_name
-        self.parser = OptionParser(
-            usage=usage, phil=phil_scope, epilog=help_message, read_experiments=True
-        )
+    The masks will be saved to disk at the location specified by
+    :attr:`params.output.mask`.  Optionally, if a path
+    :attr:`params.output.experiments` is set, a modified copy of :param:`experiments`
+    with the masks applied will be saved to that location.
 
-    def run(self):
-        """ Run the script. """
-        from dials.util.masking import MaskGenerator
-        from dials.util.options import flatten_experiments
-        from dials.util import Sorry
-        import six.moves.cPickle as pickle
-        from dials.util import log
-        from dxtbx.format.image import ImageBool
+    Args:
+        experiments (:type:`dxtbx_model_ext.ExperimentList`): An experiment list
+            containing only one :type:`dxtbx_model_ext.Experiment` object.
+        params (:type:`libtbx.phil.scope_extract`): Masking parameters, having the
+            structure defined in :data:`dials.util.masking.phil_scope`.
 
-        # Parse the command line arguments
-        params, options = self.parser.parse_args(show_diff_phil=True)
-        experiments = flatten_experiments(params.input.experiments)
+    Returns:
+        Tuple[:rtype:`scitbx_array_family_flex_ext.bool`]: A tuple containing the
+            generated pixel masks.
+        :rtype:`dxtbx_model_ext.ExperimentList` (optional): A copy of
+            :param:`experiments` with the masks applied.  Only returned if
+            :attr:`params.output.experiments` is set.
+    """
+    imagesets = experiments.imagesets()
+    if len(imagesets) > 1:
+        # Check beams (for resolution) and detectors are equivalent in each case
+        # otherwise the mask may not be appropriate across all imagesets
+        detectors = experiments.detectors()
+        beams = experiments.beams()
+        for d in detectors[1:]:
+            if not d.is_similar_to(detectors[0]):
+                raise ValueError(
+                    "Multiple imagesets are present, but their detector models differ."
+                )
+        for b in beams[1:]:
+            if not b.is_similar_to(beams[0]):
+                raise ValueError(
+                    "Multiple imagesets are present, but their beam models differ."
+                )
 
-        # Configure logging
-        log.config()
+    imageset = imagesets[0]
 
-        # Check number of args
-        if len(experiments) == 0:
-            self.parser.print_help()
-            return
+    # Generate the mask
+    generator = MaskGenerator(params)
+    mask = generator.generate(imageset)
 
-        if len(experiments) != 1:
-            raise Sorry("exactly 1 experiments must be specified")
-        imagesets = experiments.imagesets()
-        if len(imagesets) > 1:
-            # Check beams (for resolution) and detectors are equivalent in each case
-            # otherwise the mask may not be appropriate across all imagesets
-            detectors = experiments.detectors()
-            beams = experiments.beams()
-            for d in detectors[1:]:
-                if not d.is_similar_to(detectors[0]):
-                    raise Sorry(
-                        "multiple imagesets are present, but their detector"
-                        " models differ"
-                    )
-            for b in beams[1:]:
-                if not b.is_similar_to(beams[0]):
-                    raise Sorry(
-                        "multiple imagesets are present, but their beam"
-                        " models differ"
-                    )
+    # Save the mask to file
+    log.info("Writing mask to %s", params.output.mask)
+    with open(params.output.mask, "wb") as fh:
+        pickle.dump(mask, fh)
 
-        imageset = imagesets[0]
+    # Save the experiment list
+    if params.output.experiments:
+        for imageset in imagesets:
+            imageset.external_lookup.mask.data = ImageBool(mask)
+            imageset.external_lookup.mask.filename = params.output.mask
 
-        # Generate the mask
-        generator = MaskGenerator(params)
-        mask = generator.generate(imageset)
+        log.info("Saving experiments to %s", params.output.experiments)
+        dump = ExperimentListDumper(experiments)
+        dump.as_file(params.output.experiments)
 
-        # Save the mask to file
-        print("Writing mask to %s" % params.output.mask)
-        with open(params.output.mask, "wb") as fh:
-            pickle.dump(mask, fh)
+        return mask, experiments
+    else:
+        return mask
 
-        # Save the experiment list
-        if params.output.experiments is not None:
-            for imageset in imagesets:
-                imageset.external_lookup.mask.data = ImageBool(mask)
-                imageset.external_lookup.mask.filename = params.output.mask
-            from dxtbx.model.experiment_list import ExperimentListDumper
 
-            print("Saving experiments to {0}".format(params.output.experiments))
-            dump = ExperimentListDumper(experiments)
-            dump.as_file(params.output.experiments)
+def run(phil=phil_scope, args=None):
+    """
+    Parse command-line arguments, run the script.
+
+    Use the DIALS option parser to extract an experiment list and parameters.  Pass
+    these to :func:`script`.  If :param:`args` is None (default), the option parser
+    defaults to :data:`sys.argv[1:]`.
+
+    Args:
+        phil (:type:`libtbx.phil.scope`): PHIL scope for option parser.
+        args (:type:`list`): Arguments to parse.  Defaults to :data:`sys.argv[1:]`.
+    """
+    # Create the parser
+    usage = "usage: %s [options] experiments.json" % libtbx.env.dispatcher_name
+    parser = OptionParser(
+        usage=usage, phil=phil, epilog=help_message, read_experiments=True
+    )
+
+    # Parse the command line arguments
+    params, options = parser.parse_args(args=args, show_diff_phil=True)
+    experiments = flatten_experiments(params.input.experiments)
+
+    # Configure logging
+    dials.util.log.config(params.verbosity, info=params.output.log)
+
+    # Check number of args
+    if len(experiments) == 0:
+        parser.print_help()
+        sys.exit(1)
+
+    if len(experiments) != 1:
+        sys.exit("Exactly 1 experiment must be specified.")
+
+    # Run the script
+    script(experiments, params)
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
-        script = Script()
-        script.run()
-    except Exception as e:
-        halraiser(e)
+    with dials.util.show_mail_on_error():
+        run()

--- a/test/command_line/test_generate_mask.py
+++ b/test/command_line/test_generate_mask.py
@@ -5,10 +5,26 @@ import os
 import procrunner
 import pytest
 
+from dials.command_line.generate_mask import generate_mask, phil_scope
+from dxtbx.serialize import load
+
 
 @pytest.fixture
 def input_filename(dials_regression, run_in_tmpdir):
     yield os.path.join(dials_regression, "centroid_test_data", "experiments.json")
+    print("temporary directory=", run_in_tmpdir.strpath)
+
+
+@pytest.fixture(
+    params=[
+        "centroid_test_data",
+        pytest.param("l_cysteine_dials_output", marks=pytest.mark.xfail),
+    ],
+    ids=["One sweep", "Four sweeps"],
+)
+def input_experiment_list(request, dials_data, run_in_tmpdir):
+    filename = (dials_data(request.param) / "imported_experiments.json").strpath
+    yield load.experiment_list(filename)
     print("temporary directory=", run_in_tmpdir.strpath)
 
 
@@ -33,7 +49,6 @@ def test_generate_mask_with_untrusted_rectangle(input_filename):
     assert result["stderr"] == ""
     assert os.path.exists("mask2.pickle")
     assert os.path.exists("masked_experiments.json")
-    from dxtbx.serialize import load
 
     experiments = load.experiment_list("masked_experiments.json")
     imageset = experiments.imagesets()[0]
@@ -118,3 +133,22 @@ def test_generate_mask_with_untrusted_polygon_and_pixels(input_filename):
     assert not mask[0][0, 0]
     assert not mask[0][1, 1]
     assert mask[0][0, 1]
+
+
+def test_generate_mask_function_with_untrusted_rectangle(input_experiment_list):
+    params = phil_scope.extract()
+    params.output.mask = "mask4.pickle"
+    params.output.experiments = "masked_experiments.json"
+    params.untrusted.rectangle = [100, 200, 100, 200]
+    generate_mask(input_experiment_list, params)
+    assert os.path.exists("mask4.pickle") or all(
+        [os.path.exists("mask4_{:d}.pickle".format(i + 1)) for i in range(4)]
+    )
+    assert os.path.exists("masked_experiments.json")
+
+    experiments = load.experiment_list("masked_experiments.json")
+    imageset = experiments.imagesets()[0]
+    associated_masks = ["mask4.pickle", "mask4_1.pickle"]
+    assert imageset.external_lookup.mask.filename in [
+        os.path.join(os.path.abspath(os.getcwd()), mask) for mask in associated_masks
+    ]

--- a/util/masking.py
+++ b/util/masking.py
@@ -249,15 +249,19 @@ class MaskGenerator(object):
                 d_max = max(d_min + 1, 1e9)
                 get_resolution_mask_generator().apply(mask, d_min, d_max)
 
-            # Mask out the resolution range
-            for drange in self.params.resolution_range:
-                d_min = min(drange)
-                d_max = max(drange)
-                assert d_min < d_max, "d_min must be < d_max"
-                logger.info("Generating resolution range mask:")
-                logger.info(" d_min = %f" % d_min)
-                logger.info(" d_max = %f" % d_max)
-                get_resolution_mask_generator().apply(mask, d_min, d_max)
+            try:
+                # Mask out the resolution range
+                for drange in self.params.resolution_range:
+                    d_min = min(drange)
+                    d_max = max(drange)
+                    assert d_min < d_max, "d_min must be < d_max"
+                    logger.info("Generating resolution range mask:")
+                    logger.info(" d_min = %f" % d_min)
+                    logger.info(" d_max = %f" % d_max)
+                    get_resolution_mask_generator().apply(mask, d_min, d_max)
+            except TypeError:
+                # Catch the default value None of self.params.resolution_range
+                pass
 
             # Mask out the resolution ranges for the ice rings
             for drange in generate_ice_ring_resolution_ranges(

--- a/util/masking.py
+++ b/util/masking.py
@@ -261,7 +261,10 @@ class MaskGenerator(object):
                     get_resolution_mask_generator().apply(mask, d_min, d_max)
             except TypeError:
                 # Catch the default value None of self.params.resolution_range
-                pass
+                if self.params.resolution_range:
+                    raise
+                else:
+                    pass
 
             # Mask out the resolution ranges for the ice rings
             for drange in generate_ice_ring_resolution_ranges(


### PR DESCRIPTION
Following our discussion around #691, I thought I'd start a few bits of functional interface conversion, specifically the bits that affect i19.screen.  To start tamely, I've done `dials.generate_mask`.  I'd quite like to have it reviewed before I do any of the others, to check that I'm not doing anything controversial.

One particular question — I've converted some `Sorry`s to `ValueError`s, but should I be using `sys.exit()` in this context?

As far as possible, the changes follow boilerplate agreed in [the wiki](../wiki/Boilerplate-(or-the-standard-framework-of-a-DIALS-program)).