### PR TITLE
Configure automatic code formatting for C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+---
+BasedOnStyle: Google
+---
+Language: Cpp
+IndentWidth: 2
+ColumnLimit: 88
+# Put arguments and parameter on separate lines if they don't fit on one
+BinPackArguments: false
+BinPackParameters: false
+
+# If the declaration parameters fit on the next line, still don't pack
+AllowAllParametersOfDeclarationOnNextLine: false
+# public, private align with the class declaration
+AccessModifierOffset: -2
+# Only allow empty functions to be fully declared on a single line
+AllowShortFunctionsOnASingleLine: Empty
+# When splitting long expression put the operator on the new line
+# Technically break with prevailing style but matches black for operators
+BreakBeforeBinaryOperators: NonAssignment
+# Open multiple namespaces on the same line
+CompactNamespaces: true
+# When wrapping lines, indent the continuation by this
+ContinuationIndentWidth: 2
+# case: line up with the switch rather than being indented
+IndentCaseLabels: false
+NamespaceIndentation: Inner
+# Don't sort includes
+SortIncludes: false
+---


### PR DESCRIPTION
We've applied automatic formatting to python code and that's been successful. This pull request is to discuss doing the same to C++ with `clang-format`. We're not proposing that everyone has `clang-format` installed (unless you want to), but instead that the weekly "Clean Clutter" commit by Jenkins will run the formatter.

The configuration I'm presenting here has been somewhat hand-chosen to be close to our current prevailing code style, with the following deliberate divergences:
- Putting operators on the new line when splitting long expressions (like black)
- Definition parameters or function arguments that are too long to fit on a single line will be split into separate lines rather than being packed as tightly as possible. The code is a mix of styles here, with a slight preference to packing - but we've seen benefit from black's approach to this (though it isn't as extreme as black).

I've got a branch [here](https://github.com/ndevenish/dials-fork/compare/clang-format...ndevenish:clang-formatted) that shows the difference applying this configuration.

This tool is highly configurable and the list of possible configurations can be seen at: https://clang.llvm.org/docs/ClangFormatStyleOptions.html - many style preferences can be accommodated.

![image](https://user-images.githubusercontent.com/529963/59450011-34e3cf80-8e00-11e9-9abd-3dfca4578487.png)
