### PR TITLE
Run flake8 on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,7 @@ jobs:
       cache: false
       script:
          - python -m compileall -q *
-
-    - name: "Syntax validation - Python 3.4"
-      addons: false
-      cache: false
-      python: 3.4
-      script:
-         - python3 -m compileall -q *
+         - .travis/run-flake8
 
     - name: "Syntax validation - Python 3.7"
       addons: false
@@ -62,6 +56,7 @@ jobs:
       python: 3.7
       script:
          - python3 -m compileall -q *
+         - .travis/run-flake8
 
     - stage: test
       before_script:

--- a/.travis/run-flake8
+++ b/.travis/run-flake8
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Identify all python files added or modified in pull request
+CHANGED_FILES=$(git diff --name-only --diff-filter=AM $TRAVIS_BRANCH...HEAD -- "*.py")
+
+# List is empty if this is not a pull request run or if no python files have changed
+[ -z "$CHANGED_FILES" ] && echo There are no relevant changes. Skipping test. && exit 0
+
+pip install -q flake8
+echo
+echo Running flake8 on changed files
+flake8 --select=E711,E712,E713,E714,E721,E722,E901,F401,F402,F403,F632,F811,F812,F821,F822,F841,F901,W191,W602,W603,W604,W605,W606 $CHANGED_FILES


### PR DESCRIPTION
Checks all added and modified python files for the following flake8
error codes:
* E711: comparison to None should be 'if cond is None:'
* E712: comparison to True should be 'if cond is True:' or 'if cond:'
* E713: test for membership should be 'not in'
* E714: test for object identity should be 'is not'
* E721: do not compare types, use 'isinstance()'
* E722: do not use bare except, specify exception instead
* E901: SyntaxError or IndentationError
* F401: module imported but unused
* F402: import module from line N shadowed by loop variable
* F403: 'from module import *' used; unable to detect undefined names
* F632: use ==/!= to compare str, bytes, and int literals
* F811: redefinition of unused name from line N
* F812: list comprehension redefines name from line N
* F821: undefined name name
* F822: undefined name name in __all__
* F841: local variable name is assigned to but never used
* F901: raise NotImplemented should be raise NotImplementedError
* W191: indentation contains tabs
* W602: deprecated form of raising exception
* W603: '<>' is deprecated, use '!='
* W604: backticks are deprecated, use 'repr()'
* W605: invalid escape sequence '\x'
* W606: 'async'/'await' are reserved keywords starting with Python 3.7

[This is what it will look like in a pull request](https://github.com/Anthchirp/dials/pull/2) and the relevant travis build log is at https://travis-ci.com/Anthchirp/dials/builds/109012209#L468-L469:
