### PR TITLE
Improve spotfinding

### DIFF
--- a/algorithms/image/fill_holes/simple.h
+++ b/algorithms/image/fill_holes/simple.h
@@ -62,7 +62,8 @@ namespace dials { namespace algorithms {
     std::size_t width = data.accessor()[1];
 
     // Compute the manhattan distance transform of the mask
-    af::versa< int, af::c_grid<2> > distance = manhattan_distance(mask);
+    af::versa< int, af::c_grid<2> > distance(mask.accessor());
+    manhattan_distance(mask, true, distance.ref());
 
     // Get a list of the pixels to fill
     std::vector<detail::SimpleFillNode> pixels;

--- a/algorithms/image/filter/boost_python/distance.cc
+++ b/algorithms/image/filter/boost_python/distance.cc
@@ -16,11 +16,32 @@ namespace dials { namespace algorithms { namespace boost_python {
 
   using namespace boost::python;
 
+  af::versa< int, af::c_grid<2> > manhattan_distance_wrapper(
+      const af::const_ref<bool, af::c_grid<2> > &src,
+      bool value) {
+    af::versa< int, af::c_grid<2> > dst(src.accessor());
+    manhattan_distance(src, value, dst.ref());
+    return dst;
+  }
+  
+  af::versa< int, af::c_grid<2> > chebyshev_distance_wrapper(
+      const af::const_ref<bool, af::c_grid<2> > &src,
+      bool value) {
+    af::versa< int, af::c_grid<2> > dst(src.accessor());
+    chebyshev_distance(src, value, dst.ref());
+    return dst;
+  }
+
   void export_distance()
   {
     def("manhattan_distance",
-      &manhattan_distance, (
-        arg("data")));
+      &manhattan_distance_wrapper, (
+        arg("data"),
+        arg("value")));
+    def("chebyshev_distance",
+      &chebyshev_distance_wrapper, (
+        arg("data"),
+        arg("value")));
   }
 
 }}} // namespace = dials::algorithms::boost_python

--- a/algorithms/image/filter/boost_python/mean_and_variance.cc
+++ b/algorithms/image/filter/boost_python/mean_and_variance.cc
@@ -74,7 +74,8 @@ namespace dials { namespace algorithms { namespace boost_python {
       arg("image"),
       arg("mask"),
       arg("size"),
-      arg("min_count")));
+      arg("min_count"),
+      arg("ignore_masked") = true));
 
     def("mean_and_variance_filter",
       &make_mean_and_variance_filter<FloatType>, (

--- a/algorithms/image/filter/distance.h
+++ b/algorithms/image/filter/distance.h
@@ -12,6 +12,7 @@
 #define DIALS_ALGORITHMS_IMAGE_FILTER_DISTANCE_H
 
 #include <dials/array_family/scitbx_shared_and_versa.h>
+#include <dials/error.h>
 
 namespace dials { namespace algorithms {
 
@@ -20,44 +21,100 @@ namespace dials { namespace algorithms {
    * @param data The image
    * @return The distance transform
    */
-  inline
-  af::versa< int, af::c_grid<2> > manhattan_distance(
-      const af::const_ref< bool, af::c_grid<2> > &data) {
+  template <typename InputType, typename OutputType>
+  void manhattan_distance(
+      const af::const_ref<InputType, af::c_grid<2> > &src,
+      InputType value,
+      af::ref<OutputType, af::c_grid<2> > dst) {
 
     // Initialise stuff
-    std::size_t height = data.accessor()[0];
-    std::size_t width = data.accessor()[1];
-    int max_distance = height + width;
-    af::versa< int, af::c_grid<2> > result(data.accessor(), max_distance);
-
-    // Go south and west
-    for (std::size_t j = 0; j < height; ++j) {
-      for (std::size_t i = 1; i < width; ++i) {
-        int N = (j > 0) ? result(j-1,i) : max_distance;
-        int E = (i > 0) ? result(j,i-1) : max_distance;
-        if (data(j,i)) {
-          result(j,i) = 0;
-        } else {
-          result(j,i) = 1 + std::min(N, E);
-        }
-      }
-    }
+    std::size_t height = src.accessor()[0];
+    std::size_t width = src.accessor()[1];
+    OutputType max_distance = height + width;
+    DIALS_ASSERT(src.accessor().all_eq(dst.accessor()));
 
     // Go north and east
-    for (std::size_t j = height; j > 0; --j) {
-      for (std::size_t i = width; i > 0; --i) {
-        int S = (j < height) ? result(j,i-1) : max_distance;
-        int W = (i < width)  ? result(j-1,i) : max_distance;
-        int other = std::min(S, W);
-        if (other < result(j-1,i-1)) {
-          result(j-1,i-1) = 1 + other;
+    for (std::size_t j = 0; j < height; ++j) {
+      for (std::size_t i = 1; i < width; ++i) {
+        OutputType N = (j > 0) ? dst(j-1,i) : max_distance;
+        OutputType E = (i > 0) ? dst(j,i-1) : max_distance;
+        if (src(j,i) == value) {
+          dst(j,i) = 0;
+        } else {
+          dst(j,i) = 1 + std::min(N, E);
         }
       }
     }
 
-    return result;
+    // Go south and west
+    for (std::size_t j = height; j > 0; --j) {
+      for (std::size_t i = width; i > 0; --i) {
+        OutputType S = (j < height) ? dst(j,i-1) : max_distance;
+        OutputType W = (i < width)  ? dst(j-1,i) : max_distance;
+        OutputType other = std::min(S, W);
+        if (other < dst(j-1,i-1)) {
+          dst(j-1,i-1) = 1 + other;
+        }
+      }
+    }
   }
 
+  /**
+   * Compute the chebyshev distance to the given value
+   * @param src: The src array
+   * @param value: The value to compute the distance to
+   * @param dst: The destination array
+   */
+  template <typename InputType, typename OutputType>
+  void chebyshev_distance(
+        const af::const_ref<InputType, af::c_grid<2> > &src,
+        InputType value,
+        af::ref<OutputType, af::c_grid<2> > dst) {
+    
+    // Initialise stuff
+    std::size_t height = src.accessor()[0];
+    std::size_t width = src.accessor()[1];
+    OutputType max_distance = height + width;
+    DIALS_ASSERT(src.accessor().all_eq(dst.accessor()));
+
+    // Go north and east
+    for (std::size_t j = 0; j < height; ++j) {
+      for (std::size_t i = 1; i < width; ++i) {
+        OutputType N = (j > 0) 
+          ? dst(j-1,i) : max_distance;
+        OutputType E = (i > 0) 
+          ? dst(j,i-1) : max_distance;
+        OutputType NE = (j > 0 && i > 0) 
+          ? dst(j-1,i-1) : max_distance;
+        OutputType NW = (j > 0 && i < width-1) 
+          ? dst(j-1,i+1) : max_distance;
+        if (src(j,i) == value) {
+          dst(j,i) = 0;
+        } else {
+          dst(j,i) = 1 + std::min(std::min(N, E), std::min(NE, NW));
+        }
+      }
+    }
+
+    // Go south and west
+    for (std::size_t j = height; j > 0; --j) {
+      for (std::size_t i = width; i > 0; --i) {
+        OutputType S = (j < height) 
+          ? dst(j,i-1) : max_distance;
+        OutputType W = (i < width)  
+          ? dst(j-1,i) : max_distance;
+        OutputType SE = (j < height && i > 1)
+          ? dst(j,i-2) : max_distance;
+        OutputType SW = (j < height && i < width)
+          ? dst(j,i) : max_distance;
+        OutputType other = std::min(std::min(S, W), std::min(SE, SW));
+        if (other < dst(j-1,i-1)) {
+          dst(j-1,i-1) = 1 + other;
+        }
+      }
+    }
+  
+  }
 }}
 
 #endif // DIALS_ALGORITHMS_IMAGE_FILTER_DISTANCE_H

--- a/algorithms/image/filter/mean_and_variance.h
+++ b/algorithms/image/filter/mean_and_variance.h
@@ -102,7 +102,7 @@ namespace dials { namespace algorithms {
 
     // Calculate the mean filtered image
     for (std::size_t i = 0; i < image.size(); ++i) {
-      if ((ignore_masked && mask[i]) || summed_mask[i] >= min_count) {
+      if ((!ignore_masked || mask[i]) && summed_mask[i] >= min_count) {
         summed_image[i] /= (FloatType)summed_mask[i];
       } else {
         summed_image[i] = 0.0;

--- a/algorithms/image/filter/mean_and_variance.h
+++ b/algorithms/image/filter/mean_and_variance.h
@@ -65,12 +65,13 @@ namespace dials { namespace algorithms {
    * @param mask The mask to use (0 = off, 1 == on)
    * @param size The size of the filter kernel (2 * size + 1)
    * @param min_count The minimum counts to use
+   * @param ignore_masked Ignore and set mean to zero if masked
    * @returns The filtered image
    */
   template <typename FloatType>
   af::versa< FloatType, af::c_grid<2> > mean_filter_masked(
       const af::const_ref< FloatType, af::c_grid<2> > &image,
-      af::ref< int, af::c_grid<2> > mask, int2 size, int min_count) {
+      af::ref< int, af::c_grid<2> > mask, int2 size, int min_count, bool ignore_masked=true) {
 
     // Check the input is valid
     DIALS_ASSERT(size.all_ge(0));
@@ -101,7 +102,7 @@ namespace dials { namespace algorithms {
 
     // Calculate the mean filtered image
     for (std::size_t i = 0; i < image.size(); ++i) {
-      if (mask[i]) {
+      if ((ignore_masked && mask[i]) || summed_mask[i] >= min_count) {
         summed_image[i] /= (FloatType)summed_mask[i];
       } else {
         summed_image[i] = 0.0;

--- a/algorithms/image/threshold/boost_python/local.cc
+++ b/algorithms/image/threshold/boost_python/local.cc
@@ -118,6 +118,51 @@ namespace dials { namespace algorithms { namespace boost_python {
       .def("value_mask", &DispersionThresholdDebug::value_mask)
       .def("final_mask", &DispersionThresholdDebug::final_mask)
       ;
+    
+    class_<DispersionExtendedThresholdDebug>("DispersionExtendedThresholdDebug", no_init)
+      .def(init<const af::const_ref<double, af::c_grid<2> > &,
+                const af::const_ref<bool, af::c_grid<2> > &,
+                int2, double, double, double, int>((
+                    arg("image"),
+                    arg("mask"),
+                    arg("size"),
+                    arg("n_sigma_b"),
+                    arg("n_sigma_s"),
+                    arg("threshold"),
+                    arg("min_count"))))
+      .def(init<const af::const_ref<double, af::c_grid<2> > &,
+                const af::const_ref<bool, af::c_grid<2> > &,
+                const af::const_ref<double, af::c_grid<2> > &,
+                int2, double, double, double, int>((
+                    arg("image"),
+                    arg("mask"),
+                    arg("gain"),
+                    arg("size"),
+                    arg("n_sigma_b"),
+                    arg("n_sigma_s"),
+                    arg("threshold"),
+                    arg("min_count"))))
+      .def("mean", &DispersionExtendedThresholdDebug::mean)
+      .def("variance", &DispersionExtendedThresholdDebug::variance)
+      .def("index_of_dispersion", &DispersionExtendedThresholdDebug::index_of_dispersion)
+      .def("global_mask", &DispersionExtendedThresholdDebug::global_mask)
+      .def("cv_mask", &DispersionExtendedThresholdDebug::cv_mask)
+      .def("value_mask", &DispersionExtendedThresholdDebug::value_mask)
+      .def("final_mask", &DispersionExtendedThresholdDebug::final_mask)
+      ;
+    
+    class_<DispersionExtendedThreshold>("DispersionExtendedThreshold", no_init)
+      .def(init< int2,
+                 int2,
+                 double,
+                 double,
+                 double,
+                 int >())
+      /* .def("__call__", &DispersionExtendedThreshold::threshold<int>) */
+      .def("__call__", &DispersionExtendedThreshold::threshold<double>)
+      /* .def("__call__", &DispersionExtendedThreshold::threshold_w_gain<int>) */
+      .def("__call__", &DispersionExtendedThreshold::threshold_w_gain<double>)
+      ;
 
   }
 

--- a/algorithms/image/threshold/local.h
+++ b/algorithms/image/threshold/local.h
@@ -929,7 +929,7 @@ namespace dials { namespace algorithms {
       std::size_t erosion_distance = std::min(size[0], size[1]);
       af::versa< int, af::c_grid<2> > temp_mask(image.accessor(), 0);
       for (std::size_t i = 0; i < image.size(); ++i) {
-        if (mask[i]) {
+        if (temp[i]) {
           value_mask_[i] = distance[i] >= erosion_distance;
           temp_mask[i] = !(cv_mask_[i] && value_mask_[i]);
         }
@@ -938,14 +938,14 @@ namespace dials { namespace algorithms {
       // Widen the kernel slightly and compute the mean image without strong pixels
       size[0] += 2;
       size[1] += 2;
-      mean_ = mean_filter_masked(image, temp_mask.ref(), size, 2);
+      mean_ = mean_filter_masked(image, temp_mask.ref(), size, 2, false);
 
       // Compute the final thresholds
       for (std::size_t i = 0; i < image.size(); ++i) {
-        if (temp[i]) {
+        if (mask[i]) {
           double bnd_s = mean_[i] + nsig_s * std::sqrt(gain[i] * mean_[i]);
-          value_mask_[i] = (distance[i] >= nsig_s) && (image[i] >= bnd_s);
-          final_mask_[i] = cv_mask_[i] && value_mask_[i] & global_mask_[i];
+          value_mask_[i] = (distance[i] >= erosion_distance) && (image[i] >= bnd_s);
+          final_mask_[i] = cv_mask_[i] && value_mask_[i] && global_mask_[i];
         }
         global_mask_[i] = temp_mask[i];
       }
@@ -960,15 +960,26 @@ namespace dials { namespace algorithms {
     af::versa< bool, af::c_grid<2> > value_mask_;
     af::versa< bool, af::c_grid<2> > final_mask_;
   };
-  
+ 
+
   /**
    * A class to compute the threshold using index of dispersion
    */
   class DispersionExtendedThreshold {
   public:
 
-    DispersionExtendedThreshold(
-              int2 image_size,
+    /**
+     * Enable more efficient memory usage by putting components required for the
+     * summed area table closer together in memory
+     */
+    template <typename T>
+    struct Data {
+      int m;
+      T   x;
+      T   y;
+    };
+
+    DispersionExtendedThreshold(int2 image_size,
               int2 kernel_size,
               double nsig_b,
               double nsig_s,
@@ -979,8 +990,392 @@ namespace dials { namespace algorithms {
           nsig_b_(nsig_b),
           nsig_s_(nsig_s),
           threshold_(threshold),
-          min_count_(min_count) {}
+          min_count_(min_count) {
 
+      // Check the input
+      DIALS_ASSERT(threshold_ >= 0);
+      DIALS_ASSERT(nsig_b >= 0 && nsig_s >= 0);
+      DIALS_ASSERT(image_size.all_gt(0));
+      DIALS_ASSERT(kernel_size.all_gt(0));
+
+      // Ensure the min counts are valid
+      std::size_t num_kernel = (2*kernel_size[0]+1)*(2*kernel_size[1]+1);
+      if (min_count_ <= 0) {
+        min_count_ = num_kernel;
+      } else {
+        DIALS_ASSERT(min_count_ <= num_kernel && min_count_ > 1);
+      }
+
+      // Allocate the buffer
+      std::size_t element_size = sizeof(Data<double>);
+      buffer_.resize(element_size * image_size[0] * image_size[1]);
+    }
+    
+    /**
+     * Compute the summed area tables for the mask, src and src^2.
+     * @param src The input array
+     * @param mask The mask array
+     */
+    template <typename T>
+    void compute_sat(
+        af::ref< Data<T> > table,
+        const af::const_ref< T, af::c_grid<2> > &src,
+        const af::const_ref< bool, af::c_grid<2> > &mask) {
+
+      // Largest value to consider
+      const T BIG = (1 << 24); // About 16m counts
+
+      // Get the size of the image
+      std::size_t ysize = src.accessor()[0];
+      std::size_t xsize = src.accessor()[1];
+
+      // Create the summed area table
+      for (std::size_t j = 0, k = 0; j < ysize; ++j) {
+        int m = 0;
+        T   x = 0;
+        T   y = 0;
+        for (std::size_t i = 0; i < xsize; ++i, ++k) {
+          int mm = (mask[k] && src[k] < BIG) ? 1 : 0;
+          m += mm;
+          x += mm * src[k];
+          y += mm * src[k] * src[k];
+          if (j == 0) {
+            table[k].m = m;
+            table[k].x = x;
+            table[k].y = y;
+          } else {
+            table[k].m = table[k-xsize].m + m;
+            table[k].x = table[k-xsize].x + x;
+            table[k].y = table[k-xsize].y + y;
+          }
+        }
+      }
+    }
+
+    /**
+     * Compute the threshold
+     * @param src - The input array
+     * @param mask - The mask array
+     * @param dst The output array
+     */
+    template <typename T>
+    void compute_dispersion_threshold(
+        af::ref< Data<T> > table,
+        const af::const_ref< T, af::c_grid<2> > &src,
+        const af::const_ref< bool, af::c_grid<2> > &mask,
+        af::ref< bool, af::c_grid<2> > dst) {
+
+      // Get the size of the image
+      std::size_t ysize = src.accessor()[0];
+      std::size_t xsize = src.accessor()[1];
+
+      // The kernel size
+      int kxsize = kernel_size_[1];
+      int kysize = kernel_size_[0];
+
+      // Calculate the local mean at every point
+      for (std::size_t j = 0, k = 0; j < ysize; ++j) {
+        for (std::size_t i = 0 ; i < xsize; ++i, ++k) {
+          int i0 = i - kxsize - 1, i1 = i + kxsize;
+          int j0 = j - kysize - 1, j1 = j + kysize;
+          i1 = i1 < xsize ? i1 : xsize - 1;
+          j1 = j1 < ysize ? j1 : ysize - 1;
+          int k0 = j0*xsize;
+          int k1 = j1*xsize;
+
+          // Compute the number of points valid in the local area,
+          // the sum of the pixel values and the sum of the squared pixel
+          // values.
+          double m = 0;
+          double x = 0;
+          double y = 0;
+          if (i0 >= 0 && j0 >= 0) {
+            const Data<T>& d00 = table[k0+i0];
+            const Data<T>& d10 = table[k1+i0];
+            const Data<T>& d01 = table[k0+i1];
+            m += d00.m - (d10.m + d01.m);
+            x += d00.x - (d10.x + d01.x);
+            y += d00.y - (d10.y + d01.y);
+          } else if (i0 >= 0) {
+            const Data<T>& d10 = table[k1+i0];
+            m -= d10.m;
+            x -= d10.x;
+            y -= d10.y;
+          } else if (j0 >= 0) {
+            const Data<T>& d01 = table[k0+i1];
+            m -= d01.m;
+            x -= d01.x;
+            y -= d01.y;
+          }
+          const Data<T>& d11 = table[k1+i1];
+          m += d11.m;
+          x += d11.x;
+          y += d11.y;
+
+          // Compute the thresholds
+          dst[k] = false;
+          if (mask[k] && m >= min_count_ && x >= 0) {
+            double a = m * y - x * x - x * (m-1);
+            double c = x * nsig_b_ * std::sqrt(2*(m-1));
+            dst[k] = (a > c);
+          }
+        }
+      }
+    }
+
+    /**
+     * Compute the threshold
+     * @param src - The input array
+     * @param mask - The mask array
+     * @param gain - The gain array
+     * @param dst The output array
+     */
+    template <typename T>
+    void compute_dispersion_threshold(
+        af::ref< Data<T> > table,
+        const af::const_ref< T, af::c_grid<2> > &src,
+        const af::const_ref< bool, af::c_grid<2> > &mask,
+        const af::const_ref< double, af::c_grid<2> > &gain,
+        af::ref< bool, af::c_grid<2> > dst) {
+
+      // Get the size of the image
+      std::size_t ysize = src.accessor()[0];
+      std::size_t xsize = src.accessor()[1];
+
+      // The kernel size
+      int kxsize = kernel_size_[1];
+      int kysize = kernel_size_[0];
+
+      // Calculate the local mean at every point
+      for (std::size_t j = 0, k = 0; j < ysize; ++j) {
+        for (std::size_t i = 0 ; i < xsize; ++i, ++k) {
+          int i0 = i - kxsize - 1, i1 = i + kxsize;
+          int j0 = j - kysize - 1, j1 = j + kysize;
+          i1 = i1 < xsize ? i1 : xsize - 1;
+          j1 = j1 < ysize ? j1 : ysize - 1;
+          int k0 = j0*xsize;
+          int k1 = j1*xsize;
+
+          // Compute the number of points valid in the local area,
+          // the sum of the pixel values and the num of the squared pixel
+          // values.
+          double m = 0;
+          double x = 0;
+          double y = 0;
+          if (i0 >= 0 && j0 >= 0) {
+            const Data<T>& d00 = table[k0+i0];
+            const Data<T>& d10 = table[k1+i0];
+            const Data<T>& d01 = table[k0+i1];
+            m += d00.m - (d10.m + d01.m);
+            x += d00.x - (d10.x + d01.x);
+            y += d00.y - (d10.y + d01.y);
+          } else if (i0 >= 0) {
+            const Data<T>& d10 = table[k1+i0];
+            m -= d10.m;
+            x -= d10.x;
+            y -= d10.y;
+          } else if (j0 >= 0) {
+            const Data<T>& d01 = table[k0+i1];
+            m -= d01.m;
+            x -= d01.x;
+            y -= d01.y;
+          }
+          const Data<T>& d11 = table[k1+i1];
+          m += d11.m;
+          x += d11.x;
+          y += d11.y;
+
+          // Compute the thresholds
+          dst[k] = false;
+          if (mask[k] && m >= min_count_ && x >= 0) {
+            double a = m * y - x * x;
+            double c = gain[k] * x * (m-1+nsig_b_ * std::sqrt(2*(m-1)));
+            dst[k] = (a > c);
+          }
+        }
+      }
+    }
+   
+    /**
+     * Erode the dispersion mask
+     * @param dst The dispersion mask
+     */
+    void erode_dispersion_mask(
+        const af::const_ref< bool, af::c_grid<2> > &mask,
+        af::ref< bool, af::c_grid<2> > dst) {
+      
+      // The distance array
+      af::versa< int, af::c_grid<2> > distance(dst.accessor(), 0);
+
+      // Compute the chebyshev distance to the nearest valid background pixel
+      chebyshev_distance(dst, false, distance.ref());
+
+      // The erosion distance
+      std::size_t erosion_distance = std::min(kernel_size_[0], kernel_size_[1]);
+
+      // Compute the eroded mask
+      for (std::size_t k = 0; k < dst.size(); ++k) {
+        if (mask[k]) {
+          dst[k] = !(dst[k] && distance[k] >= erosion_distance);
+        } else {
+          dst[k] = false;
+        }
+      }
+    }
+
+    
+    /**
+     * Compute the threshold
+     * @param src - The input array
+     * @param mask - The mask array
+     * @param dst The output array
+     */
+    template <typename T>
+    void compute_final_threshold(
+        af::ref< Data<T> > table,
+        const af::const_ref< T, af::c_grid<2> > &src,
+        const af::const_ref< bool, af::c_grid<2> > &mask,
+        af::ref< bool, af::c_grid<2> > dst) {
+
+      // Get the size of the image
+      std::size_t ysize = src.accessor()[0];
+      std::size_t xsize = src.accessor()[1];
+
+      // The kernel size
+      int kxsize = kernel_size_[1]+2;
+      int kysize = kernel_size_[0]+2;
+
+      // Calculate the local mean at every point
+      for (std::size_t j = 0, k = 0; j < ysize; ++j) {
+        for (std::size_t i = 0 ; i < xsize; ++i, ++k) {
+          int i0 = i - kxsize - 1, i1 = i + kxsize;
+          int j0 = j - kysize - 1, j1 = j + kysize;
+          i1 = i1 < xsize ? i1 : xsize - 1;
+          j1 = j1 < ysize ? j1 : ysize - 1;
+          int k0 = j0*xsize;
+          int k1 = j1*xsize;
+
+          // Compute the number of points valid in the local area,
+          // the sum of the pixel values and the sum of the squared pixel
+          // values.
+          double m = 0;
+          double x = 0;
+          if (i0 >= 0 && j0 >= 0) {
+            const Data<T>& d00 = table[k0+i0];
+            const Data<T>& d10 = table[k1+i0];
+            const Data<T>& d01 = table[k0+i1];
+            m += d00.m - (d10.m + d01.m);
+            x += d00.x - (d10.x + d01.x);
+          } else if (i0 >= 0) {
+            const Data<T>& d10 = table[k1+i0];
+            m -= d10.m;
+            x -= d10.x;
+          } else if (j0 >= 0) {
+            const Data<T>& d01 = table[k0+i1];
+            m -= d01.m;
+            x -= d01.x;
+          }
+          const Data<T>& d11 = table[k1+i1];
+          m += d11.m;
+          x += d11.x;
+
+          // Compute the thresholds. The pixel is marked True if:
+          // 1. The pixel is valid
+          // 2. It has 1 or more unmasked neighbours
+          // 3. It is within the dispersion masked region
+          // 4. It is greater than the global threshold
+          // 5. It is greater than the local mean threshold
+          //
+          // Otherwise it is false
+          if (mask[k] && m >= 0 && x >= 0) {
+            bool dispersion_mask = !dst[k];
+            bool global_mask = src[k] > threshold_;
+            double mean = (m >= 2 ? (x / m) : 0);
+            bool local_mask = src[k] >= (mean + nsig_s_ * std::sqrt(mean));
+            dst[k] = dispersion_mask && global_mask && local_mask;
+          } else {
+            dst[k] = false;
+          }
+        }
+      }
+    }
+    
+    /**
+     * Compute the threshold
+     * @param src - The input array
+     * @param mask - The mask array
+     * @param dst The output array
+     */
+    template <typename T>
+    void compute_final_threshold(
+        af::ref< Data<T> > table,
+        const af::const_ref< T, af::c_grid<2> > &src,
+        const af::const_ref< bool, af::c_grid<2> > &mask,
+        const af::const_ref< double, af::c_grid<2> > &gain,
+        af::ref< bool, af::c_grid<2> > dst) {
+
+      // Get the size of the image
+      std::size_t ysize = src.accessor()[0];
+      std::size_t xsize = src.accessor()[1];
+
+      // The kernel size
+      int kxsize = kernel_size_[1]+2;
+      int kysize = kernel_size_[0]+2;
+
+      // Calculate the local mean at every point
+      for (std::size_t j = 0, k = 0; j < ysize; ++j) {
+        for (std::size_t i = 0 ; i < xsize; ++i, ++k) {
+          int i0 = i - kxsize - 1, i1 = i + kxsize;
+          int j0 = j - kysize - 1, j1 = j + kysize;
+          i1 = i1 < xsize ? i1 : xsize - 1;
+          j1 = j1 < ysize ? j1 : ysize - 1;
+          int k0 = j0*xsize;
+          int k1 = j1*xsize;
+
+          // Compute the number of points valid in the local area,
+          // the sum of the pixel values and the sum of the squared pixel
+          // values.
+          double m = 0;
+          double x = 0;
+          if (i0 >= 0 && j0 >= 0) {
+            const Data<T>& d00 = table[k0+i0];
+            const Data<T>& d10 = table[k1+i0];
+            const Data<T>& d01 = table[k0+i1];
+            m += d00.m - (d10.m + d01.m);
+            x += d00.x - (d10.x + d01.x);
+          } else if (i0 >= 0) {
+            const Data<T>& d10 = table[k1+i0];
+            m -= d10.m;
+            x -= d10.x;
+          } else if (j0 >= 0) {
+            const Data<T>& d01 = table[k0+i1];
+            m -= d01.m;
+            x -= d01.x;
+          }
+          const Data<T>& d11 = table[k1+i1];
+          m += d11.m;
+          x += d11.x;
+
+          // Compute the thresholds. The pixel is marked True if:
+          // 1. The pixel is valid
+          // 2. It has 1 or more unmasked neighbours
+          // 3. It is within the dispersion masked region
+          // 4. It is greater than the global threshold
+          // 5. It is greater than the local mean threshold
+          //
+          // Otherwise it is false
+          if (mask[k] && m >= 0 && x >= 0) {
+            bool dispersion_mask = !dst[k];
+            bool global_mask = src[k] > threshold_;
+            double mean = (m >= 2 ? (x / m) : 0);
+            bool local_mask = src[k] >= (mean + nsig_s_ * std::sqrt(gain[k] * mean));
+            dst[k] = dispersion_mask && global_mask && local_mask;
+          } else {
+            dst[k] = false;
+          }
+        }
+      }
+    }
 
     /**
      * Compute the threshold for the given image and mask.
@@ -993,23 +1388,39 @@ namespace dials { namespace algorithms {
         const af::const_ref< T, af::c_grid<2> > &src,
         const af::const_ref< bool, af::c_grid<2> > &mask,
         af::ref< bool, af::c_grid<2> > dst) {
-    
-      DispersionExtendedThresholdDebug debug(
-          src,
-          mask,
-          kernel_size_,
-          nsig_b_,
-          nsig_s_,
-          threshold_,
-          min_count_);
+
+      // check the input
+      DIALS_ASSERT(src.accessor().all_eq(image_size_));
+      DIALS_ASSERT(src.accessor().all_eq(mask.accessor()));
+      DIALS_ASSERT(src.accessor().all_eq(dst.accessor()));
+
+      // Get the table
+      DIALS_ASSERT(sizeof(T) <= sizeof(double));
+
+      // Cast the buffer to the table type
+      af::ref< Data<T> > table(
+          reinterpret_cast<Data<T>*>(&buffer_[0]),
+          buffer_.size());
       
-      DIALS_ASSERT(dst.accessor().all_eq(src.accessor()));
-      af::versa<bool, af::c_grid<2> > final_mask = debug.final_mask();
-      std::copy(final_mask.begin(), final_mask.end(), dst.begin());
+      // compute the summed area table
+      compute_sat(table, src, mask);
+
+      // Compute the dispersion threshold. This output is in dst which contains
+      // a mask where 1 is valid background and 0 is invalid pixels and stuff
+      // above the dispersion threshold 
+      compute_dispersion_threshold(table, src, mask, dst);
+
+      // Erode the dispersion mask
+      erode_dispersion_mask(mask, dst);
+
+      // Compute the summed area table again now excluding the threshold pixels
+      compute_sat(table, src, dst);
+
+      // Compute the final threshold
+      compute_final_threshold(table, src, mask, dst);
     }
 
     /**
-     *
      * Compute the threshold for the given image and mask.
      * @param src - The input image array.
      * @param mask - The mask array.
@@ -1023,21 +1434,37 @@ namespace dials { namespace algorithms {
         const af::const_ref< double, af::c_grid<2> > &gain,
         af::ref< bool, af::c_grid<2> > dst) {
 
-      DispersionExtendedThresholdDebug debug(
-          src,
-          mask,
-          gain,
-          kernel_size_,
-          nsig_b_,
-          nsig_s_,
-          threshold_,
-          min_count_);
-      
-      DIALS_ASSERT(dst.accessor().all_eq(src.accessor()));
-      af::versa<bool, af::c_grid<2> > final_mask = debug.final_mask();
-      std::copy(final_mask.begin(), final_mask.end(), dst.begin());
+      // check the input
+      DIALS_ASSERT(src.accessor().all_eq(image_size_));
+      DIALS_ASSERT(src.accessor().all_eq(mask.accessor()));
+      DIALS_ASSERT(src.accessor().all_eq(gain.accessor()));
+      DIALS_ASSERT(src.accessor().all_eq(dst.accessor()));
 
+      // Get the table
+      DIALS_ASSERT(sizeof(T) <= sizeof(double));
+
+      // Cast the buffer to the table type
+      af::ref< Data<T> > table((Data<T> *)&buffer_[0], buffer_.size());
+
+      // compute the summed area table
+      compute_sat(table, src, mask);
+      
+      // Compute the dispersion threshold. This output is in dst which contains
+      // a mask where 1 is valid background and 0 is invalid pixels and stuff
+      // above the dispersion threshold 
+      compute_dispersion_threshold(table, src, mask, gain, dst);
+
+      // Erode the dispersion mask
+      erode_dispersion_mask(mask, dst);
+
+      // Compute the summed area table again now excluding the threshold pixels
+      compute_sat(table, src, dst);
+
+      // Compute the final threshold
+      compute_final_threshold(table, src, mask, gain, dst);
     }
+
+  private:
 
     int2 image_size_;
     int2 kernel_size_;
@@ -1045,8 +1472,9 @@ namespace dials { namespace algorithms {
     double nsig_s_;
     double threshold_;
     int min_count_;
-
+    std::vector<char> buffer_;
   };
+
 
 
 }} // namespace dials::algorithms

--- a/algorithms/spot_finding/factory.py
+++ b/algorithms/spot_finding/factory.py
@@ -421,7 +421,7 @@ class SpotDensityFilter(object):
             pyplot.xlim((0, pyplot.xlim()[1]))
             pyplot.ylim((0, pyplot.ylim()[1]))
             pyplot.gca().invert_yaxis()
-            cbar1 = pyplot.colorbar(plot1)
+            pyplot.colorbar(plot1)
             pyplot.axes().set_aspect("equal")
             pyplot.show()
 
@@ -442,7 +442,7 @@ class SpotDensityFilter(object):
             pyplot.xlim((0, pyplot.xlim()[1]))
             pyplot.ylim((0, pyplot.ylim()[1]))
             pyplot.gca().invert_yaxis()
-            cbar1 = pyplot.colorbar(plot1)
+            pyplot.colorbar(plot1)
             pyplot.axes().set_aspect("equal")
             pyplot.show()
 

--- a/algorithms/spot_finding/factory.py
+++ b/algorithms/spot_finding/factory.py
@@ -61,7 +61,7 @@ def generate_phil_scope():
                 "to be accepted by the filtering algorithm."
         .type = int(value_min=1)
 
-      max_spot_size = 100
+      max_spot_size = 1000
         .help = "The maximum number of contiguous pixels for a spot"
                 "to be accepted by the filtering algorithm."
         .type = int(value_min=1, allow_none=False)

--- a/algorithms/spot_finding/threshold.py
+++ b/algorithms/spot_finding/threshold.py
@@ -145,3 +145,74 @@ class DispersionThresholdStrategy(ThresholdStrategy):
 
         # Return the result
         return result
+
+class DispersionExtendedThresholdStrategy(ThresholdStrategy):
+    """
+    A class implementing a 'gain' threshold.
+
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Set the threshold algorithm up
+
+        """
+
+        # Initialise the base class
+        ThresholdStrategy.__init__(self, **kwargs)
+
+        # Get the parameters
+        self._kernel_size = kwargs.get("kernel_size", (3, 3))
+        self._gain = kwargs.get("gain")
+        self._n_sigma_b = kwargs.get("n_sigma_b", 6)
+        self._n_sigma_s = kwargs.get("n_sigma_s", 3)
+        self._min_count = kwargs.get("min_count", 2)
+        self._threshold = kwargs.get("global_threshold", 0)
+
+        # Save the constant gain
+        self._gain_map = None
+
+        # Create a buffer
+        self.algorithm = {}
+
+    def __call__(self, image, mask):
+        """
+        Call the thresholding function
+
+        :param image: The image to process
+        :param mask: The mask to use
+        :return: The thresholded image
+
+        """
+        from dials.algorithms.image import threshold
+        from dials.array_family import flex
+
+        # Initialise the algorithm
+        try:
+            algorithm = self.algorithm[image.all()]
+        except Exception:
+            algorithm = threshold.DispersionExtendedThreshold(
+                image.all(),
+                self._kernel_size,
+                self._n_sigma_b,
+                self._n_sigma_s,
+                self._threshold,
+                self._min_count,
+            )
+            self.algorithm[image.all()] = algorithm
+
+        # Set the gain
+        if self._gain is not None:
+            assert self._gain > 0
+            self._gain_map = flex.double(image.accessor(), self._gain)
+            self._gain = None
+
+        # Compute the threshold
+        result = flex.bool(flex.grid(image.all()))
+        if self._gain_map:
+            algorithm(image, mask, self._gain_map, result)
+        else:
+            algorithm(image, mask, result)
+
+        # Return the result
+        return result

--- a/algorithms/spot_finding/threshold.py
+++ b/algorithms/spot_finding/threshold.py
@@ -146,6 +146,7 @@ class DispersionThresholdStrategy(ThresholdStrategy):
         # Return the result
         return result
 
+
 class DispersionExtendedThresholdStrategy(ThresholdStrategy):
     """
     A class implementing a 'gain' threshold.

--- a/extensions/__init__.py
+++ b/extensions/__init__.py
@@ -86,6 +86,9 @@ class SpotFinderThreshold(_Extension):
         from dials.extensions.dispersion_spotfinder_threshold_ext import (
             DispersionSpotFinderThresholdExt,
         )
+        from dials.extensions.dispersion_extended_spotfinder_threshold_ext import (
+            DispersionExtendedSpotFinderThresholdExt,
+        )
         from dials.extensions.helen_spotfinder_threshold_ext import (
             HelenSpotFinderThresholdExt,
         )
@@ -95,6 +98,7 @@ class SpotFinderThreshold(_Extension):
 
         return [
             DispersionSpotFinderThresholdExt,
+            DispersionExtendedSpotFinderThresholdExt,
             HelenSpotFinderThresholdExt,
             GlobalSpotFinderThresholdExt,
         ]

--- a/extensions/dispersion_extended_spotfinder_threshold_ext.py
+++ b/extensions/dispersion_extended_spotfinder_threshold_ext.py
@@ -3,67 +3,21 @@ from __future__ import print_function
 
 import logging
 
-logger = logging.getLogger("dials.extensions.dispersion_spotfinder_threshold_ext")
+logger = logging.getLogger("dials.extensions.dispersion_extended_spotfinder_threshold_ext")
 
 
-class DispersionSpotFinderThresholdExt(object):
+class DispersionExtendedSpotFinderThresholdExt(object):
     """ Extensions to do dispersion threshold. """
 
-    name = "dispersion"
+    name = "dispersion_extended"
+
+    default = True
 
     @classmethod
     def phil(cls):
         from libtbx.phil import parse
 
-        phil = parse(
-            """
-      gain = None
-        .type = float(value_min=0.0)
-        .help = "Use a flat gain map for the entire detector to act as a"
-                "multiplier for the gain set by the format. Cannot be used"
-                "in conjunction with lookup.gain_map parameter."
-
-      kernel_size = 3 3
-        .help = "The size of the local area around the spot in which"
-                "to calculate the mean and variance. The kernel is"
-                "given as a box of size (2 * nx + 1, 2 * ny + 1) centred"
-                "at the pixel."
-        .type = ints(size=2)
-        .expert_level = 1
-
-      sigma_background = 6
-        .help = "The number of standard deviations of the index of dispersion"
-                "(variance / mean) in the local area below"
-                "which the pixel will be classified as background."
-        .type = float
-        .expert_level = 1
-
-      sigma_strong = 3
-        .help = "The number of standard deviations above the mean in the"
-                "local area above which the pixel will be classified as"
-                "strong."
-        .type = float
-        .expert_level = 1
-
-      min_local = 2
-        .help = "The minimum number of pixels under the image processing kernel"
-                "that are need to do the thresholding operation. Setting the"
-                "value between 2 and the total number of pixels under the"
-                "kernel will force the algorithm to use that number as the"
-                "minimum. If the value is less than or equal to zero, then"
-                "the algorithm will use all pixels under the kernel. In"
-                "effect this will add a border of pixels which are always"
-                "classed as background around the edge of the image and around"
-                "any masked out pixels."
-        .type = int
-        .expert_level = 1
-
-      global_threshold = 0
-        .type = float
-        .help = "The global threshold value. Consider all pixels less than this"
-                "value to be part of the background."
-    """
-        )
+        phil = parse("")
         return phil
 
     def __init__(self, params):
@@ -97,9 +51,9 @@ class DispersionSpotFinderThresholdExt(object):
                 % (params.spotfinder.threshold.dispersion.global_threshold)
             )
 
-        from dials.algorithms.spot_finding.threshold import DispersionThresholdStrategy
+        from dials.algorithms.spot_finding.threshold import DispersionExtendedThresholdStrategy
 
-        self._algorithm = DispersionThresholdStrategy(
+        self._algorithm = DispersionExtendedThresholdStrategy(
             kernel_size=params.spotfinder.threshold.dispersion.kernel_size,
             gain=params.spotfinder.threshold.dispersion.gain,
             mask=params.spotfinder.lookup.mask,

--- a/extensions/dispersion_extended_spotfinder_threshold_ext.py
+++ b/extensions/dispersion_extended_spotfinder_threshold_ext.py
@@ -3,7 +3,9 @@ from __future__ import print_function
 
 import logging
 
-logger = logging.getLogger("dials.extensions.dispersion_extended_spotfinder_threshold_ext")
+logger = logging.getLogger(
+    "dials.extensions.dispersion_extended_spotfinder_threshold_ext"
+)
 
 
 class DispersionExtendedSpotFinderThresholdExt(object):
@@ -51,7 +53,9 @@ class DispersionExtendedSpotFinderThresholdExt(object):
                 % (params.spotfinder.threshold.dispersion.global_threshold)
             )
 
-        from dials.algorithms.spot_finding.threshold import DispersionExtendedThresholdStrategy
+        from dials.algorithms.spot_finding.threshold import (
+            DispersionExtendedThresholdStrategy,
+        )
 
         self._algorithm = DispersionExtendedThresholdStrategy(
             kernel_size=params.spotfinder.threshold.dispersion.kernel_size,

--- a/extensions/dispersion_extended_spotfinder_threshold_ext.py
+++ b/extensions/dispersion_extended_spotfinder_threshold_ext.py
@@ -107,12 +107,12 @@ def estimate_global_threshold(image, mask=None, plot=False):
 
     # more conservative, choose point 2 left of the elbow point
     x_g = x[p_g + p_m - 2]
-    y_g = y[p_g + p_m - 2]
+    # y_g = y[p_g + p_m - 2]
 
     if plot:
         from matplotlib import pyplot
 
-        f = pyplot.figure(figsize=(16, 12))
+        pyplot.figure(figsize=(16, 12))
         pyplot.scatter(threshold, n_above_threshold, marker="+")
         # for i in range(len(threshold)-1):
         #  pyplot.plot([threshold[i], threshold[-1]],

--- a/extensions/dispersion_spotfinder_threshold_ext.py
+++ b/extensions/dispersion_spotfinder_threshold_ext.py
@@ -166,7 +166,7 @@ def estimate_global_threshold(image, mask=None, plot=False):
         # for i in range(1, len(threshold)):
         #  pyplot.plot([threshold[0], threshold[i]],
         #              [n_above_threshold[0], n_above_threshold[i]])
-        pyplot.plot([x_g, x_g], pyplot.ylim())
+        pyplot.plot([x_g, y_g], pyplot.ylim())
         pyplot.plot(
             [threshold[p_m], threshold[-1]],
             [n_above_threshold[p_m], n_above_threshold[-1]],

--- a/newsfragments/758.feature
+++ b/newsfragments/758.feature
@@ -1,0 +1,1 @@
+Replace default spotfinder with improved dispersion algorithm

--- a/test/algorithms/image/filter/test_distance.py
+++ b/test/algorithms/image/filter/test_distance.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import math
 
+
 def test_manhattan():
     from dials.algorithms.image.filter import manhattan_distance
     from scitbx.array_family import flex
@@ -60,16 +61,16 @@ def test_chebyshev():
     D = data[1:-1, 1:-1]
     selection = D.as_1d().select(M.as_1d() == 0)
     assert selection.all_eq(True)
-    
+
     while True:
         N = data[0:-2, 1:-1]
         S = data[2:, 1:-1]
         E = data[1:-1, 0:-2]
         W = data[1:-1, 2:]
-        NE = data[0:-2,0:-2]
-        NW = data[0:-2,2:]
-        SE = data[2:,0:-2]
-        SW = data[2:,2:]
+        NE = data[0:-2, 0:-2]
+        NW = data[0:-2, 2:]
+        SE = data[2:, 0:-2]
+        SW = data[2:, 2:]
         selection = M.as_1d() == 1
         neighbours = (
             N.select(selection)

--- a/test/algorithms/image/filter/test_distance.py
+++ b/test/algorithms/image/filter/test_distance.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import math
 
-
-def test():
+def test_manhattan():
     from dials.algorithms.image.filter import manhattan_distance
     from scitbx.array_family import flex
 
@@ -14,7 +13,7 @@ def test():
             if math.sqrt((j - 50) ** 2 + (i - 50) ** 2) <= 10.5:
                 data[j, i] = False
 
-    distance = manhattan_distance(data)
+    distance = manhattan_distance(data, True)
 
     M = distance[1:-1, 1:-1]
     D = data[1:-1, 1:-1]
@@ -33,6 +32,54 @@ def test():
             | S.select(selection)
             | E.select(selection)
             | W.select(selection)
+        )
+        assert neighbours.all_eq(True)
+        indices = flex.size_t(range(len(D))).select(selection)
+        for i in indices:
+            D[i] = True
+        data[1:-1, 1:-1] = D
+        M -= 1
+        if (M > 0).count(True) == 0:
+            break
+
+
+def test_chebyshev():
+    from dials.algorithms.image.filter import chebyshev_distance
+    from scitbx.array_family import flex
+
+    data = flex.bool(flex.grid(100, 100), True)
+
+    for j in range(100):
+        for i in range(100):
+            if math.sqrt((j - 50) ** 2 + (i - 50) ** 2) <= 10.5:
+                data[j, i] = False
+
+    distance = chebyshev_distance(data, True)
+
+    M = distance[1:-1, 1:-1]
+    D = data[1:-1, 1:-1]
+    selection = D.as_1d().select(M.as_1d() == 0)
+    assert selection.all_eq(True)
+    
+    while True:
+        N = data[0:-2, 1:-1]
+        S = data[2:, 1:-1]
+        E = data[1:-1, 0:-2]
+        W = data[1:-1, 2:]
+        NE = data[0:-2,0:-2]
+        NW = data[0:-2,2:]
+        SE = data[2:,0:-2]
+        SW = data[2:,2:]
+        selection = M.as_1d() == 1
+        neighbours = (
+            N.select(selection)
+            | S.select(selection)
+            | E.select(selection)
+            | W.select(selection)
+            | NE.select(selection)
+            | NW.select(selection)
+            | SE.select(selection)
+            | SW.select(selection)
         )
         assert neighbours.all_eq(True)
         indices = flex.size_t(range(len(D))).select(selection)

--- a/test/algorithms/image/threshold/test_local.py
+++ b/test/algorithms/image/threshold/test_local.py
@@ -154,3 +154,4 @@ class Test:
         algorithm(self.image, self.mask, self.gain, result4)
         assert result1 == result3
         assert result2 == result4
+    

--- a/test/algorithms/image/threshold/test_local.py
+++ b/test/algorithms/image/threshold/test_local.py
@@ -41,26 +41,26 @@ class Test:
         from dials.algorithms.image.threshold import niblack
 
         n_sigma = 3
-        result = niblack(self.image, self.size, n_sigma)
+        niblack(self.image, self.size, n_sigma)
 
     def test_sauvola(self):
         from dials.algorithms.image.threshold import sauvola
 
         k = 3
         r = 3
-        result = sauvola(self.image, self.size, k, r)
+        sauvola(self.image, self.size, k, r)
 
     def test_index_of_dispersion(self):
         from dials.algorithms.image.threshold import index_of_dispersion
 
         n_sigma = 3
-        result = index_of_dispersion(self.image, self.size, n_sigma)
+        index_of_dispersion(self.image, self.size, n_sigma)
 
     def test_index_of_dispersion_masked(self):
         from dials.algorithms.image.threshold import index_of_dispersion_masked
 
         n_sigma = 3
-        result = index_of_dispersion_masked(
+        index_of_dispersion_masked(
             self.image, self.mask, self.size, self.min_count, n_sigma
         )
 
@@ -68,7 +68,7 @@ class Test:
         from dials.algorithms.image.threshold import gain
 
         n_sigma = 3
-        result = gain(
+        gain(
             self.image, self.mask, self.gain, self.size, self.min_count, n_sigma
         )
 
@@ -77,7 +77,7 @@ class Test:
 
         nsig_b = 3
         nsig_s = 3
-        result = dispersion(
+        dispersion(
             self.image, self.mask, self.size, nsig_b, nsig_s, self.min_count
         )
 

--- a/test/algorithms/image/threshold/test_local.py
+++ b/test/algorithms/image/threshold/test_local.py
@@ -155,3 +155,36 @@ class Test:
         assert result1 == result3
         assert result2 == result4
     
+    def test_dispersion_extended_threshold(self):
+        from dials.algorithms.image.threshold import DispersionExtendedThreshold
+        from dials.algorithms.image.threshold import DispersionExtendedThresholdDebug
+        from dials.array_family import flex
+
+        nsig_b = 3
+        nsig_s = 3
+        algorithm = DispersionExtendedThreshold(
+            self.image.all(), self.size, nsig_b, nsig_s, 0, self.min_count
+        )
+        result1 = flex.bool(flex.grid(self.image.all()))
+        result2 = flex.bool(flex.grid(self.image.all()))
+        algorithm(self.image, self.mask, result1)
+        algorithm(self.image, self.mask, self.gain, result2)
+
+        debug = DispersionExtendedThresholdDebug(
+            self.image, self.mask, self.size, nsig_b, nsig_s, 0, self.min_count
+        )
+        result3 = debug.final_mask()
+        assert result1.all_eq(result3)
+
+        debug = DispersionExtendedThresholdDebug(
+            self.image,
+            self.mask,
+            self.gain,
+            self.size,
+            nsig_b,
+            nsig_s,
+            0,
+            self.min_count,
+        )
+        result4 = debug.final_mask()
+        assert result2 == result4

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -8,7 +8,9 @@ from past.builtins import basestring, unicode
 import wx
 from cctbx import crystal, uctbx
 from cctbx.miller import index_generator
-from dials.algorithms.image.threshold import DispersionExtendedThresholdDebug as DispersionThresholdDebug
+from dials.algorithms.image.threshold import (
+    DispersionExtendedThresholdDebug as DispersionThresholdDebug,
+)
 from dials.algorithms.shoebox import MaskCode
 from dials.array_family import flex
 from dials.command_line.find_spots import phil_scope as find_spots_phil_scope

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -8,7 +8,7 @@ from past.builtins import basestring, unicode
 import wx
 from cctbx import crystal, uctbx
 from cctbx.miller import index_generator
-from dials.algorithms.image.threshold import DispersionThresholdDebug
+from dials.algorithms.image.threshold import DispersionExtendedThresholdDebug as DispersionThresholdDebug
 from dials.algorithms.shoebox import MaskCode
 from dials.array_family import flex
 from dials.command_line.find_spots import phil_scope as find_spots_phil_scope


### PR DESCRIPTION
This pull request implements an extended dispersion threshold algorithm for spot finding to try and address https://github.com/dials/dials/issues/752. 

The algorithm does the following steps:

1. Compute the dispersion image
2. Compute the dispersion mask as normal
3. Erode the dispersion mask by half the kernel size
4. Expand the kernel slightly
5. Compute the mean pixel value excluding the dispersion mask
6. Compute the strong mask as normal

The rationale for the algorithm is that the dispersion mask is computed by testing the null hypothesis that all the pixels in the local area are drawn from a Poisson distribution. If this hypothesis is false then the pixel is marked as True in the dispersion mask. 

If a strong pixel is at the edge of the local area then the pixel at the centre of the box is marked True.  This means that the dispersion image tends to have the strong pixels and a band of pixels 1/2 the kernel size around it. Therefore, for true strong spots we can safely erode the dispersion mask by 1/2 the kernel size. This results in a mask which pretty much fits the the spot exactly. 

Finally, we want to only select the strong pixels (sometimes the erodes mask still incorporates weak pixels); however, the problem we had before is that we were using the mean calculated including the strong pixels. This was inevitable if we wanted to do the whole thing with a single summed area table. However, we can recompute the mean excluding the dispersion masked pixels with a slightly expanded kernel to ensure we have plenty of pixels to choose from. This gives actually a pretty good estimate of the background from which we can then threshold the strong pixels as done previously. 

The end result is that we get much better segmentation of the strong spots.  However, the algorithms is a bit slower (currently a lot slower since I have only implemented the debug version - once we are happy that the algorithm is an improvement I will implement a more optimised version). Once optimized I think it will still require more passes of the image data:

1. One pass to compute the initial summed area table.
2. One pass to compute the dispersion mask.
3. Two passes to compute the distance metric for the erosion
4. One pass to compute the eroded dispersion mask
5. One pass to compute the second summed area table
6. One pass to compute the final mask

However, if slower still means better then this may be acceptable.

Here are some examples of some output:
 
The raw data from an I23 image
![data_1_0001_image_close](https://user-images.githubusercontent.com/2241889/56295421-b4b52c80-6124-11e9-9286-02a520ddec39.png)

The threshold from the same image
![data_1_0001_threshold_close](https://user-images.githubusercontent.com/2241889/56295425-b67ef000-6124-11e9-96b7-3ca83defa047.png)

The spot finding results with strong pixels marked
![data_1_0001_pixels](https://user-images.githubusercontent.com/2241889/56295430-b8e14a00-6124-11e9-8b76-962793a348b7.png)

I have also modified the largest spot size to be 1000 pixels (10x10x10) since this will tend to find larger spots. 

Another nice side effect is that the could now have pretty decent background estimates from the spot finding with little extra cost which might also make the change desirable.

Next steps are to test thoroughly, particular on the data that @rjgildea has been looking at.  Then once we are satisfied we need to optimize the code! 