### PR TITLE
Python 3: lib2to3.fixes.fix_filter

### DIFF
--- a/algorithms/refinement/parameterisation/configure.py
+++ b/algorithms/refinement/parameterisation/configure.py
@@ -338,7 +338,7 @@ def _centroid_analysis(options, experiments, reflection_manager):
     for i, a in enumerate(analysis):
         intervals = [a.get("x_interval"), a.get("y_interval"), a.get("phi_interval")]
         try:
-            min_interval = min(filter(None, intervals))
+            min_interval = min([_f for _f in intervals if _f])
         except ValueError:
             # empty list - analysis was unable to suggest a suitable interval
             # width. Default to the safest case

--- a/algorithms/refinement/parameterisation/configure.py
+++ b/algorithms/refinement/parameterisation/configure.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, division, print_function
-import re
-import logging
 
-logger = logging.getLogger(__name__)
+import logging
+import re
 
 import libtbx  # for libtbx.Auto
 from dials.algorithms.refinement import DialsRefineConfigError
@@ -63,6 +62,8 @@ format_data = {
     "constr_phil": constr_phil_str,
     "sv_phil": sv_phil_str,
 }
+
+logger = logging.getLogger(__name__)
 
 phil_str = (
     """
@@ -285,6 +286,7 @@ phil_str = (
     % format_data
 )
 phil_scope = parse(phil_str)
+
 
 # A helper function for parameter fixing
 def _filter_parameter_names(parameterisation):

--- a/algorithms/refinement/parameterisation/configure.py
+++ b/algorithms/refinement/parameterisation/configure.py
@@ -336,9 +336,9 @@ def _centroid_analysis(options, experiments, reflection_manager):
     # for each of the residuals in x, y and phi, as long as this is not smaller
     # than either the outlier rejection block width, or 9.0 degrees.
     for i, a in enumerate(analysis):
-        intervals = [a.get("x_interval"), a.get("y_interval"), a.get("phi_interval")]
+        intervals = (a.get("x_interval"), a.get("y_interval"), a.get("phi_interval"))
         try:
-            min_interval = min([_f for _f in intervals if _f])
+            min_interval = min(_f for _f in intervals if _f is not None)
         except ValueError:
             # empty list - analysis was unable to suggest a suitable interval
             # width. Default to the safest case

--- a/test/command_line/test_show.py
+++ b/test/command_line/test_show.py
@@ -11,7 +11,7 @@ def test_dials_show(dials_regression):
         ["dials.show", path], environment_override={"DIALS_NOBANNER": "1"}
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list(filter(None, (s.rstrip() for s in result["stdout"].split("\n"))))
+    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
     assert (
         "\n".join(output[4:])
         == """
@@ -79,7 +79,7 @@ def test_dials_show_i04_weak_data(dials_regression):
         ["dials.show", path], environment_override={"DIALS_NOBANNER": "1"}
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list(filter(None, (s.rstrip() for s in result["stdout"].split("\n"))))
+    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
     assert (
         "\n".join(output[4:])
         == """
@@ -136,7 +136,7 @@ def test_dials_show_centroid_test_data(dials_data):
         environment_override={"DIALS_NOBANNER": "1"},
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list(filter(None, (s.rstrip() for s in result["stdout"].split("\n"))))
+    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
     assert (
         "\n".join(output[4:])
         == """
@@ -193,7 +193,7 @@ def test_dials_show_multi_panel_i23(dials_regression):
         ["dials.show", path], environment_override={"DIALS_NOBANNER": "1"}
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list(filter(None, (s.rstrip() for s in result["stdout"].split("\n"))))
+    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
 
     assert (
         "\n".join(output[4:25])
@@ -280,7 +280,7 @@ def test_dials_show_reflection_table(dials_data):
         environment_override={"DIALS_NOBANNER": "1"},
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list(filter(None, (s.rstrip() for s in result["stdout"].split("\n"))))
+    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
     assert output[4] == "Reflection list contains 2269 reflections"
     headers = ["Column", "min", "max", "mean"]
     for header in headers:

--- a/test/command_line/test_show.py
+++ b/test/command_line/test_show.py
@@ -10,10 +10,8 @@ def test_dials_show(dials_regression):
     result = procrunner.run(
         ["dials.show", path], environment_override={"DIALS_NOBANNER": "1"}
     )
-    assert not result["exitcode"] and not result["stderr"]
-    output = list(
-        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
-    )
+    assert not result.returncode and not result.stderr
+    output = [_f for _f in (s.rstrip() for s in result.stdout.split("\n")) if _f]
     assert (
         "\n".join(output[4:])
         == """
@@ -80,10 +78,8 @@ def test_dials_show_i04_weak_data(dials_regression):
     result = procrunner.run(
         ["dials.show", path], environment_override={"DIALS_NOBANNER": "1"}
     )
-    assert not result["exitcode"] and not result["stderr"]
-    output = list(
-        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
-    )
+    assert not result.returncode and not result.stderr
+    output = [_f for _f in (s.rstrip() for s in result.stdout.split("\n")) if _f]
     assert (
         "\n".join(output[4:])
         == """
@@ -133,16 +129,11 @@ Goniometer:
 def test_dials_show_centroid_test_data(dials_data):
     result = procrunner.run(
         ["dials.show"]
-        + [
-            f.strpath
-            for f in dials_data("centroid_test_data").listdir("centroid_*.cbf")
-        ],
+        + list(dials_data("centroid_test_data").listdir("centroid_*.cbf")),
         environment_override={"DIALS_NOBANNER": "1"},
     )
-    assert not result["exitcode"] and not result["stderr"]
-    output = list(
-        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
-    )
+    assert not result.returncode and not result.stderr
+    output = [_f for _f in (s.rstrip() for s in result.stdout.split("\n")) if _f]
     assert (
         "\n".join(output[4:])
         == """
@@ -198,10 +189,8 @@ def test_dials_show_multi_panel_i23(dials_regression):
     result = procrunner.run(
         ["dials.show", path], environment_override={"DIALS_NOBANNER": "1"}
     )
-    assert not result["exitcode"] and not result["stderr"]
-    output = list(
-        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
-    )
+    assert not result.returncode and not result.stderr
+    output = [_f for _f in (s.rstrip() for s in result.stdout.split("\n")) if _f]
 
     assert (
         "\n".join(output[4:25])
@@ -281,16 +270,12 @@ Goniometer:
 def test_dials_show_reflection_table(dials_data):
     """Test the output of dials.show on a reflection_table pickle file"""
     result = procrunner.run(
-        [
-            "dials.show",
-            dials_data("centroid_test_data").join("integrated.pickle").strpath,
-        ],
+        ["dials.show", dials_data("centroid_test_data").join("integrated.pickle")],
         environment_override={"DIALS_NOBANNER": "1"},
     )
-    assert not result["exitcode"] and not result["stderr"]
-    output = list(
-        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
-    )
+    assert not result.returncode and not result.stderr
+    output = [_f for _f in (s.rstrip() for s in result.stdout.split("\n")) if _f]
+
     assert output[4] == "Reflection list contains 2269 reflections"
     headers = ["Column", "min", "max", "mean"]
     for header in headers:

--- a/test/command_line/test_show.py
+++ b/test/command_line/test_show.py
@@ -11,7 +11,9 @@ def test_dials_show(dials_regression):
         ["dials.show", path], environment_override={"DIALS_NOBANNER": "1"}
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
+    output = list(
+        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
+    )
     assert (
         "\n".join(output[4:])
         == """
@@ -79,7 +81,9 @@ def test_dials_show_i04_weak_data(dials_regression):
         ["dials.show", path], environment_override={"DIALS_NOBANNER": "1"}
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
+    output = list(
+        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
+    )
     assert (
         "\n".join(output[4:])
         == """
@@ -136,7 +140,9 @@ def test_dials_show_centroid_test_data(dials_data):
         environment_override={"DIALS_NOBANNER": "1"},
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
+    output = list(
+        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
+    )
     assert (
         "\n".join(output[4:])
         == """
@@ -193,7 +199,9 @@ def test_dials_show_multi_panel_i23(dials_regression):
         ["dials.show", path], environment_override={"DIALS_NOBANNER": "1"}
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
+    output = list(
+        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
+    )
 
     assert (
         "\n".join(output[4:25])
@@ -280,7 +288,9 @@ def test_dials_show_reflection_table(dials_data):
         environment_override={"DIALS_NOBANNER": "1"},
     )
     assert not result["exitcode"] and not result["stderr"]
-    output = list([_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f])
+    output = list(
+        [_f for _f in (s.rstrip() for s in result["stdout"].split("\n")) if _f]
+    )
     assert output[4] == "Reflection list contains 2269 reflections"
     headers = ["Column", "min", "max", "mean"]
     for header in headers:


### PR DESCRIPTION
This pull request is based on the `lib2to3.fixes.fix_filter` fixer. In Python 3 `filter()` is gone. The automatic fixer converts `filter()` into list comprehensions which is also a general code improvement and better code style anyway as it is easier to read and to extend.