### PR TITLE
Enable LGTM for DIALS repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # DIALS: Diffraction Integration for Advanced Light Sources
 
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/dials/dials.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dials/dials/context:python)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/dials/dials.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dials/dials/alerts/)
 
 X-ray crystallography for structural biology has benefited greatly from a number of advances in recent years including high performance pixel array detectors, new beamlines capable of delivering micron and sub-micron focus and new light sources such as X-FELs. The DIALS project is a collaborative endeavour to develop new diffraction integration software to meet the data analysis requirements presented by these recent advances. There are three end goals: to develop an extensible framework for the development of algorithms to analyse X-ray diffraction data; the implementation of algorithms within this framework and finally a set of user facing tools using these algorithms to allow integration of data from diffraction experiments on synchrotron and free electron sources.
 


### PR DESCRIPTION
LGTM is a static code analyser which has identified a number of issues in the DIALS code base.
So far the results look useful. It found a few programming errors that were rather hard to spot.

I would like to add the badges 
[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/dials/dials.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dials/dials/context:python) [![Total alerts](https://img.shields.io/lgtm/alerts/g/dials/dials.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dials/dials/alerts/)
to the main README, and enable LGTM on pull requests to highlight any new issues being introduced.

Opinions?