### PR TITLE
Add dials.merge and finish off post-integration workflow

### DIFF
--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -111,9 +111,10 @@ def merge_and_truncate(params, experiments, reflections):
     anom_amplitudes = None
     if params.truncate:
         if params.anomalous:
+            logger.info("\nScaling input intensities via French-Wilson Method")
             out = StringIO()
             anom_amplitudes = intensities.french_wilson(params=params, log=out)
-            logger.info(out.getvalue())
+            logger.debug(out.getvalue())
             assert anom_amplitudes.is_xray_amplitude_array()
             amplitudes = anom_amplitudes.as_non_anomalous_array()
             amplitudes = amplitudes.merge_equivalents().array()

--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -1,0 +1,147 @@
+"""Merging functions for experiment lists and reflection tables."""
+import logging
+from cStringIO import StringIO
+from dials.array_family import flex
+from dials.command_line.space_group import run_sys_abs_checks
+from dials.algorithms.scaling.scaling_library import (
+    scaled_data_as_miller_array,
+    merging_stats_from_scaled_array,
+)
+from dials.util.filter_reflections import filter_reflection_table
+from dials.util.export_mtz import MADMergedMTZWriter, MergedMTZWriter
+from dials.report.analysis import make_merging_statistics_summary
+from mmtbx.scaling import data_statistics
+
+logger = logging.getLogger("dials")
+
+
+def make_MAD_merged_mtz_file(params, experiments, reflections, wavelengths):
+    """Make a multi wavelength merged mtz file from experiments and reflections."""
+    # need to add a crystal to the mtz object
+    # now go through data selecting on wavelength - loop over each to get mtz_object
+    # Create the mtz file
+
+    mtz_writer = MADMergedMTZWriter(
+        experiments[0].crystal.get_space_group(), experiments[0].crystal.get_unit_cell()
+    )
+
+    # now add each wavelength.
+    for wavelength, exp_nos in wavelengths.iteritems():
+        expids = []
+        from dxtbx.model import ExperimentList
+
+        new_exps = ExperimentList()
+        for i in exp_nos:
+            expids.append(experiments[i].identifier)  # string
+            new_exps.append(experiments[i])
+        refls = reflections[0].select_on_experiment_identifiers(expids)
+
+        logger.info("Running merge for wavelength: %s", wavelength)
+        merged, anom, amplitudes, anom_amp = merge_and_truncate(
+            params, new_exps, [refls]
+        )
+        #### Add each wavelength as a new crystal.
+        mtz_writer.add_crystal()
+        mtz_writer.add_dataset(wavelength, merged, anom, amplitudes, anom_amp)
+
+    return mtz_writer.mtz_file
+
+
+def make_merged_mtz_file(
+    merged_array,
+    merged_anomalous_array=None,
+    amplitudes=None,
+    anomalous_amplitudes=None,
+):
+    """Make an mtz object for the data, adding the date, time and program."""
+
+    assert merged_array.is_xray_intensity_array()
+    assert merged_anomalous_array.is_xray_intensity_array()
+
+    mtz_writer = MergedMTZWriter(merged_array.space_group(), merged_array.unit_cell())
+    mtz_writer.add_crystal(crystal_name="DIALS")
+    mtz_writer.add_dataset(
+        merged_array, merged_anomalous_array, amplitudes, anomalous_amplitudes
+    )
+
+    return mtz_writer.mtz_file
+
+
+def merge_and_truncate(params, experiments, reflections):
+    """Filter data, assess space group, run french wilson and Wilson stats."""
+
+    logger.info("\nMerging scaled reflection data\n")
+    # first filter bad reflections using dials.util.filter methods
+    reflections = filter_reflection_table(
+        reflections[0], intensity_choice=["scale"], d_min=params.d_min
+    )
+    # ^ scale factor has been applied, so now set to 1.0 - okay as not
+    # going to output scale factor in merged mtz.
+    reflections["inverse_scale_factor"] = flex.double(reflections.size(), 1.0)
+
+    scaled_array = scaled_data_as_miller_array([reflections], experiments)
+    if params.anomalous:
+        anomalous_scaled = scaled_array.as_anomalous_array()
+
+    merged = scaled_array.merge_equivalents(
+        use_internal_variance=params.merging.use_internal_variance
+    ).array()
+    merged_anom = None
+    if params.anomalous:
+        merged_anom = anomalous_scaled.merge_equivalents(
+            use_internal_variance=params.merging.use_internal_variance
+        ).array()
+
+    # Before merge, do some assessment of the space_group
+    if params.assess_space_group:
+        merged_reflections = flex.reflection_table()
+        merged_reflections["intensity"] = merged.data()
+        merged_reflections["variance"] = merged.sigmas() ** 2
+        merged_reflections["miller_index"] = merged.indices()
+        logger.info("Running systematic absences check")
+        run_sys_abs_checks(experiments, merged_reflections)
+
+    # Run the stats on truncating on anomalous or non anomalous?
+    if params.anomalous:
+        intensities = merged_anom
+    else:
+        intensities = merged
+
+    assert intensities.is_xray_intensity_array()
+    amplitudes = None
+    anom_amplitudes = None
+    if params.truncate:
+        if params.anomalous:
+            out = StringIO()
+            anom_amplitudes = intensities.french_wilson(params=params, log=out)
+            logger.info(out.getvalue())
+            assert anom_amplitudes.is_xray_amplitude_array()
+            amplitudes = anom_amplitudes.as_non_anomalous_array()
+            amplitudes = amplitudes.merge_equivalents().array()
+        else:
+            amplitudes = intensities.french_wilson(params=params)
+
+    if params.reporting.wilson_stats:
+        if not intensities.space_group().is_centric():
+            wilson_scaling = data_statistics.wilson_scaling(
+                miller_array=intensities, n_residues=params.n_residues
+            )  # XXX default n_residues?
+            # Divert output through logger - do with StringIO rather than
+            # info_handle else get way too much whitespace in output.
+            out = StringIO()
+            wilson_scaling.show(out=out)
+            logger.info(out.getvalue())
+
+    # Apply wilson B to give absolute scale?
+
+    # Show merging stats again.
+    if params.reporting.merging_stats:
+        stats, anom_stats = merging_stats_from_scaled_array(
+            scaled_array, params.merging.n_bins, params.merging.use_internal_variance
+        )
+        if params.anomalous:
+            logger.info(make_merging_statistics_summary(anom_stats))
+        else:
+            logger.info(make_merging_statistics_summary(stats))
+
+    return merged, merged_anom, amplitudes, anom_amplitudes

