### PR TITLE
Add client/server to stills_process

### DIFF
--- a/algorithms/integration/stills_significance_filter.py
+++ b/algorithms/integration/stills_significance_filter.py
@@ -146,10 +146,10 @@ class SignificanceFilter(object):
                     )
                 )
 
-                table_row.append("%.1f" % (avg_i))
-                table_row.append("%.1f" % (avg_i_sigi))
+                table_row.append("%.2f" % (avg_i))
+                table_row.append("%.2f" % (avg_i_sigi))
                 table_row.append("%3d" % n_bright)
-                table_row.append("%.1f" % (rmsd_obs))
+                table_row.append("%.2f" % (rmsd_obs))
                 table_data.append(table_row)
 
             # Throw out bins that go back above the cutoff after the first non-passing bin is found

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -506,8 +506,10 @@ class Script(object):
 
             log.config(params.verbosity, info=info_path, debug=debug_path)
 
-            if size <= 2: # client/server only makes sense for n>2
-                subset = [item for i, item in enumerate(iterable) if (i + rank) % size == 0]
+            if size <= 2:  # client/server only makes sense for n>2
+                subset = [
+                    item for i, item in enumerate(iterable) if (i + rank) % size == 0
+                ]
                 do_work(rank, subset)
             else:
                 if rank == 0:
@@ -515,32 +517,35 @@ class Script(object):
                     for item in iterable:
                         print("Getting next available process")
                         rankreq = comm.recv(source=MPI.ANY_SOURCE)
-                        print("Process %s is ready, sending %s\n"%(rankreq, item[0]))
-                        comm.send(item,dest=rankreq)
+                        print("Process %s is ready, sending %s\n" % (rankreq, item[0]))
+                        comm.send(item, dest=rankreq)
                     # send a stop command to each process
                     print("MPI DONE, sending stops\n")
-                    for rankreq in range(size-1):
+                    for rankreq in range(size - 1):
                         rankreq = comm.recv(source=MPI.ANY_SOURCE)
-                        print("Sending stop to %d\n"%rankreq)
-                        comm.send('endrun',dest=rankreq)
+                        print("Sending stop to %d\n" % rankreq)
+                        comm.send("endrun", dest=rankreq)
                     print("All stops sent.")
                 else:
                     # client process
                     while True:
-                      # inform the server this process is ready for an event
-                      print("Rank %d getting next task"%rank)
-                      comm.send(rank,dest=0)
-                      print("Rank %d waiting for response"%rank)
-                      item = comm.recv(source=0)
-                      if item == 'endrun':
-                          print("Rank %d recieved endrun"%rank)
-                          break
-                      print("Rank %d beginning processing"%rank)
-                      try:
-                          do_work(rank, [item])
-                      except Exception as e:
-                          print("Rank %d unhandled exception processing event"%rank, str(e))
-                      print("Rank %d event pocessed"%rank)
+                        # inform the server this process is ready for an event
+                        print("Rank %d getting next task" % rank)
+                        comm.send(rank, dest=0)
+                        print("Rank %d waiting for response" % rank)
+                        item = comm.recv(source=0)
+                        if item == "endrun":
+                            print("Rank %d received endrun" % rank)
+                            break
+                        print("Rank %d beginning processing" % rank)
+                        try:
+                            do_work(rank, [item])
+                        except Exception as e:
+                            print(
+                                "Rank %d unhandled exception processing event" % rank,
+                                str(e),
+                            )
+                        print("Rank %d event processed" % rank)
         else:
             from dxtbx.command_line.image_average import splitit
 

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -506,8 +506,41 @@ class Script(object):
 
             log.config(params.verbosity, info=info_path, debug=debug_path)
 
-            subset = [item for i, item in enumerate(iterable) if (i + rank) % size == 0]
-            do_work(rank, subset)
+            if size <= 2: # client/server only makes sense for n>2
+                subset = [item for i, item in enumerate(iterable) if (i + rank) % size == 0]
+                do_work(rank, subset)
+            else:
+                if rank == 0:
+                    # server process
+                    for item in iterable:
+                        print("Getting next available process")
+                        rankreq = comm.recv(source=MPI.ANY_SOURCE)
+                        print("Process %s is ready, sending %s\n"%(rankreq, item[0]))
+                        comm.send(item,dest=rankreq)
+                    # send a stop command to each process
+                    print("MPI DONE, sending stops\n")
+                    for rankreq in range(size-1):
+                        rankreq = comm.recv(source=MPI.ANY_SOURCE)
+                        print("Sending stop to %d\n"%rankreq)
+                        comm.send('endrun',dest=rankreq)
+                    print("All stops sent.")
+                else:
+                    # client process
+                    while True:
+                      # inform the server this process is ready for an event
+                      print("Rank %d getting next task"%rank)
+                      comm.send(rank,dest=0)
+                      print("Rank %d waiting for response"%rank)
+                      item = comm.recv(source=0)
+                      if item == 'endrun':
+                          print("Rank %d recieved endrun"%rank)
+                          break
+                      print("Rank %d beginning processing"%rank)
+                      try:
+                          do_work(rank, [item])
+                      except Exception as e:
+                          print("Rank %d unhandled exception processing event"%rank, str(e))
+                      print("Rank %d event pocessed"%rank)
         else:
             from dxtbx.command_line.image_average import splitit
 


### PR DESCRIPTION
Recent experiment at SACLA really highlighted the need for client/server in dials.stills_process so I've ported it from xtc_process into here.  I've made it the only option because it's nearly always better than striping (if n > 2).