### PR TITLE
DIALS 1.14.5

### DIFF
--- a/command_line/assign_experiment_identifiers.py
+++ b/command_line/assign_experiment_identifiers.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # LIBTBX_SET_DISPATCHER_NAME dev.dials.assign_experiment_identifiers
+# LIBTBX_SET_DISPATCHER_NAME dials.assign_experiment_identifiers
 # coding: utf-8
 from __future__ import absolute_import, division, print_function
 


### PR DESCRIPTION
* xia2: Disable multiprocessing on Windows (xia2/xia2#191)
* xia2: Fix call to `dev.dials.assign_experiment_identifiers` on system without `dev.*` commands