### PR TITLE
Enable travis builds for 1.14 release candidates

### DIFF
--- a/.travis/setup-base
+++ b/.travis/setup-base
@@ -11,8 +11,8 @@ if [ -f $HOME/build_dials/.cache_valid ]; then
 else
   echo -e "\e[31;1mThis is not the cache you are looking for: Starting from scratch\e[0m"
   cd $HOME
-  wget http://dials.diamond.ac.uk/diamond_builds/dials-linux-x86_64.tar.xz -O - | tar xJ
-  cd dials-installer-dev
+  wget https://dials.diamond.ac.uk/diamond_builds/dials-v1.14-release-candidate-linux-x86_64.tar.gz -O - | tar xz
+  cd dials-installer
   ./install --nopycompile --verbose --prefix=..
   cd ..
 
@@ -20,8 +20,8 @@ else
   rm -rf build_dials
 
   # Fix up build path
-  mv dials-dev* build_dials
-  sed -i -e 's/dials-dev[0-9]\+/build_dials/g' $HOME/build_dials/build/setpaths.sh
+  mv dials-v* build_dials
+  sed -i -e 's/dials-v[^/]\+/build_dials/g' $HOME/build_dials/build/setpaths.sh
 
   # Define this as a valid base install
   touch $HOME/build_dials/.cache_valid

--- a/.travis/setup-base
+++ b/.travis/setup-base
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+EXPECTED_CACHE_REVISION=1
+
 if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
   echo -e "\e[31;1mCron job build detected. Invalidating cache.\e[0m"
   rm -f $HOME/build_dials/.cache_valid
   rm -f $HOME/build_dials/.build_complete
 fi
 
-if [ -f $HOME/build_dials/.cache_valid ]; then
+if [ -f $HOME/build_dials/.cache_valid ] && [ "$EXPECTED_CACHE_REVISION" == "$(cat $HOME/build_dials/.cache_valid)" ]; then
   echo -e "\e[1mCache probably valid\e[0m"
 else
   echo -e "\e[31;1mThis is not the cache you are looking for: Starting from scratch\e[0m"
@@ -24,5 +26,5 @@ else
   sed -i -e 's/dials-v[^/]\+/build_dials/g' $HOME/build_dials/build/setpaths.sh
 
   # Define this as a valid base install
-  touch $HOME/build_dials/.cache_valid
+  echo $EXPECTED_CACHE_REVISION>$HOME/build_dials/.cache_valid
 fi


### PR DESCRIPTION
should be easy. only need to build on top of the Diamond 1.14 RC builds rather than the 2.0 nightlies.