### PR TITLE
Report standard error of correlation coefficients.

### DIFF
--- a/command_line/check_indexing_symmetry.py
+++ b/command_line/check_indexing_symmetry.py
@@ -11,6 +11,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import math
 import logging
 import sys
 
@@ -123,12 +124,16 @@ def standard_error_of_pearson_cc(corr_coeffs, n):
 
     numerator = 1 - flex.pow2(corr_coeffs)
     denominator = n - 2
-    if min(denominator) < 1:
-        raise ValueError("Too few reflections to calculate a standard error")
-    return numerator / denominator.as_double()
+    sel = denominator < 1
+    denominator.set_selected(sel, 1)
+    vals = numerator / denominator.as_double()
+    vals.set_selected(sel, float("NaN"))
+    return vals
 
 
 def format_cc_with_standard_error(cc, se, decimal_places=3):
+    if math.isnan(se):
+        return "?"
     minimum = pow(0.1, decimal_places)
     if se >= minimum:
         cc_str = format_float_with_standard_uncertainty(cc, se, minimum=1.0e-3)

--- a/command_line/check_indexing_symmetry.py
+++ b/command_line/check_indexing_symmetry.py
@@ -60,9 +60,8 @@ d_max = 0
   .help = "Low resolution limit to use for analysis"
 symop_threshold = 0
   .type = float
-  .help = "Threshold above which we consider a symmetry operator true."
-          "The value tested is the correlation coefficient minus one"
-          "standard error."
+  .help = "Threshold above which we consider a symmetry operator true"
+          "at approximately 95% confidence."
 grid = 0
   .type = int
   .help = "Search scope for testing misindexing on h, k, l."
@@ -218,7 +217,7 @@ def test_crystal_pointgroup_symmetry(reflections, experiment, params):
     for smx, cc, n_ref, se in zip(space_group.smx(), ccs, n_refs, ses):
         accept = ""
         if params.symop_threshold:
-            if cc - se > params.symop_threshold:
+            if (cc - 2.0 * se) > params.symop_threshold:
                 true_symops.append(smx)
                 accept = "***"
         cc_str = format_cc_with_standard_error(cc, se)


### PR DESCRIPTION
This is intended to address #215. Standard errors are printed
alongside the correlation coefficients. These can be large when
the number of reflections is small. To enact as a sanity check,
the correlation coefficient itself is not compared with
symop_threshold, but a lower bound given by (CC - SE) is
calculated first then this is compared with symop_threshold.