### PR TITLE
Refactor cosym command line program, to separate out exporting.

### DIFF
--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -255,7 +255,7 @@ class cosym(Subject):
             sel = expt.crystal.get_space_group().is_sys_absent(refl["miller_index"])
             if sel.count(True):
                 logger.info(
-                    "Elminating %i systematic absences for experiment %s",
+                    "Eliminating %i systematic absences for experiment %s",
                     sel.count(True),
                     expt.identifier,
                 )


### PR DESCRIPTION
This change refactors the end stages of dials.cosym - splitting the reindexing of experiments and reflections from the exporting. This allows the reflections and experiments from the cosym_instance to be used by other programs. The separate export step then does not need to be called by other programs, but is for the command line script.

The motivation behind this is that it would be nice to have the option in dials.scale to do automatic consistent reindexing with cosym when adding multiple datasets, or for incremental scaling. I think this can now be achieved with this snippet:
```
from dials.command_line.cosym import cosym
cosym_instance = cosym(experiments=experiments, reflections=reflections)
cosym_instance.run()
experiments = cosym_instance.experiments
reflections = cosym_instance.reflections 
```

The only potential issue is that the "run_cosym" notification now occurs before exporting, but I think all the data should already be there for the observers. I also removed a copy.deepcopy on the reflections, I don't think this is needed now? I don't think any other behaviour is changed and the tests pass.