### PR TITLE
Pythonic reserved names

### DIFF
--- a/algorithms/integration/filtering.py
+++ b/algorithms/integration/filtering.py
@@ -146,8 +146,8 @@ class MultiPowderRingFilter:
         from dials.array_family import flex
 
         result = flex.bool(len(d), False)
-        for filter in self:
-            result = result | filter(d)
+        for _filter in self:
+            result = result | _filter(d)
         return result
 
     def __len__(self):

--- a/command_line/complete_full_sphere.py
+++ b/command_line/complete_full_sphere.py
@@ -106,7 +106,7 @@ class Script(object):
         from cctbx import miller
         from cctbx import crystal
 
-        all = miller.build_set(
+        all_idx = miller.build_set(
             crystal_symmetry=crystal.symmetry(
                 space_group=expt.crystal.get_space_group(),
                 unit_cell=expt.crystal.get_unit_cell(),
@@ -122,10 +122,10 @@ class Script(object):
 
         logger.info(
             "Fraction of unique observations at datum: %.1f%%"
-            % (100.0 * len(obs.indices()) / len(all.indices()))
+            % (100.0 * len(obs.indices()) / len(all_idx.indices()))
         )
 
-        missing = all.lone_set(other=obs)
+        missing = all_idx.lone_set(other=obs)
 
         logger.info("%d unique reflections in blind region" % len(missing.indices()))
 

--- a/command_line/complete_full_sphere.py
+++ b/command_line/complete_full_sphere.py
@@ -106,7 +106,7 @@ class Script(object):
         from cctbx import miller
         from cctbx import crystal
 
-        all_idx = miller.build_set(
+        all_indices = miller.build_set(
             crystal_symmetry=crystal.symmetry(
                 space_group=expt.crystal.get_space_group(),
                 unit_cell=expt.crystal.get_unit_cell(),
@@ -122,10 +122,10 @@ class Script(object):
 
         logger.info(
             "Fraction of unique observations at datum: %.1f%%"
-            % (100.0 * len(obs.indices()) / len(all_idx.indices()))
+            % (100.0 * len(obs.indices()) / len(all_indices.indices()))
         )
 
-        missing = all_idx.lone_set(other=obs)
+        missing = all_indices.lone_set(other=obs)
 
         logger.info("%d unique reflections in blind region" % len(missing.indices()))
 

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -1780,9 +1780,9 @@ class ReferenceProfileAnalyser(object):
         binner = binner_d_star_cubed(d_spacings)
         bin_centres = flex.double()
         ccs = flex.double()
-        for b in binner.bins:
-            d_min = b.d_min
-            d_max = b.d_max
+        for d_bin in binner.bins:
+            d_min = d_bin.d_min
+            d_max = d_bin.d_max
             ds3_min = 1 / d_min ** 3
             ds3_max = 1 / d_max ** 3
             ds3_centre = (ds3_max - ds3_min) / 2 + ds3_min

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -1780,9 +1780,9 @@ class ReferenceProfileAnalyser(object):
         binner = binner_d_star_cubed(d_spacings)
         bin_centres = flex.double()
         ccs = flex.double()
-        for bin in binner.bins:
-            d_min = bin.d_min
-            d_max = bin.d_max
+        for b in binner.bins:
+            d_min = b.d_min
+            d_max = b.d_max
             ds3_min = 1 / d_min ** 3
             ds3_max = 1 / d_max ** 3
             ds3_centre = (ds3_max - ds3_min) / 2 + ds3_min

--- a/libtbx_refresh.py
+++ b/libtbx_refresh.py
@@ -42,13 +42,13 @@ def _install_dials_autocompletion():
     commands_dir = os.path.join(dist_path, "command_line")
     command_list = []
     print("Identifying autocompletable commands:", end=" ")
-    for f in sorted(os.listdir(commands_dir)):
-        if not f.startswith("_") and f.endswith(".py"):
+    for filename in sorted(os.listdir(commands_dir)):
+        if not filename.startswith("_") and filename.endswith(".py"):
             if (
                 "DIALS_ENABLE_COMMAND_LINE_COMPLETION"
-                in open(os.path.join(commands_dir, f)).read()
+                in open(os.path.join(commands_dir, filename)).read()
             ):
-                command_name = "dials.%s" % f[:-3]
+                command_name = "dials.%s" % filename[:-3]
                 print(command_name, end=" ")
                 command_list.append(command_name)
     print()
@@ -90,14 +90,14 @@ for cmd in [%s]:
 
     # Permanently install the autocompletion script into setpaths-scripts.
     print("Installing autocompletion script into:", end=" ")
-    for f in os.listdir(build_path):
-        if f.startswith("setpath") and f.endswith(".sh"):
-            original_file = open(os.path.join(build_path, f)).read()
+    for filename in os.listdir(build_path):
+        if filename.startswith("setpath") and filename.endswith(".sh"):
+            original_file = open(os.path.join(build_path, filename)).read()
             if not "DIALS_ENABLE_COMMAND_LINE_COMPLETION" in original_file:
                 marker = "\nexport PATH\n"
                 original_position = original_file.find(marker)
                 if original_position >= 0:
-                    print(f, end=" ")
+                    print(filename, end=" ")
                     insert_position = original_position + len(marker)
                     added_script = (
                         "# DIALS_ENABLE_COMMAND_LINE_COMPLETION\n"
@@ -110,7 +110,7 @@ for cmd in [%s]:
                             )
                         )
                     )
-                    with open(os.path.join(build_path, f), "w") as script:
+                    with open(os.path.join(build_path, filename), "w") as script:
                         script.write(
                             original_file[:insert_position]
                             + added_script

--- a/libtbx_refresh.py
+++ b/libtbx_refresh.py
@@ -42,13 +42,13 @@ def _install_dials_autocompletion():
     commands_dir = os.path.join(dist_path, "command_line")
     command_list = []
     print("Identifying autocompletable commands:", end=" ")
-    for file in sorted(os.listdir(commands_dir)):
-        if not file.startswith("_") and file.endswith(".py"):
+    for f in sorted(os.listdir(commands_dir)):
+        if not f.startswith("_") and f.endswith(".py"):
             if (
                 "DIALS_ENABLE_COMMAND_LINE_COMPLETION"
-                in open(os.path.join(commands_dir, file)).read()
+                in open(os.path.join(commands_dir, f)).read()
             ):
-                command_name = "dials.%s" % file[:-3]
+                command_name = "dials.%s" % f[:-3]
                 print(command_name, end=" ")
                 command_list.append(command_name)
     print()
@@ -90,14 +90,14 @@ for cmd in [%s]:
 
     # Permanently install the autocompletion script into setpaths-scripts.
     print("Installing autocompletion script into:", end=" ")
-    for file in os.listdir(build_path):
-        if file.startswith("setpath") and file.endswith(".sh"):
-            original_file = open(os.path.join(build_path, file)).read()
+    for f in os.listdir(build_path):
+        if f.startswith("setpath") and f.endswith(".sh"):
+            original_file = open(os.path.join(build_path, f)).read()
             if not "DIALS_ENABLE_COMMAND_LINE_COMPLETION" in original_file:
                 marker = "\nexport PATH\n"
                 original_position = original_file.find(marker)
                 if original_position >= 0:
-                    print(file, end=" ")
+                    print(f, end=" ")
                     insert_position = original_position + len(marker)
                     added_script = (
                         "# DIALS_ENABLE_COMMAND_LINE_COMPLETION\n"
@@ -110,7 +110,7 @@ for cmd in [%s]:
                             )
                         )
                     )
-                    with open(os.path.join(build_path, file), "w") as script:
+                    with open(os.path.join(build_path, f), "w") as script:
                         script.write(
                             original_file[:insert_position]
                             + added_script

--- a/test/util/test_export_mtz.py
+++ b/test/util/test_export_mtz.py
@@ -64,8 +64,8 @@ class TestBatchRangeCalculations(object):
 
     def _run_ranges(self, ranges):
         """Convenience method to run the routine with a minimal experiment, and return the result as ranges of batch number"""
-        input = [self.MockExperiment(x) for x in ranges]
-        return offset_ranges(calculate_batch_offsets(input), ranges)
+        input_data = [self.MockExperiment(x) for x in ranges]
+        return offset_ranges(calculate_batch_offsets(input_data), ranges)
 
     def _run_ranges_to_set(self, ranges):
         """Runs a list of ranges and returns a set of individual batch numbers"""
@@ -79,7 +79,7 @@ class TestBatchRangeCalculations(object):
             [x > 0 for x in self._run_ranges_to_set([(0, 0)])]
         ), "Should be no zeroth/negative batch"
 
-        input = [self.MockExperiment(x) for x in [(1, 1), (1, 1)]]
+        input_data = [self.MockExperiment(x) for x in [(1, 1), (1, 1)]]
         assert not set(self._run_ranges([(1, 1), (1, 1)])) == {
             (1, 1)
         }, "Overlapping simple ranges"

--- a/util/image.py
+++ b/util/image.py
@@ -39,9 +39,7 @@ class reader:
 
         # Check the type of the element to ensure it's a binary
         # otherwise raise an exception
-        dtype = self.cbf_handle.get_typeofvalue()
-        if dtype.find("bnry") > -1:
-
+        if "bnry" in self.cbf_handle.get_typeofvalue():
             # Read the image data into an array
             image_string = self.cbf_handle.get_integerarray_as_string()
             image = flex.int(numpy.fromstring(image_string, numpy.int32))
@@ -52,7 +50,6 @@ class reader:
 
             # Resize the image
             image.reshape(flex.grid(*image_size))
-
         else:
             raise TypeError("Can't find image")
 
@@ -62,7 +59,7 @@ class reader:
 
 if __name__ == "__main__":
     import sys
-    import numpy  # noqa: F401
+    import numpy
 
     handle = reader()
     handle.read_file(sys.argv[1])

--- a/util/image.py
+++ b/util/image.py
@@ -39,8 +39,8 @@ class reader:
 
         # Check the type of the element to ensure it's a binary
         # otherwise raise an exception
-        type = self.cbf_handle.get_typeofvalue()
-        if type.find("bnry") > -1:
+        dtype = self.cbf_handle.get_typeofvalue()
+        if dtype.find("bnry") > -1:
 
             # Read the image data into an array
             image_string = self.cbf_handle.get_integerarray_as_string()
@@ -62,7 +62,7 @@ class reader:
 
 if __name__ == "__main__":
     import sys
-    import numpy
+    import numpy  # noqa: F401
 
     handle = reader()
     handle.read_file(sys.argv[1])

--- a/util/intensity_explorer.py
+++ b/util/intensity_explorer.py
@@ -392,10 +392,10 @@ def data_from_unmerged_mtz(filename):
     rtable["id"] = flex.int(rtable.size(), 0)
 
     # Now generate a corresponding experiment list.
-    id = flex.vec3_double([(1, 0, 0), (0, 1, 0), (0, 0, 1)])
+    _id = flex.vec3_double([(1, 0, 0), (0, 1, 0), (0, 0, 1)])
     # Each Crystal object needs to be constructed from xyz unit cell
     # parameters and a space group.
-    abc = [m[0].unit_cell().orthogonalize(vec) for vec in id]
+    abc = [m[0].unit_cell().orthogonalize(vec) for vec in _id]
     space_group = m[0].crystal_symmetry().space_group()
     crystal_params = abc + [space_group]
 

--- a/util/intensity_explorer.py
+++ b/util/intensity_explorer.py
@@ -392,10 +392,10 @@ def data_from_unmerged_mtz(filename):
     rtable["id"] = flex.int(rtable.size(), 0)
 
     # Now generate a corresponding experiment list.
-    _id = flex.vec3_double([(1, 0, 0), (0, 1, 0), (0, 0, 1)])
+    indices = flex.vec3_double([(1, 0, 0), (0, 1, 0), (0, 0, 1)])
     # Each Crystal object needs to be constructed from xyz unit cell
     # parameters and a space group.
-    abc = [m[0].unit_cell().orthogonalize(vec) for vec in _id]
+    abc = [m[0].unit_cell().orthogonalize(vec) for vec in indices]
     space_group = m[0].crystal_symmetry().space_group()
     crystal_params = abc + [space_group]
 

--- a/util/pycbf_extra.py
+++ b/util/pycbf_extra.py
@@ -128,8 +128,8 @@ def get_image(cbf_handle, category="array_data", column="data", row=0, element=0
 
     # Check the type of the element to ensure it's a binary
     # otherwise raise an exception
-    type = cbf_handle.get_typeofvalue()
-    if type.find("bnry") > -1:
+    dtype = cbf_handle.get_typeofvalue()
+    if dtype.find("bnry") > -1:
 
         # Read the image data into an array
         image_string = cbf_handle.get_integerarray_as_string()

--- a/util/pycbf_extra.py
+++ b/util/pycbf_extra.py
@@ -128,8 +128,7 @@ def get_image(cbf_handle, category="array_data", column="data", row=0, element=0
 
     # Check the type of the element to ensure it's a binary
     # otherwise raise an exception
-    dtype = cbf_handle.get_typeofvalue()
-    if dtype.find("bnry") > -1:
+    if "bnry" in cbf_handle.get_typeofvalue():
 
         # Read the image data into an array
         image_string = cbf_handle.get_integerarray_as_string()

--- a/util/wx_viewer.py
+++ b/util/wx_viewer.py
@@ -1142,25 +1142,25 @@ class App(wx.App):
         self.frame.Destroy()
 
     def OnToolClick(self, event):
-        _id = event.GetId()
-        if _id == self.mcs_center_id:
+        eid = event.GetId()
+        if eid == self.mcs_center_id:
             self.view_objects.move_rotation_center_to_mcs_center()
-        elif _id == self.center_on_screen_id:
+        elif eid == self.center_on_screen_id:
             self.view_objects.move_to_center_of_viewport(
                 self.view_objects.rotation_center
             )
-        elif _id == self.fit_on_screen_id:
+        elif eid == self.fit_on_screen_id:
             self.view_objects.fit_into_viewport()
-        elif _id == self.mark_snap_back_id:
+        elif eid == self.mark_snap_back_id:
             self.view_objects.mark_rotation()
-        elif _id == self.snap_back_id:
+        elif eid == self.snap_back_id:
             self.view_objects.snap_back_rotation()
-        elif _id == self.toggle_spin_id:
+        elif eid == self.toggle_spin_id:
             self.view_objects.autospin_allowed = not self.view_objects.autospin_allowed
             self.view_objects.autospin = False
             self.update_status_bar()
         else:
-            raise RuntimeError("Unknown event Id: %d" % _id)
+            raise RuntimeError("Unknown event Id: %d" % eid)
 
     def update_status_bar(self):
         self.frame.SetStatusText(

--- a/util/wx_viewer.py
+++ b/util/wx_viewer.py
@@ -1142,25 +1142,25 @@ class App(wx.App):
         self.frame.Destroy()
 
     def OnToolClick(self, event):
-        id = event.GetId()
-        if id == self.mcs_center_id:
+        _id = event.GetId()
+        if _id == self.mcs_center_id:
             self.view_objects.move_rotation_center_to_mcs_center()
-        elif id == self.center_on_screen_id:
+        elif _id == self.center_on_screen_id:
             self.view_objects.move_to_center_of_viewport(
                 self.view_objects.rotation_center
             )
-        elif id == self.fit_on_screen_id:
+        elif _id == self.fit_on_screen_id:
             self.view_objects.fit_into_viewport()
-        elif id == self.mark_snap_back_id:
+        elif _id == self.mark_snap_back_id:
             self.view_objects.mark_rotation()
-        elif id == self.snap_back_id:
+        elif _id == self.snap_back_id:
             self.view_objects.snap_back_rotation()
-        elif id == self.toggle_spin_id:
+        elif _id == self.toggle_spin_id:
             self.view_objects.autospin_allowed = not self.view_objects.autospin_allowed
             self.view_objects.autospin = False
             self.update_status_bar()
         else:
-            raise RuntimeError("Unknown event Id: %d" % id)
+            raise RuntimeError("Unknown event Id: %d" % _id)
 
     def update_status_bar(self):
         self.frame.SetStatusText(


### PR DESCRIPTION
Avoid python reserved names as variables in source code - have avoided wx which seems to overload the use of id by default but otherwise we have a few hand-tweaked names which should be idiomatically sensible. 