### PR TITLE
Add check-merge-conflict pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,4 @@ repos:
   - id: check-ast
   - id: flake8
     args: ['--max-line-length=88', '--select=W291,W292,W293,F401']
+  - id: check-merge-conflict


### PR DESCRIPTION
Add the check-merge-conflict precommit hook, to check that
"<<<<<<< HEAD" etc hasn't been left in a file, which I have accidentally done before and know of others who have also.
While some of these cases should be picked up by the check-ast hook for python, this can be missed if within a docstring or non-python file.