### PR TITLE
Per-image-analysis matplotlib fix

### DIFF
--- a/algorithms/spot_finding/per_image_analysis.py
+++ b/algorithms/spot_finding/per_image_analysis.py
@@ -7,12 +7,11 @@ from dials.array_family import flex
 
 try:
     import matplotlib
-
-    # http://matplotlib.org/faq/howto_faq.html#generate-images-without-having-a-window-appear
-    matplotlib.use("Agg")  # use a non-interactive backend
-    from matplotlib import pyplot
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure
+    from matplotlib.gridspec import GridSpec
 except ImportError:
-    pyplot = None
+    matplotlib = None
 
 
 class slot(object):
@@ -282,9 +281,11 @@ def estimate_resolution_limit(reflections, imageset, ice_sel=None, plot_filename
     # resolution_estimate = max(resolution_estimate, flex.min(d_spacings))
 
     if plot_filename is not None:
-        if pyplot is None:
-            raise Sorry("matplotlib must be installed to generate a plot.")
-        fig = pyplot.figure()
+        if not matplotlib:
+            raise ImportError("Could not import matplotlib")
+        fig = Figure()
+        FigureCanvasAgg(fig)
+
         ax = fig.add_subplot(1, 1, 1)
         ax.scatter(d_star_sq, log_i_over_sigi, marker="+")
         ax.scatter(
@@ -313,7 +314,7 @@ def estimate_resolution_limit(reflections, imageset, ice_sel=None, plot_filename
                 [intersection[0]], [intersection[1]], marker="x", s=50, color="b"
             )
         # ax.hexbin(d_star_sq, log_i_over_sigi, gridsize=30)
-        xlim = pyplot.xlim()
+        xlim = ax.get_xlim()
         ax.plot(xlim, [(m * x + c) for x in xlim])
         ax.plot(xlim, [(m_upper * x + c_upper) for x in xlim], color="red")
         ax.plot(xlim, [(m_lower * x + c_lower) for x in xlim], color="red")
@@ -348,9 +349,8 @@ def estimate_resolution_limit(reflections, imageset, ice_sel=None, plot_filename
         ax_.set_xlim(ax.get_xlim())
         ax_.set_xlabel(r"Resolution ($\AA$)")
         ax_.set_xticklabels(["%.1f" % d for d in xticks_d])
-        # pyplot.show()
-        pyplot.savefig(plot_filename)
-        pyplot.close()
+        fig.savefig(plot_filename)
+        fig.close()
 
     return resolution_estimate
 
@@ -436,20 +436,21 @@ def estimate_resolution_limit_distl_method1(reflections, imageset, plot_filename
     noisiness /= (n - 1) * (n - 2) / 2
 
     if plot_filename is not None:
-        if pyplot is None:
-            raise Sorry("matplotlib must be installed to generate a plot.")
-        fig = pyplot.figure()
+        if not matplotlib:
+            raise ImportError("Could not import matplotlib")
+        fig = Figure()
+        FigureCanvasAgg(fig)
         ax = fig.add_subplot(1, 1, 1)
         ax.scatter(range(len(ds3_subset)), ds3_subset)
         # ax.set_xlabel('')
         ax.set_ylabel("D^-3")
-        xlim = pyplot.xlim()
-        ylim = pyplot.ylim()
+        xlim = ax.get_xlim()
+        ylim = ax.get_ylim()
         ax.vlines(p_g, ylim[0], ylim[1], colors="red")
-        pyplot.xlim(0, xlim[1])
-        pyplot.ylim(0, ylim[1])
-        pyplot.savefig(plot_filename)
-        pyplot.close()
+        ax.set_xlim(0, xlim[1])
+        ax.set_ylim(0, ylim[1])
+        fig.savefig(plot_filename)
+        fig.close()
 
     return d_g, noisiness
 
@@ -500,20 +501,21 @@ def estimate_resolution_limit_distl_method2(reflections, imageset, plot_filename
     noisiness /= 0.5 * m * (m - 1)
 
     if plot_filename is not None:
-        if pyplot is None:
-            raise Sorry("matplotlib must be installed to generate a plot.")
-        fig = pyplot.figure()
+        if not matplotlib:
+            raise ImportError("Could not import matplotlib")
+        fig = Figure()
+        FigureCanvasAgg(fig)
         ax = fig.add_subplot(1, 1, 1)
         ax.scatter(range(len(bin_counts)), bin_counts)
         # ax.set_xlabel('')
         ax.set_ylabel("number of spots in shell")
-        xlim = pyplot.xlim()
-        ylim = pyplot.ylim()
+        xlim = ax.get_xlim()
+        ylim = ax.get_ylim()
         ax.vlines(i, ylim[0], ylim[1], colors="red")
-        pyplot.xlim(0, xlim[1])
-        pyplot.ylim(0, ylim[1])
-        pyplot.savefig(plot_filename)
-        pyplot.close()
+        ax.set_xlim(0, xlim[1])
+        ax.set_ylim(0, ylim[1])
+        fig.savefig(plot_filename)
+        fig.close()
 
     return d_min, noisiness
 
@@ -577,9 +579,10 @@ def resolution_histogram(reflections, imageset, plot_filename=None):
     hist = get_histogram(d_star_sq)
 
     if plot_filename is not None:
-        if pyplot is None:
-            raise Sorry("matplotlib must be installed to generate a plot.")
-        fig = pyplot.figure()
+        if not matplotlib:
+            raise ImportError("Could not import matplotlib")
+        fig = Figure()
+        FigureCanvasAgg(fig)
         ax = fig.add_subplot(1, 1, 1)
         ax.bar(
             hist.slot_centers() - 0.5 * hist.slot_width(),
@@ -599,8 +602,8 @@ def resolution_histogram(reflections, imageset, plot_filename=None):
         ax_.set_xlabel(r"Resolution ($\AA$)")
         ax_.set_xticklabels(["%.1f" % d for d in xticks_d])
         # pyplot.show()
-        pyplot.savefig(plot_filename)
-        pyplot.close()
+        fig.savefig(plot_filename)
+        fig.close()
 
 
 def log_sum_i_sigi_vs_resolution(reflections, imageset, plot_filename=None):
@@ -626,9 +629,10 @@ def log_sum_i_sigi_vs_resolution(reflections, imageset, plot_filename=None):
             slots.append(0)
 
     if plot_filename is not None:
-        if pyplot is None:
-            raise Sorry("matplotlib must be installed to generate a plot.")
-        fig = pyplot.figure()
+        if not matplotlib:
+            raise ImportError("Could not import matplotlib")
+        fig = Figure()
+        FigureCanvasAgg(fig)
         ax = fig.add_subplot(1, 1, 1)
         # ax.bar(hist.slot_centers()-0.5*hist.slot_width(), hist.slots(),
         ax.scatter(
@@ -651,19 +655,18 @@ def log_sum_i_sigi_vs_resolution(reflections, imageset, plot_filename=None):
         ax_.set_xlim(ax.get_xlim())
         ax_.set_xlabel(r"Resolution ($\AA$)")
         ax_.set_xticklabels(["%.1f" % d for d in xticks_d])
-        # pyplot.show()
-        pyplot.savefig(plot_filename)
-        pyplot.close()
+        fig.savefig(plot_filename)
+        fig.close()
 
 
 def plot_ordered_d_star_sq(reflections, imageset):
-    if pyplot is None:
-        raise Sorry("matplotlib must be installed to generate a plot.")
+    if not matplotlib:
+        raise ImportError("Could not import matplotlib")
     d_star_sq = flex.pow2(reflections["rlp"].norms())
-
+    fig = Figure()
     perm = flex.sort_permutation(d_star_sq)
-    pyplot.scatter(list(range(len(perm))), list(d_star_sq.select(perm)), marker="+")
-    pyplot.show()
+    fig.gca().scatter(list(range(len(perm))), list(d_star_sq.select(perm)), marker="+")
+    fig.show()
 
 
 def stats_single_image(
@@ -881,6 +884,8 @@ def print_table(stats, perm=None, n_rows=None, out=None):
 
 
 def plot_stats(stats, filename="per_image_analysis.png"):
+    if not matplotlib:
+        raise ImportError("Could not import matplotlib")
     n_spots_total = flex.int(stats.n_spots_total)
     n_spots_no_ice = stats.n_spots_no_ice
     n_spots_4A = stats.n_spots_4A
@@ -890,9 +895,15 @@ def plot_stats(stats, filename="per_image_analysis.png"):
     total_intensity = stats.total_intensity
 
     i_image = flex.int(list(range(1, len(n_spots_total) + 1)))
-    if pyplot is None:
-        raise Sorry("matplotlib must be installed to generate a plot.")
-    _, (ax1, ax2, ax3) = pyplot.subplots(nrows=3)
+    fig = Figure()
+    FigureCanvasAgg(fig)
+    # Do this here because fig.subplots not added until matplotlib 2.1.0 (2015)
+    # ax1, ax2, ax3 = fig.subplots(nrows=3)
+    gs = GridSpec(3, 1)
+    ax1 = fig.add_subplot(gs[0, 0])
+    ax2 = fig.add_subplot(gs[1, 0])
+    ax3 = fig.add_subplot(gs[2, 0])
+    # end of version workaround
     ax1.scatter(
         list(i_image),
         list(n_spots_total),
@@ -976,4 +987,4 @@ def plot_stats(stats, filename="per_image_analysis.png"):
     ax3.set_xlabel("Image #")
     ax3.legend(bbox_to_anchor=(1.05, 0.5), loc="center left", borderaxespad=0.0)
 
-    pyplot.savefig(filename, dpi=600, bbox_inches="tight")
+    fig.savefig(filename, dpi=600, bbox_inches="tight")

--- a/algorithms/spot_finding/per_image_analysis.py
+++ b/algorithms/spot_finding/per_image_analysis.py
@@ -1,8 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import math
-from libtbx import group_args
+
 from cctbx import sgtbx, uctbx
+from libtbx import group_args, table_utils
+from libtbx.math_utils import nearest_integer as nint
+from scitbx import matrix
+
+from dials.algorithms.integration import filtering
 from dials.array_family import flex
 
 try:
@@ -22,8 +27,6 @@ class slot(object):
 
 class binner_equal_population(object):
     def __init__(self, d_star_sq, target_n_per_bin=20, max_slots=20, min_slots=5):
-        from libtbx.math_utils import nearest_integer as nint
-
         n_slots = len(d_star_sq) // target_n_per_bin
         if max_slots is not None:
             n_slots = min(n_slots, max_slots)
@@ -154,7 +157,6 @@ def wilson_outliers(reflections, ice_sel=None, p_cutoff=1e-2):
 
 
 def estimate_resolution_limit(reflections, imageset, ice_sel=None, plot_filename=None):
-
     if ice_sel is None:
         ice_sel = flex.bool(len(reflections), False)
 
@@ -194,36 +196,14 @@ def estimate_resolution_limit(reflections, imageset, ice_sel=None, plot_filename
     for i_slot, slot in enumerate(binner.bins):
         sel_all = (d_spacings < slot.d_max) & (d_spacings >= slot.d_min)
         sel = ~(ice_sel) & sel_all
-        # sel = ~(ice_sel) & (d_spacings < slot.d_max) & (d_spacings >= slot.d_min)
-
-        # print "%.2f" %(sel.count(True)/sel_all.count(True))
 
         if sel.count(True) == 0:
-            # outliers_all.set_selected(sel_all & ice_sel, True)
             continue
-            # if i_slot > i_slot_max:
-            # break
-            # else:
-            # continue
 
         outliers = wilson_outliers(
             reflections.select(sel_all), ice_sel=ice_sel.select(sel_all)
         )
-        # print "rejecting %d wilson outliers" %outliers.count(True)
         outliers_all.set_selected(sel_all, outliers)
-
-        # if sel.count(True)/sel_all.count(True) < 0.25:
-        # outliers_all.set_selected(sel_all & ice_sel, True)
-
-        # from scitbx.math import median_statistics
-        # intensities_sel = intensities.select(sel)
-        # stats = median_statistics(intensities_sel)
-        # z_score = 0.6745 * (intensities_sel - stats.median)/stats.median_absolute_deviation
-        # outliers = z_score > 3.5
-        # perm = flex.sort_permutation(intensities_sel)
-        ##print ' '.join('%.2f' %v for v in intensities_sel.select(perm))
-        ##print ' '.join('%.2f' %v for v in z_score.select(perm))
-        ##print
 
         isel = sel_all.iselection().select(~(outliers) & ~(ice_sel).select(sel_all))
         log_i_over_sigi_sel = log_i_over_sigi.select(isel)
@@ -344,7 +324,6 @@ def estimate_resolution_limit(reflections, imageset, ice_sel=None, plot_filename
         xticks = ax.get_xticks()
         xlim = ax.get_xlim()
         xticks_d = [uctbx.d_star_sq_as_d(ds2) if ds2 > 0 else 0 for ds2 in xticks]
-        xticks_ = [ds2 / (xlim[1] - xlim[0]) for ds2 in xticks]
         ax_.set_xticks(xticks)
         ax_.set_xlim(ax.get_xlim())
         ax_.set_xlabel(r"Resolution ($\AA$)")
@@ -356,7 +335,6 @@ def estimate_resolution_limit(reflections, imageset, ice_sel=None, plot_filename
 
 
 def estimate_resolution_limit_distl_method1(reflections, imageset, plot_filename=None):
-
     # Implementation of Method 1 (section 2.4.4) of:
     # Z. Zhang, N. K. Sauter, H. van den Bedem, G. Snell and A. M. Deacon
     # J. Appl. Cryst. (2006). 39, 112-119
@@ -365,7 +343,6 @@ def estimate_resolution_limit_distl_method1(reflections, imageset, plot_filename
     variances = reflections["intensity.sum.variance"]
 
     sel = variances > 0
-    intensities = reflections["intensity.sum.value"]
     reflections = reflections.select(sel)
     d_star_sq = flex.pow2(reflections["rlp"].norms())
     d_spacings = uctbx.d_star_sq_as_d(d_star_sq)
@@ -456,7 +433,6 @@ def estimate_resolution_limit_distl_method1(reflections, imageset, plot_filename
 
 
 def estimate_resolution_limit_distl_method2(reflections, imageset, plot_filename=None):
-
     # Implementation of Method 2 (section 2.4.4) of:
     # Z. Zhang, N. K. Sauter, H. van den Bedem, G. Snell and A. M. Deacon
     # J. Appl. Cryst. (2006). 39, 112-119
@@ -465,7 +441,6 @@ def estimate_resolution_limit_distl_method2(reflections, imageset, plot_filename
     variances = reflections["intensity.sum.variance"]
 
     sel = variances > 0
-    intensities = reflections["intensity.sum.value"]
     reflections = reflections.select(sel)
     d_star_sq = flex.pow2(reflections["rlp"].norms())
     d_spacings = uctbx.d_star_sq_as_d(d_star_sq)
@@ -521,9 +496,6 @@ def estimate_resolution_limit_distl_method2(reflections, imageset, plot_filename
 
 
 def points_below_line(d_star_sq, log_i_over_sigi, m, c):
-
-    from scitbx import matrix
-
     p1 = matrix.col((0, c))
     p2 = matrix.col((1, m * 1 + c))
 
@@ -556,8 +528,6 @@ def points_inside_envelope(
 def ice_rings_selection(reflections, width=0.004):
     d_star_sq = flex.pow2(reflections["rlp"].norms())
     d_spacings = uctbx.d_star_sq_as_d(d_star_sq)
-
-    from dials.algorithms.integration import filtering
 
     unit_cell = uctbx.unit_cell((4.498, 4.498, 7.338, 90, 90, 120))
     space_group = sgtbx.space_group_info(number=194).group()
@@ -594,9 +564,7 @@ def resolution_histogram(reflections, imageset, plot_filename=None):
 
         ax_ = ax.twiny()  # ax2 is responsible for "top" axis and "right" axis
         xticks = ax.get_xticks()
-        xlim = ax.get_xlim()
         xticks_d = [uctbx.d_star_sq_as_d(ds2) if ds2 > 0 else 0 for ds2 in xticks]
-        xticks_ = [ds2 / (xlim[1] - xlim[0]) for ds2 in xticks]
         ax_.set_xticks(xticks)
         ax_.set_xlim(ax.get_xlim())
         ax_.set_xlabel(r"Resolution ($\AA$)")
@@ -648,9 +616,7 @@ def log_sum_i_sigi_vs_resolution(reflections, imageset, plot_filename=None):
 
         ax_ = ax.twiny()  # ax2 is responsible for "top" axis and "right" axis
         xticks = ax.get_xticks()
-        xlim = ax.get_xlim()
         xticks_d = [uctbx.d_star_sq_as_d(ds2) if ds2 > 0 else 0 for ds2 in xticks]
-        xticks_ = [ds2 / (xlim[1] - xlim[0]) for ds2 in xticks]
         ax_.set_xticks(xticks)
         ax_.set_xlim(ax.get_xlim())
         ax_.set_xlabel(r"Resolution ($\AA$)")
@@ -875,7 +841,6 @@ def print_table(stats, perm=None, n_rows=None, out=None):
         import sys
 
         out = sys.stdout
-    from libtbx import table_utils
 
     rows = table(stats, perm=perm, n_rows=n_rows)
     print(


### PR DESCRIPTION
Alternative (to pull #796) way of fixing #795. Rather than setting the backend at all, this should build using the backend renderer explicitly without setting the global backend (which should rightly be controlled by the user). This is demonstrated in the [CanvasAgg](https://matplotlib.org/3.1.0/gallery/user_interfaces/canvasagg.html) matplotlib example.

Unfortunately, some of the easier ways of doing this are restricted to matplotlib>3.0.

A second commit does flake8 and other tidying.