### PR TITLE
Python 3: stage 1 code changes

### DIFF
--- a/algorithms/refinement/prediction/managed_predictors.py
+++ b/algorithms/refinement/prediction/managed_predictors.py
@@ -128,7 +128,7 @@ class ScansExperimentsPredictor(ExperimentsPredictor):
 
     def _post_prediction(self, reflections):
 
-        if reflections.has_key("xyzobs.mm.value"):
+        if "xyzobs.mm.value" in reflections:
             reflections = self._match_full_turns(reflections)
 
         return reflections

--- a/algorithms/scaling/scaler.py
+++ b/algorithms/scaling/scaler.py
@@ -253,7 +253,7 @@ class SingleScaler(ScalerBase):
         created using the SingleScalerFactory.
         """
         assert all(
-            reflection_table.has_key(i)
+            i in reflection_table
             for i in ["inverse_scale_factor", "intensity", "variance", "id"]
         )
         super(SingleScaler, self).__init__()

--- a/algorithms/scaling/test_scaler_factory.py
+++ b/algorithms/scaling/test_scaler_factory.py
@@ -197,14 +197,13 @@ def test_SingleScalerFactory(generated_param, refl_to_filter, mock_scaling_compo
     test_refl, exp = test_refl_and_exp(mock_scaling_component)
     # Test that all required attributes get added with standard params.
     assert all(
-        (not test_refl.has_key(i))
-        for i in ["inverse_scale_factor", "intensity", "variance"]
+        (i not in test_refl) for i in ["inverse_scale_factor", "intensity", "variance"]
     )
     # Test default, (no split into free set)
     ss = SingleScalerFactory.create(generated_param, exp, test_refl)
     assert isinstance(ss, SingleScaler)
     assert all(
-        ss.reflection_table.has_key(i)
+        i in ss.reflection_table
         for i in ["inverse_scale_factor", "intensity", "variance"]
     )
 

--- a/command_line/filter_reflections.py
+++ b/command_line/filter_reflections.py
@@ -134,7 +134,7 @@ def eval_flag_expression(expression, reflections):
 
         # Extract next token, catching unmatched brackets
         try:
-            toknum, tokval, _, _, _ = g.next()
+            toknum, tokval, _, _, _ = next(g)
         except TokenError:
             raise Sorry("errors found in {0}".format(expression))
         except StopIteration:


### PR DESCRIPTION
Kicking off the work for #843 with a simple fixer.
These are Python 2 syntax regressions that have crept back in over time.
`has_key()` is no more and `next` has changed.