### PR TITLE
Updates to dxtbx and dials to allow image viewer regarding load_models

### DIFF
--- a/command_line/image_viewer.py
+++ b/command_line/image_viewer.py
@@ -196,9 +196,9 @@ if __name__ == "__main__":
 
     flat_expts = flatten_experiments(params.input.experiments)
     if params.load_models:
-        if any([e.detector is None for e in flat_expts]):
+        if any(e.detector is None for e in flat_expts):
             sys.exit("Error: experiment has no detector")
-        if any([e.beam is None for e in flat_expts]):
+        if any(e.beam is None for e in flat_expts):
             sys.exit("Error: experiment has no beam")
 
     if params.mask is not None:

--- a/command_line/image_viewer.py
+++ b/command_line/image_viewer.py
@@ -117,6 +117,9 @@ predict_reflections = False
 include scope dials.algorithms.profile_model.factory.phil_scope
 include scope dials.algorithms.spot_prediction.reflection_predictor.phil_scope
 
+load_models = True
+  .type = bool
+  .help = "Whether to load every model, which matters for large image files"
 """,
     process_includes=True,
 )
@@ -192,10 +195,11 @@ if __name__ == "__main__":
         exit(0)
 
     flat_expts = flatten_experiments(params.input.experiments)
-    if not all(e.detector for e in flat_expts):
-        sys.exit("Error: experiment has no detector")
-    if not all(e.beam for e in flat_expts):
-        sys.exit("Error: experiment has no beam")
+    if params.load_models:
+        if any([e.detector is None for e in flat_expts]):
+            sys.exit("Error: experiment has no detector")
+        if any([e.beam is None for e in flat_expts]):
+            sys.exit("Error: experiment has no beam")
 
     if params.mask is not None:
         from libtbx import easy_pickle

--- a/util/options.py
+++ b/util/options.py
@@ -549,7 +549,7 @@ class PhilCommandParser(object):
         try:
             load_models = params.load_models
         except AttributeError:
-            load_models = True  # NOTE: this is defaulted in Importer as True already
+            load_models = True
 
         # Try to import everything
         importer = Importer(

--- a/util/options.py
+++ b/util/options.py
@@ -275,7 +275,7 @@ class Importer(object):
         :param compare_goniometer:
         :param scan_tolerance:
         :param format_kwargs:
-        :param load_models: whether to load all models for expLists
+        :param load_models: Whether to load all models for ExperimentLists
         :param propagate_geom: for stills, whether to propagate the initial images geometry to all experiments
           (mainly used for imageviewer)
         :return: Unhandled arguments

--- a/util/options.py
+++ b/util/options.py
@@ -188,6 +188,7 @@ class Importer(object):
         compare_goniometer=None,
         scan_tolerance=None,
         format_kwargs=None,
+        load_models=True,
     ):
         """
         Parse the arguments. Populates its instance attributes in an intelligent way
@@ -207,7 +208,7 @@ class Importer(object):
         :param read_experiments_from_images: Try to read the experiments from images
         :param check_format: Check the format when reading images
         :param verbose: True/False print out some stuff
-
+        :param load_models: whether to load models from every experiment
         """
 
         # Initialise output
@@ -227,6 +228,7 @@ class Importer(object):
                 compare_goniometer,
                 scan_tolerance,
                 format_kwargs,
+                load_models,
             )
 
         # Second try to read experiment files
@@ -261,14 +263,22 @@ class Importer(object):
         compare_goniometer,
         scan_tolerance,
         format_kwargs,
+        load_models=True,
     ):
         """
         Try to import images.
 
         :param args: The input arguments
         :param verbose: Print verbose output
+        :param compare_beam:
+        :param compare_detector:
+        :param compare_goniometer:
+        :param scan_tolerance:
+        :param format_kwargs:
+        :param load_models: whether to load all models for expLists
+        :param propagate_geom: for stills, whether to propagate the initial images geometry to all experiments
+          (mainly used for imageviewer)
         :return: Unhandled arguments
-
         """
         from dxtbx.model.experiment_list import ExperimentListFactory
         from dials.util.phil import FilenameDataWrapper, ExperimentListConverters
@@ -293,6 +303,7 @@ class Importer(object):
             compare_goniometer=compare_goniometer,
             scan_tolerance=scan_tolerance,
             format_kwargs=format_kwargs,
+            load_models=load_models,  # default is True in from_filenames
         )
         if len(experiments) > 0:
             filename = "<image files>"
@@ -535,6 +546,11 @@ class PhilCommandParser(object):
             scan_tolerance = None
             format_kwargs = None
 
+        try:
+            load_models = params.load_models
+        except AttributeError:
+            load_models = True  # NOTE: this is defaulted in Importer as True already
+
         # Try to import everything
         importer = Importer(
             unhandled,
@@ -548,6 +564,7 @@ class PhilCommandParser(object):
             compare_goniometer=compare_goniometer,
             scan_tolerance=scan_tolerance,
             format_kwargs=format_kwargs,
+            load_models=load_models,
         )
 
         # Grab a copy of the errors that occured in case the caller wants them

--- a/util/options.py
+++ b/util/options.py
@@ -208,7 +208,7 @@ class Importer(object):
         :param read_experiments_from_images: Try to read the experiments from images
         :param check_format: Check the format when reading images
         :param verbose: True/False print out some stuff
-        :param load_models: whether to load models from every experiment
+        :param load_models: Whether to load all models for ExperimentLists
         """
 
         # Initialise output

--- a/util/options.py
+++ b/util/options.py
@@ -276,8 +276,6 @@ class Importer(object):
         :param scan_tolerance:
         :param format_kwargs:
         :param load_models: Whether to load all models for ExperimentLists
-        :param propagate_geom: for stills, whether to propagate the initial images geometry to all experiments
-          (mainly used for imageviewer)
         :return: Unhandled arguments
         """
         from dxtbx.model.experiment_list import ExperimentListFactory

--- a/util/options.py
+++ b/util/options.py
@@ -303,7 +303,7 @@ class Importer(object):
             compare_goniometer=compare_goniometer,
             scan_tolerance=scan_tolerance,
             format_kwargs=format_kwargs,
-            load_models=load_models,  # default is True in from_filenames
+            load_models=load_models,
         )
         if len(experiments) > 0:
             filename = "<image files>"


### PR DESCRIPTION
This PR arose from working with XTC Formats, where the detector models are loaded on the fly and in order to load all models one must parse entire XTC files, which is time consuming and not necessary for stills image display. 

Current image viewer requires that all detector and beam models be loaded prior to display. In which cases is this necessary ? Maybe one would display a scan vector for rotation series data ? If most of the time folks would rather just load models on the fly, then perhaps the default value should be False in the image viewer, but for now it is as it was, set t as load_models=True for all image formats