--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -48,6 +48,7 @@ def make_MAD_merged_mtz_file(params, experiments, reflections, wavelengths):
 
 
 def make_merged_mtz_file(
+    wavelength,
     merged_array,
     merged_anomalous_array=None,
     amplitudes=None,
@@ -60,7 +61,11 @@ def make_merged_mtz_file(
     mtz_writer = MergedMTZWriter(merged_array.space_group(), merged_array.unit_cell())
     mtz_writer.add_crystal(crystal_name="DIALS")
     mtz_writer.add_dataset(
-        merged_array, merged_anomalous_array, amplitudes, anomalous_amplitudes
+        merged_array,
+        merged_anomalous_array,
+        amplitudes,
+        anomalous_amplitudes,
+        wavelength,
     )
 
     return mtz_writer.mtz_file

--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -10,6 +10,7 @@ from dials.algorithms.scaling.scaling_library import (
 from dials.util.filter_reflections import filter_reflection_table
 from dials.util.export_mtz import MADMergedMTZWriter, MergedMTZWriter
 from dials.report.analysis import make_merging_statistics_summary
+from dxtbx.model import ExperimentList
 from mmtbx.scaling import data_statistics
 
 logger = logging.getLogger("dials")
@@ -28,7 +29,6 @@ def make_MAD_merged_mtz_file(params, experiments, reflections, wavelengths):
     # now add each wavelength.
     for wavelength, exp_nos in wavelengths.iteritems():
         expids = []
-        from dxtbx.model import ExperimentList
 
         new_exps = ExperimentList()
         for i in exp_nos:
@@ -56,7 +56,6 @@ def make_merged_mtz_file(
     """Make an mtz object for the data, adding the date, time and program."""
 
     assert merged_array.is_xray_intensity_array()
-    assert merged_anomalous_array.is_xray_intensity_array()
 
     mtz_writer = MergedMTZWriter(merged_array.space_group(), merged_array.unit_cell())
     mtz_writer.add_crystal(crystal_name="DIALS")

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -275,8 +275,8 @@ def test_scale_physical(dials_regression, tmpdir):
     run_one_scaling(tmpdir, [refl_1, expt_1] + extra_args)
     result = get_merging_stats(tmpdir.join("unmerged.mtz").strpath)
     assert (
-        result.overall.r_pim < 0.0255
-    )  # at 14/08/18, value was 0.023, at 07/02/19 was 0.0243
+        result.overall.r_pim < 0.026
+    )  # at 17/07/19 was 0.256 after updates to merged mtz export
     assert (
         result.overall.cc_one_half > 0.9955
     )  # at 14/08/18, value was 0.999, at 07/02/19 was 0.9961

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -81,22 +81,19 @@ include scope cctbx.french_wilson.master_phil
 
 def merge_data_to_mtz(params, experiments, reflections):
     """Merge data (at each wavelength) and write to an mtz file object."""
-    if len(experiments) > 1:
-        wavelengths = match_wavelengths(experiments)
-        if len(wavelengths.keys()) > 1:
-            logger.info(
-                "Multiple wavelengths found: \n%s",
-                "\n".join(
-                    "  Wavlength: %.5f, experiment numbers: %s "
-                    % (k, ",".join(map(str, v)))
-                    for k, v in wavelengths.iteritems()
-                ),
-            )
-            return make_MAD_merged_mtz_file(
-                params, experiments, reflections, wavelengths
-            )
+    wavelengths = match_wavelengths(experiments)
+    if len(wavelengths.keys()) > 1:
+        logger.info(
+            "Multiple wavelengths found: \n%s",
+            "\n".join(
+                "  Wavlength: %.5f, experiment numbers: %s "
+                % (k, ",".join(map(str, v)))
+                for k, v in wavelengths.iteritems()
+            ),
+        )
+        return make_MAD_merged_mtz_file(params, experiments, reflections, wavelengths)
     merged_data = merge_and_truncate(params, experiments, reflections)
-    return make_merged_mtz_file(*merged_data)
+    return make_merged_mtz_file(*((wavelengths.keys()[0],) + merged_data))
 
 
 def run(args=None):

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -36,6 +36,16 @@ truncate = True
 d_min = None
     .type = float
     .help = "Resolution limit to apply to the data."
+combine_partials = True
+    .type = bool
+    .help = "Combine partials that have the same partial id into one
+        reflection, with an updated partiality given by the sum of the
+        individual partialities."
+partiality_threshold=0.99
+    .type = float
+    .help = "All reflections with partiality values above the partiality
+        threshold will be retained. This is done after any combination of
+        partials if applicable."
 n_residues = 200
     .type = int
     .help = "Number of residues to use in Wilson scaling"
@@ -44,6 +54,9 @@ merging {
         .type = bool
     n_bins = 20
         .type = int(value_min=5)
+    anomalous = False
+        .type = bool
+        .help = "Option to control whether reported merging stats are anomalous."
 }
 reporting {
     wilson_stats = True

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -72,6 +72,12 @@ output {
     mtz = merged.mtz
         .type = str
         .help = "Filename to use for mtz output."
+    crystal_names = XTAL
+        .type = strings
+    project_name = AUTOMATIC
+        .type = str
+    dataset_names = NATIVE
+        .type = strings
 }
 include scope cctbx.french_wilson.master_phil
 """,
@@ -93,7 +99,7 @@ def merge_data_to_mtz(params, experiments, reflections):
         )
         return make_MAD_merged_mtz_file(params, experiments, reflections, wavelengths)
     merged_data = merge_and_truncate(params, experiments, reflections)
-    return make_merged_mtz_file(*((wavelengths.keys()[0],) + merged_data))
+    return make_merged_mtz_file(*((params, wavelengths.keys()[0]) + merged_data))
 
 
 def run(args=None):

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -22,7 +22,6 @@ from libtbx import phil, Auto
 help_message = """Program to merge scaled dials data."""
 
 logger = logging.getLogger("dials")
-info_handle = log.info_handle(logger)
 phil_scope = phil.parse(
     """
 assess_space_group = True

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""
+Command line script to allow merging and truncating of a dials dataset.
+"""
+from __future__ import absolute_import, division, print_function
+import logging
+import sys
+from cStringIO import StringIO
+from dials.util import log, show_mail_on_error, Sorry
+from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.version import dials_version
+from dials.util.export_mtz import match_wavelengths
+from dials.algorithms.merging.merge import (
+    make_MAD_merged_mtz_file,
+    make_merged_mtz_file,
+    merge_and_truncate,
+)
+from libtbx import phil, Auto
+
+
+help_message = """Program to merge scaled dials data."""
+
+logger = logging.getLogger("dials")
+info_handle = log.info_handle(logger)
+phil_scope = phil.parse(
+    """
+assess_space_group = True
+    .type = bool
+    .help = "Option to assess space group by testing presence of axial reflections"
+anomalous = True
+    .type = bool
+    .help = "Output anomalous as well as mean intensities."
+truncate = True
+    .type = bool
+    .help = "Option to perform truncation on merged data."
+d_min = None
+    .type = float
+    .help = "Resolution limit to apply to the data."
+n_residues = 200
+    .type = int
+    .help = "Number of residues to use in Wilson scaling"
+merging {
+    use_internal_variance = False
+        .type = bool
+    n_bins = 20
+        .type = int(value_min=5)
+}
+reporting {
+    wilson_stats = True
+        .type = bool
+        .help = "Option to turn off reporting of wilson statistics"
+    merging_stats = True
+        .type = bool
+        .help = "Option to turn off reporting of merging statistics."
+}
+output {
+    log = dials.merge.log
+        .type = str
+    mtz = auto
+        .type = str
+        .help = "Filename to use, defaults to truncated.mtz or scaled_merged.mtz"
+                "depending on whether the data has been truncated."
+}
+include scope cctbx.french_wilson.master_phil
+""",
+    process_includes=True,
+)
+
+
+def merge_data_to_mtz(params, experiments, reflections):
+    """Merge data (at each wavelength) and write to an mtz file object."""
+    if len(experiments) > 1:
+        wavelengths = match_wavelengths(experiments)
+        if len(wavelengths.keys()) > 1:
+            logger.info(
+                "Multiple wavelengths found: \n%s",
+                "\n".join(
+                    "  Wavlength: %.5f, experiment numbers: %s "
+                    % (k, ",".join(map(str, v)))
+                    for k, v in wavelengths.iteritems()
+                ),
+            )
+            return make_MAD_merged_mtz_file(
+                params, experiments, reflections, wavelengths
+            )
+    merged_data = merge_and_truncate(params, experiments, reflections)
+    return make_merged_mtz_file(*merged_data)
+
+
+def run(args=None):
+    """Run the merging from the command-line."""
+    usage = """Usage: dials.merge scaled.refl scaled.expt [options]"""
+
+    parser = OptionParser(
+        usage=usage,
+        read_experiments=True,
+        read_reflections=True,
+        phil=phil_scope,
+        check_format=False,
+        epilog=help_message,
+    )
+    params, _ = parser.parse_args(args=args, show_diff_phil=False)
+
+    if not params.input.experiments or not params.input.reflections:
+        parser.print_help()
+        sys.exit()
+
+    reflections = flatten_reflections(params.input.reflections)
+    experiments = flatten_experiments(params.input.experiments)
+
+    log.config(verbosity=1, info=params.output.log)
+    logger.info(dials_version())
+
+    diff_phil = parser.diff_phil.as_str()
+    if diff_phil != "":
+        logger.info("The following parameters have been modified:\n")
+        logger.info(diff_phil)
+
+    ### Assert that all data have been scaled with dials - should only be
+    # able to input one reflection table and experimentlist that are
+    # matching and scaled together.
+
+    if len(reflections) != 1:
+        raise Sorry(
+            """Only data scaled together in a single reflection data
+can be processed with dials.merge"""
+        )
+
+    for k in [
+        "intensity.scale.value",
+        "intensity.scale.variance",
+        "inverse_scale_factor",
+    ]:
+        if not k in reflections[0]:
+            raise Sorry(
+                """%s not found in the reflection table. Only scaled data can be processed
+with dials.merge"""
+                % k
+            )
+
+    # Decide a suitable output filename if using auto option.
+    if params.output.mtz in (None, Auto, "auto"):
+        if params.truncate:
+            params.output.mtz = "truncated.mtz"
+        else:
+            params.output.mtz = "scaled_merged.mtz"
+
+    try:
+        mtz_file = merge_data_to_mtz(params, experiments, reflections)
+    except ValueError as e:
+        raise Sorry(e)
+
+    logger.info("\nWriting reflections to %s", (params.output.mtz))
+    out = StringIO()
+    mtz_file.show_summary(out=out)
+    logger.info(out.getvalue())
+    mtz_file.write(params.output.mtz)
+
+
+if __name__ == "__main__":
+    with show_mail_on_error():
+        run()

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -16,7 +16,7 @@ from dials.algorithms.merging.merge import (
     make_merged_mtz_file,
     merge_and_truncate,
 )
-from libtbx import phil, Auto
+from libtbx import phil
 
 
 help_message = """Program to merge scaled dials data."""
@@ -56,10 +56,9 @@ reporting {
 output {
     log = dials.merge.log
         .type = str
-    mtz = auto
+    mtz = merged.mtz
         .type = str
-        .help = "Filename to use, defaults to truncated.mtz or scaled_merged.mtz"
-                "depending on whether the data has been truncated."
+        .help = "Filename to use for mtz output."
 }
 include scope cctbx.french_wilson.master_phil
 """,
@@ -137,13 +136,6 @@ can be processed with dials.merge"""
 with dials.merge"""
                 % k
             )
-
-    # Decide a suitable output filename if using auto option.
-    if params.output.mtz in (None, Auto, "auto"):
-        if params.truncate:
-            params.output.mtz = "truncated.mtz"
-        else:
-            params.output.mtz = "scaled_merged.mtz"
 
     try:
         mtz_file = merge_data_to_mtz(params, experiments, reflections)

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -132,7 +132,7 @@ can be processed with dials.merge"""
         "intensity.scale.variance",
         "inverse_scale_factor",
     ]:
-        if not k in reflections[0]:
+        if k not in reflections[0]:
             raise Sorry(
                 """%s not found in the reflection table. Only scaled data can be processed
 with dials.merge"""

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -74,10 +74,15 @@ output {
         .help = "Filename to use for mtz output."
     crystal_names = XTAL
         .type = strings
+        .help = "Crystal name to be used in MTZ file output (multiple names
+            allowed for MAD datasets)"
     project_name = AUTOMATIC
         .type = str
+        .help = "Project name to be used in MTZ file output"
     dataset_names = NATIVE
         .type = strings
+        .help = "Dataset name to be used in MTZ file output (multiple names
+            allowed for MAD datasets)"
 }
 include scope cctbx.french_wilson.master_phil
 """,

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -617,6 +617,7 @@ def _export_merged_mtz(params, experiments, joint_table):
     merge_params.reporting.wilson_stats = False
     merge_params.reporting.merging_stats = False
     merge_params.assess_space_group = False
+    merge_params.partiality_threshold = params.cut_data.partiality_cutoff
     mtz_file = merge_data_to_mtz(merge_params, experiments, [joint_table])
     logger.info("\nWriting reflections to %s", (params.output.merged_mtz))
     out = StringIO()

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -8,7 +8,7 @@ import gc
 import json
 import libtbx
 from libtbx import phil
-from cStringIO import StringIO
+from six.moves import cStringIO as StringIO
 from dials.util import log, show_mail_on_error, Sorry
 from dials.array_family import flex
 from dials.util.options import OptionParser, flatten_reflections, flatten_experiments

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -418,7 +418,7 @@ prepare the data in the correct space group.\n"""
             logger.info("Finished running dials.cosym, continuing with scaling.\n")
 
         #### Make sure all experiments in same space group
-        sgs = [e.crystal.get_space_group().type().number() for e in experiments]
+        sgs = [expt.crystal.get_space_group().type().number() for expt in experiments]
         if len(set(sgs)) > 1:
             raise Sorry(
                 """The experiments have different space groups:

--- a/command_line/space_group.py
+++ b/command_line/space_group.py
@@ -208,8 +208,8 @@ def run(args=None):
     if not len(reflections) == 1:
         raise Sorry("Only one reflection table can be given as input.")
 
-    if (not "intensity.scale.value" in reflections[0]) and (
-        not "intensity.prf.value" in reflections[0]
+    if ("intensity.scale.value" not in reflections[0]) and (
+        "intensity.prf.value" not in reflections[0]
     ):
         raise Sorry(
             "Unable to find integrated or scaled reflections in the reflection table."

--- a/test/command_line/test_merge.py
+++ b/test/command_line/test_merge.py
@@ -23,8 +23,8 @@ def test_merge(dials_data, tmpdir):
     result = procrunner.run(command, working_directory=tmpdir)
     assert result.returncode == 0
     assert result.stderr == ""
-    assert tmpdir.join("truncated.mtz").check()
-    m = mtz.object(tmpdir.join("truncated.mtz").strpath)
+    assert tmpdir.join("merged.mtz").check()
+    m = mtz.object(tmpdir.join("merged.mtz").strpath)
     labels = []
     for ma in m.as_miller_arrays(merge_equivalents=False):
         labels.extend(ma.info().labels)
@@ -38,8 +38,8 @@ def test_merge(dials_data, tmpdir):
     result = procrunner.run(command, working_directory=tmpdir)
     assert result.returncode == 0
     assert result.stderr == ""
-    assert tmpdir.join("scaled_merged.mtz").check()
-    m = mtz.object(tmpdir.join("scaled_merged.mtz").strpath)
+    assert tmpdir.join("merged.mtz").check()
+    m = mtz.object(tmpdir.join("merged.mtz").strpath)
     labels = []
     for ma in m.as_miller_arrays(merge_equivalents=False):
         labels.extend(ma.info().labels)
@@ -53,8 +53,8 @@ def test_merge(dials_data, tmpdir):
     result = procrunner.run(command, working_directory=tmpdir)
     assert result.returncode == 0
     assert result.stderr == ""
-    assert tmpdir.join("truncated.mtz").check()
-    m = mtz.object(tmpdir.join("truncated.mtz").strpath)
+    assert tmpdir.join("merged.mtz").check()
+    m = mtz.object(tmpdir.join("merged.mtz").strpath)
     labels = []
     for ma in m.as_miller_arrays(merge_equivalents=False):
         labels.extend(ma.info().labels)
@@ -68,8 +68,8 @@ def test_merge(dials_data, tmpdir):
     result = procrunner.run(command, working_directory=tmpdir)
     assert result.returncode == 0
     assert result.stderr == ""
-    assert tmpdir.join("scaled_merged.mtz").check()
-    m = mtz.object(tmpdir.join("scaled_merged.mtz").strpath)
+    assert tmpdir.join("merged.mtz").check()
+    m = mtz.object(tmpdir.join("merged.mtz").strpath)
     labels = []
     for ma in m.as_miller_arrays(merge_equivalents=False):
         labels.extend(ma.info().labels)
@@ -127,8 +127,8 @@ def test_merge_multi_wavelength(dials_data, tmpdir):
     result = procrunner.run(command, working_directory=tmpdir)
     assert result.returncode == 0
     assert result.stderr == ""
-    assert tmpdir.join("truncated.mtz").check()
-    m = mtz.object(tmpdir.join("truncated.mtz").strpath)
+    assert tmpdir.join("merged.mtz").check()
+    m = mtz.object(tmpdir.join("merged.mtz").strpath)
     labels = []
     for ma in m.as_miller_arrays(merge_equivalents=False):
         labels.extend(ma.info().labels)

--- a/test/command_line/test_merge.py
+++ b/test/command_line/test_merge.py
@@ -20,7 +20,16 @@ def test_merge(dials_data, tmpdir):
     expts = location.join("scaled_20_25.expt").strpath
 
     # First try with defaults (truncate on, anomalous on)
-    command = ["dials.merge", refls, expts, "truncate=True", "anomalous=True"]
+    command = [
+        "dials.merge",
+        refls,
+        expts,
+        "truncate=True",
+        "anomalous=True",
+        "project_name=ham",
+        "crystal_name=jam",
+        "dataset_name=spam",
+    ]
     result = procrunner.run(command, working_directory=tmpdir)
     assert result.returncode == 0
     assert result.stderr == ""

--- a/test/command_line/test_merge.py
+++ b/test/command_line/test_merge.py
@@ -1,0 +1,160 @@
+"""Tests for dials.merge command line program."""
+import procrunner
+from iotbx import mtz
+from dxtbx.model.experiment_list import ExperimentListFactory
+from dials.array_family import flex
+
+
+def test_merge(dials_data, tmpdir):
+    """Test the command line script with LCY data"""
+    # Main options: truncate on/off, anomalous on/off
+
+    mean_labels = ["IMEAN", "SIGIMEAN"]
+    anom_labels = ["I(+)", "I(-)", "SIGI(+)", "SIGI(-)"]
+    amp_labels = ["F", "SIGF"]
+    anom_amp_labels = ["F(+)", "SIGF(+)", "F(-)", "SIGF(-)"]
+
+    location = dials_data("l_cysteine_4_sweeps_scaled")
+    refls = location.join("scaled_20_25.refl").strpath
+    expts = location.join("scaled_20_25.expt").strpath
+
+    # First try with defaults (truncate on, anomalous on)
+    command = ["dials.merge", refls, expts, "truncate=True", "anomalous=True"]
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert tmpdir.join("truncated.mtz").check()
+    m = mtz.object(tmpdir.join("truncated.mtz").strpath)
+    labels = []
+    for ma in m.as_miller_arrays(merge_equivalents=False):
+        labels.extend(ma.info().labels)
+    assert all(x in labels for x in mean_labels)
+    assert all(x in labels for x in anom_labels)
+    assert all(x in labels for x in amp_labels)
+    assert all(x in labels for x in anom_amp_labels)
+
+    # now try with no truncate option
+    command = ["dials.merge", refls, expts, "truncate=False", "anomalous=True"]
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert tmpdir.join("scaled_merged.mtz").check()
+    m = mtz.object(tmpdir.join("scaled_merged.mtz").strpath)
+    labels = []
+    for ma in m.as_miller_arrays(merge_equivalents=False):
+        labels.extend(ma.info().labels)
+    assert all(x in labels for x in mean_labels)
+    assert all(x in labels for x in anom_labels)
+    assert all(not x in labels for x in amp_labels)
+    assert all(not x in labels for x in anom_amp_labels)
+
+    # now try with no anomalous option
+    command = ["dials.merge", refls, expts, "anomalous=False", "truncate=True"]
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert tmpdir.join("truncated.mtz").check()
+    m = mtz.object(tmpdir.join("truncated.mtz").strpath)
+    labels = []
+    for ma in m.as_miller_arrays(merge_equivalents=False):
+        labels.extend(ma.info().labels)
+    assert all(x in labels for x in mean_labels)
+    assert all(not x in labels for x in anom_labels)
+    assert all(x in labels for x in amp_labels)
+    assert all(not x in labels for x in anom_amp_labels)
+
+    # now try with no truncate or anomalous
+    command = ["dials.merge", refls, expts, "truncate=False", "anomalous=False"]
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert tmpdir.join("scaled_merged.mtz").check()
+    m = mtz.object(tmpdir.join("scaled_merged.mtz").strpath)
+    labels = []
+    for ma in m.as_miller_arrays(merge_equivalents=False):
+        labels.extend(ma.info().labels)
+    assert all(x in labels for x in mean_labels)
+    assert all(not x in labels for x in anom_labels)
+    assert all(not x in labels for x in amp_labels)
+    assert all(not x in labels for x in anom_amp_labels)
+
+
+def test_merge_multi_wavelength(dials_data, tmpdir):
+    """Test that merge handles multi-wavelength data suitably - should be
+    exported into an mtz with seprate columns for each wavelength."""
+
+    mean_labels = ["%sIMEAN_WAVE%s" % (pre, i) for i in [1, 2] for pre in ["", "SIG"]]
+    anom_labels = [
+        "%sI_WAVE%s(%s)" % (pre, i, sgn)
+        for i in [1, 2]
+        for pre in ["", "SIG"]
+        for sgn in ["+", "-"]
+    ]
+    amp_labels = ["%sF_WAVE%s" % (pre, i) for i in [1, 2] for pre in ["", "SIG"]]
+    anom_amp_labels = [
+        "%sF_WAVE%s(%s)" % (pre, i, sgn)
+        for i in [1, 2]
+        for pre in ["", "SIG"]
+        for sgn in ["+", "-"]
+    ]
+
+    location = dials_data("l_cysteine_4_sweeps_scaled")
+    refl1 = location.join("scaled_30.refl").strpath
+    expt1 = location.join("scaled_30.expt").strpath
+    refl2 = location.join("scaled_35.refl").strpath
+    expt2 = location.join("scaled_35.expt").strpath
+    expts1 = ExperimentListFactory.from_json_file(expt1, check_format=False)
+    expts1[0].beam.set_wavelength(0.5)
+    expts2 = ExperimentListFactory.from_json_file(expt2, check_format=False)
+    expts1.extend(expts2)
+
+    tmp_expt = tmpdir.join("tmp.expt").strpath
+    expts1.as_json(tmp_expt)
+
+    reflections1 = flex.reflection_table.from_pickle(refl1)
+    reflections2 = flex.reflection_table.from_pickle(refl2)
+    # first need to resolve identifiers - usually done on loading
+    reflections2["id"] = flex.int(reflections2.size(), 1)
+    del reflections2.experiment_identifiers()[0]
+    reflections2.experiment_identifiers()[1] = "3"
+    reflections1.extend(reflections2)
+
+    tmp_refl = tmpdir.join("tmp.refl").strpath
+    reflections1.as_pickle(tmp_refl)
+
+    # Can now run after creating our 'fake' multiwavelength dataset
+    command = ["dials.merge", tmp_refl, tmp_expt, "truncate=True", "anomalous=True"]
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert tmpdir.join("truncated.mtz").check()
+    m = mtz.object(tmpdir.join("truncated.mtz").strpath)
+    labels = []
+    for ma in m.as_miller_arrays(merge_equivalents=False):
+        labels.extend(ma.info().labels)
+    assert all(x in labels for x in mean_labels)
+    assert all(x in labels for x in anom_labels)
+    assert all(x in labels for x in amp_labels)
+    assert all(x in labels for x in anom_amp_labels)
+
+
+def test_merge_bad_input(dials_data, tmpdir):
+    """Test suitable exit for bad input."""
+    location = dials_data("vmxi_proteinase_k_sweeps")
+
+    command = ["dials.merge", "output.experiments=symmetrized.expt"]
+    command.append(location.join("experiments_0.json").strpath)
+    command.append(location.join("reflections_0.pickle").strpath)
+
+    # unscaled data
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert result.returncode == 1
+    assert result.stderr.startswith("Sorry")
+
+    command.append(location.join("experiments_1.json").strpath)
+    command.append(location.join("reflections_1.pickle").strpath)
+
+    # more than one reflection table.
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert result.returncode == 1
+    assert result.stderr.startswith("Sorry")

--- a/test/command_line/test_merge.py
+++ b/test/command_line/test_merge.py
@@ -1,4 +1,5 @@
 """Tests for dials.merge command line program."""
+import pytest
 import procrunner
 from iotbx import mtz
 from dxtbx.model.experiment_list import ExperimentListFactory
@@ -25,6 +26,8 @@ def test_merge(dials_data, tmpdir):
     assert result.stderr == ""
     assert tmpdir.join("merged.mtz").check()
     m = mtz.object(tmpdir.join("merged.mtz").strpath)
+
+    assert m.as_miller_arrays()[0].info().wavelength == pytest.approx(0.6889)
     labels = []
     for ma in m.as_miller_arrays(merge_equivalents=False):
         labels.extend(ma.info().labels)
@@ -136,6 +139,10 @@ def test_merge_multi_wavelength(dials_data, tmpdir):
     assert all(x in labels for x in anom_labels)
     assert all(x in labels for x in amp_labels)
     assert all(x in labels for x in anom_amp_labels)
+
+    # 5 miller arrays for each dataset
+    assert m.as_miller_arrays()[0].info().wavelength == pytest.approx(0.5)
+    assert m.as_miller_arrays()[5].info().wavelength == pytest.approx(0.6889)
 
 
 def test_merge_bad_input(dials_data, tmpdir):

--- a/test/command_line/test_merge.py
+++ b/test/command_line/test_merge.py
@@ -45,8 +45,8 @@ def test_merge(dials_data, tmpdir):
         labels.extend(ma.info().labels)
     assert all(x in labels for x in mean_labels)
     assert all(x in labels for x in anom_labels)
-    assert all(not x in labels for x in amp_labels)
-    assert all(not x in labels for x in anom_amp_labels)
+    assert all(x not in labels for x in amp_labels)
+    assert all(x not in labels for x in anom_amp_labels)
 
     # now try with no anomalous option
     command = ["dials.merge", refls, expts, "anomalous=False", "truncate=True"]
@@ -59,9 +59,9 @@ def test_merge(dials_data, tmpdir):
     for ma in m.as_miller_arrays(merge_equivalents=False):
         labels.extend(ma.info().labels)
     assert all(x in labels for x in mean_labels)
-    assert all(not x in labels for x in anom_labels)
+    assert all(x not in labels for x in anom_labels)
     assert all(x in labels for x in amp_labels)
-    assert all(not x in labels for x in anom_amp_labels)
+    assert all(x not in labels for x in anom_amp_labels)
 
     # now try with no truncate or anomalous
     command = ["dials.merge", refls, expts, "truncate=False", "anomalous=False"]
@@ -74,9 +74,9 @@ def test_merge(dials_data, tmpdir):
     for ma in m.as_miller_arrays(merge_equivalents=False):
         labels.extend(ma.info().labels)
     assert all(x in labels for x in mean_labels)
-    assert all(not x in labels for x in anom_labels)
-    assert all(not x in labels for x in amp_labels)
-    assert all(not x in labels for x in anom_amp_labels)
+    assert all(x not in labels for x in anom_labels)
+    assert all(x not in labels for x in amp_labels)
+    assert all(x not in labels for x in anom_amp_labels)
 
 
 def test_merge_multi_wavelength(dials_data, tmpdir):

--- a/util/export_mtz.py
+++ b/util/export_mtz.py
@@ -115,25 +115,6 @@ class MADMergedMTZWriter(MergedMTZWriter):
         )
 
 
-def make_merged_mtz_file(
-    merged_array,
-    merged_anomalous_array=None,
-    amplitudes=None,
-    anomalous_amplitudes=None,
-):
-    """Make an mtz object for the data, adding the date, time and program."""
-
-    assert merged_array.is_xray_intensity_array()
-
-    mtz_writer = MergedMTZWriter(merged_array.space_group(), merged_array.unit_cell())
-    mtz_writer.add_crystal(crystal_name="DIALS")
-    mtz_writer.add_dataset(
-        merged_array, merged_anomalous_array, amplitudes, anomalous_amplitudes
-    )
-
-    return mtz_writer.mtz_file
-
-
 def _add_batch(
     mtz,
     experiment,


### PR DESCRIPTION
This pull request introduces dials.merge, a command line program to create a merged, truncated mtz from scaled.refl, scaled.expt. This merges the data, truncates using the french_wilson miller array method, prints the Wilson statistics and merging statistics before exporting to mtz. Fixes #826 
If multi-wavelength data is present, the merged mtz contains two datasets, one for each wavelength.

There will be an equivalent pull request to update the dials-full pipeline in xia2 to use the updated programs which should be merged at the same time.

dials.merge main options (and defaults);

- truncate = True (turn off to not truncate - no Fs in output just Is). Turning off changes default filename from truncated.mtz to scaled_merged.mtz

- anomalous = True (turn off to only output mean Is & Fs)

- assess_space_group = True (currently runs dials.space_group, in future when all is rolled into dials.symmetry, it would run dials.symmetry but maybe False by default)


As part of this work, dials.scale was also simplified to call the new dials.merge code to improve consistency, as well as removing a few hacky options that were put in for xia2 that are now redundant.

With these (and recent) changes, the post-integration workflow is as follows:
![post_integration_workflow](https://user-images.githubusercontent.com/30625594/61544785-08922300-aa3e-11e9-8f1a-a76dba20c702.png)

Example of default mtz output (thaumatin example dataset):
```
Writing reflections to truncated.mtz
Title: From dials.merge
Space group symbol from file: P41212
Space group number from file: 92
Space group from matrices: P 41 21 2 (No. 92)
Point group symbol from file: 422
Number of crystals: 1
Number of Miller indices: 71077
Resolution range: 150.001 1.16996
History:
  From DIALS 2.dev.568-gac9b16a59, run on 2019-07-19 at 15:18:43 BST  (2019-07-19
Crystal 1:
  Name: DIALS
  Project: DIALS
  Id: 1
  Unit cell: (57.7835, 57.7835, 150.001, 90, 90, 90)
  Number of datasets: 1
  Dataset 1:
    Name: FROMDIALS
    Id: 1
    Wavelength: 1
    Number of columns: 17
    label    #valid  %valid   min     max type
    H         71077 100.00%  0.00   47.00 H: index h,k,l
    K         71077 100.00%  0.00   33.00 H: index h,k,l
    L         71077 100.00%  0.00  114.00 H: index h,k,l
    IMEAN     71077 100.00% -7.67 4040.99 J: intensity
    SIGIMEAN  71077 100.00%  0.01   61.38 Q: standard deviation
    I(+)      69611  97.94% -7.67 4040.99 K: I(+) or I(-)
    SIGI(+)   69611  97.94%  0.01   61.38 M: standard deviation
    I(-)      56579  79.60% -7.72 3049.79 K: I(+) or I(-)
    SIGI(-)   56579  79.60%  0.22   46.70 M: standard deviation
    N(+)      69611  97.94%  2.00    8.00 I: integer
    N(-)      56579  79.60%  8.00    8.00 I: integer
    F         71070  99.99%  0.03   63.50 F: amplitude
    SIGF      71070  99.99%  0.02    1.05 Q: standard deviation
    F(+)      69607  97.93%  0.03   63.50 G: F(+) or F(-)
    SIGF(+)   69607  97.93%  0.02    1.05 L: standard deviation
    F(-)      56575  79.60%  0.56   55.14 G: F(+) or F(-)
    SIGF(-)   56575  79.60%  0.07    0.87 L: standard deviation
```