### PR TITLE
change default experiment identifier

### DIFF
--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -137,13 +137,25 @@ class StillsIndexer(Indexer):
             n_lattices_previous_cycle = len(experiments)
 
             # index multiple lattices per shot
+            # Append tags to identifiers  and assign them if identifier
+            # from spotfinding is not an empty string
+            # For example for XTC streams when read with FormatXTC
+            # 2016-12-13T21:10Z19.804-00 where -00 gets added at the end.
             if len(experiments) == 0:
                 experiments.extend(self.find_lattices())
                 if len(experiments) == 0:
                     raise DialsIndexError("No suitable lattice could be found.")
+                if self.experiments[0].identifier != "":
+                    experiments[0].identifier = self.experiments[
+                        0
+                    ].identifier + "-%02d" % (len(experiments) - 1)
             else:
                 try:
                     new = self.find_lattices()
+                    if self.experiments[0].identifier != "":
+                        new.identifier = self.experiments[0].identifier + "-%02d" % (
+                            len(experiments) - 1
+                        )
                     experiments.extend(new)
                 except Exception as e:
                     logger.info("Indexing remaining reflections failed")


### PR DESCRIPTION
This is parallel pull request with cctbx/dxtbx#39 . Since after spotfinding the experiment identifier was set to an empty string in stills_indexer, these changes (a) ensure the identifier is preserved through indexing and subsequently integration (b) append tags based on number of lattices indexed. The tags based on number of lattices ensure that each experiment identifier for LCLS experiments is unique, even in situations where there are multiple lattices. 

Example of changes
```
In [1]: from dxtbx.model.experiment_list import ExperimentListFactory

In [2]: spotfinder_expts=ExperimentListFactory.from_json_file('idx-mfx_data_00001_experiments.json')

In [3]: indexing_expts=ExperimentListFactory.from_json_file('idx-mfx_data_00001_refined_experiments.json')

In [4]: spotfinder_expts[0].identifier
Out[4]: '2016-12-13T21:10Z22.805'

In [5]: indexing_expts[0].identifier
Out[5]: '2016-12-13T21:10Z22.805-00'
```
As being discussed in the dxtbx PR, the changes are specifically for stills. Hoping that something similar will be done for sweeps to maintain consistency in behaviour. 
