### PR TITLE
In dials.cosym, remove bad datasets rather than raising an assertion

### DIFF
--- a/test/command_line/test_cosym.py
+++ b/test/command_line/test_cosym.py
@@ -4,6 +4,7 @@ import pytest
 import procrunner
 
 from dxtbx.serialize import load
+from dials.array_family import flex
 
 
 @pytest.mark.parametrize("space_group", [None, "P 1", "P 4"])
@@ -30,3 +31,43 @@ def test_cosym(dials_data, tmpdir, space_group):
             experiments[0].crystal.get_space_group().type().lookup_symbol()
             == space_group
         )
+
+
+def test_cosym_partial_dataset(dials_data, tmpdir):
+    """Test how cosym handles partial/bad datasets."""
+    mcp = dials_data("multi_crystal_proteinase_k")
+    command = ["dials.cosym"]
+    for i in [1, 2]:
+        command.append(mcp.join("experiments_%d.json" % i).strpath)
+        command.append(mcp.join("reflections_%d.pickle" % i).strpath)
+    # Make one dataset that will be removed in prefiltering
+    r = flex.reflection_table.from_pickle(mcp.join("reflections_8.pickle").strpath)
+    r["partiality"] = flex.double(r.size(), 0.1)
+    r.as_pickle(tmpdir.join("renamed.pickle").strpath)
+    command.append(tmpdir.join("renamed.pickle").strpath)
+    command.append(mcp.join("experiments_8.json").strpath)
+    # Add another good dataset at the end of the input list
+    command.append(mcp.join("experiments_10.json").strpath)
+    command.append(mcp.join("reflections_10.pickle").strpath)
+
+    result = procrunner.run(command, working_directory=tmpdir.strpath)
+    assert not result["exitcode"] and not result["stderr"]
+    assert tmpdir.join("reindexed_reflections.pickle").check(file=1)
+    assert tmpdir.join("reindexed_experiments.json").check(file=1)
+    experiments = load.experiment_list(
+        tmpdir.join("reindexed_experiments.json").strpath, check_format=False
+    )
+    assert len(experiments) == 3
+
+    command = ["dials.cosym"]
+    command.append(tmpdir.join("renamed.pickle").strpath)
+    command.append(mcp.join("experiments_8.json").strpath)
+    r2 = flex.reflection_table.from_pickle(mcp.join("reflections_10.pickle").strpath)
+    r2["partiality"] = flex.double(r2.size(), 0.1)
+    r2.as_pickle(tmpdir.join("renamed2.pickle").strpath)
+    command.append(tmpdir.join("renamed2.pickle").strpath)
+    command.append(mcp.join("experiments_10.json").strpath)
+
+    result = procrunner.run(command, working_directory=tmpdir.strpath)
+    # Sorry exceptions are only raised as text at the system level
+    assert result["stderr"][0:5] == "Sorry"


### PR DESCRIPTION
If an input dataset is bad, such as no fully recorded reflections, then an assert refl.size() > 0 was being raised. 
However it is probably quite likely that bad datasets will sometimes work their way into a multi crystal dataset. This change instead catches these cases and removes them from the overall dataset, such that they do not appear in the output. If all data are bad, then a Sorry is raised.

A potential issue is if a program like xia2.multiplex is expecting all input reflection tables to be present in the output.