### PR TITLE
Python 3: fix dictionary iteration from C++

### DIFF
--- a/array_family/boost_python/flex_reflection_table.cc
+++ b/array_family/boost_python/flex_reflection_table.cc
@@ -909,10 +909,11 @@ namespace dials { namespace af { namespace boost_python {
       // Extract the columns
       dict columns = extract<dict>(state[3]);
       DIALS_ASSERT(len(columns) == ncols);
-      object iterator = boost::python::import("six").attr("iteritems")(columns);
+      object items = list(columns.items());
       object self_obj(self);
+      DIALS_ASSERT(len(items) == ncols);
       for (std::size_t i = 0; i < ncols; ++i) {
-        object item = boost::python::import("six").attr("next")(iterator);
+        object item = items[i];
         DIALS_ASSERT(len(item[1]) == nrows);
         std::string name = extract<std::string>(item[0]);
         self_obj[name] = item[1];
@@ -926,9 +927,10 @@ namespace dials { namespace af { namespace boost_python {
 
       // Extract the identifiers
       dict identifiers = extract<dict>(state[1]);
-      object identifier_iterator = boost::python::import("six").attr("iteritems")(identifiers);
+      object identifier_items = list(identifiers.items());
+      DIALS_ASSERT(len(identifier_items) == len(identifiers));
       for (std::size_t i = 0; i < len(identifiers); ++i) {
-        object item = boost::python::import("six").attr("next")(identifier_iterator);
+        object item = identifier_items[i];
         std::size_t index = extract<std::size_t>(item[0]);
         std::string ident = extract<std::string>(item[1]);
         (*self.experiment_identifiers())[index] = ident;
@@ -942,10 +944,11 @@ namespace dials { namespace af { namespace boost_python {
       // Extract the columns
       dict columns = extract<dict>(state[4]);
       DIALS_ASSERT(len(columns) == ncols);
-      object iterator = boost::python::import("six").attr("iteritems")(columns);
+      object items = list(columns.items());
       object self_obj(self);
+      DIALS_ASSERT(len(items) == ncols);
       for (std::size_t i = 0; i < ncols; ++i) {
-        object item = boost::python::import("six").attr("next")(iterator);
+        object item = items[i];
         DIALS_ASSERT(len(item[1]) == nrows);
         std::string name = extract<std::string>(item[0]);
         self_obj[name] = item[1];

--- a/array_family/boost_python/flex_reflection_table.cc
+++ b/array_family/boost_python/flex_reflection_table.cc
@@ -909,10 +909,10 @@ namespace dials { namespace af { namespace boost_python {
       // Extract the columns
       dict columns = extract<dict>(state[3]);
       DIALS_ASSERT(len(columns) == ncols);
-      object iterator = columns.iteritems();
+      object iterator = boost::python::import("six").attr("iteritems")(columns);
       object self_obj(self);
       for (std::size_t i = 0; i < ncols; ++i) {
-        object item = iterator.attr("next")();
+        object item = boost::python::import("six").attr("next")(iterator);
         DIALS_ASSERT(len(item[1]) == nrows);
         std::string name = extract<std::string>(item[0]);
         self_obj[name] = item[1];
@@ -926,9 +926,9 @@ namespace dials { namespace af { namespace boost_python {
 
       // Extract the identifiers
       dict identifiers = extract<dict>(state[1]);
-      object identifier_iterator = identifiers.iteritems();
+      object identifier_iterator = boost::python::import("six").attr("iteritems")(identifiers);
       for (std::size_t i = 0; i < len(identifiers); ++i) {
-        object item = identifier_iterator.attr("next")();
+        object item = boost::python::import("six").attr("next")(identifier_iterator);
         std::size_t index = extract<std::size_t>(item[0]);
         std::string ident = extract<std::string>(item[1]);
         (*self.experiment_identifiers())[index] = ident;
@@ -942,10 +942,10 @@ namespace dials { namespace af { namespace boost_python {
       // Extract the columns
       dict columns = extract<dict>(state[4]);
       DIALS_ASSERT(len(columns) == ncols);
-      object iterator = columns.iteritems();
+      object iterator = boost::python::import("six").attr("iteritems")(columns);
       object self_obj(self);
       for (std::size_t i = 0; i < ncols; ++i) {
-        object item = iterator.attr("next")();
+        object item = boost::python::import("six").attr("next")(iterator);
         DIALS_ASSERT(len(item[1]) == nrows);
         std::string name = extract<std::string>(item[0]);
         self_obj[name] = item[1];

--- a/array_family/boost_python/flex_table_suite.h
+++ b/array_family/boost_python/flex_table_suite.h
@@ -438,9 +438,9 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
       scitbx::boost_python::raise_index_error();
     }
     typedef typename T::iterator iterator;
-    object iteritems = row.iteritems();
+    object iteritems = boost::python::import("six").attr("iteritems")(row);
     for (std::size_t i = 0; i < len(row); ++i) {
-      object item = iteritems.attr("next")();
+      object item = boost::python::import("six").attr("next")(iteritems);
       setitem_row_visitor visitor(n, item[1]);
       iterator it = self.find(extract<std::string>(item[0]));
       DIALS_ASSERT(it != self.end());
@@ -1112,10 +1112,10 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
       // Extract the columns
       dict columns = extract<dict>(state[3]);
       DIALS_ASSERT(len(columns) == ncols);
-      object iterator = columns.iteritems();
+      object iterator = boost::python::import("six").attr("iteritems")(columns);
       object self_obj(self);
       for (std::size_t i = 0; i < ncols; ++i) {
-        object item = iterator.attr("next")();
+        object item = boost::python::import("six").attr("next")(iterator);
         DIALS_ASSERT(len(item[1]) == nrows);
         std::string name = extract<std::string>(item[0]);
         self_obj[name] = item[1];

--- a/array_family/boost_python/flex_table_suite.h
+++ b/array_family/boost_python/flex_table_suite.h
@@ -438,9 +438,10 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
       scitbx::boost_python::raise_index_error();
     }
     typedef typename T::iterator iterator;
-    object iteritems = boost::python::import("six").attr("iteritems")(row);
+    object items = list(row.items());
+    DIALS_ASSERT(len(items) == len(row));
     for (std::size_t i = 0; i < len(row); ++i) {
-      object item = boost::python::import("six").attr("next")(iteritems);
+      object item = items[i];
       setitem_row_visitor visitor(n, item[1]);
       iterator it = self.find(extract<std::string>(item[0]));
       DIALS_ASSERT(it != self.end());
@@ -1112,10 +1113,11 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
       // Extract the columns
       dict columns = extract<dict>(state[3]);
       DIALS_ASSERT(len(columns) == ncols);
-      object iterator = boost::python::import("six").attr("iteritems")(columns);
+      object items = list(columns.items());
+      DIALS_ASSERT(len(items) == ncols);
       object self_obj(self);
       for (std::size_t i = 0; i < ncols; ++i) {
-        object item = boost::python::import("six").attr("next")(iterator);
+        object item = items[i];
         DIALS_ASSERT(len(item[1]) == nrows);
         std::string name = extract<std::string>(item[0]);
         self_obj[name] = item[1];

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -16,13 +16,15 @@ import operator
 import warnings
 
 import boost.python
-from dials_array_family_flex_ext import *
+import cctbx
+import libtbx.smart_open
+import six
+import six.moves.cPickle as pickle
 from cctbx.array_family.flex import *
 from cctbx.array_family import flex
-import cctbx
 from cctbx import miller
+from dials_array_family_flex_ext import *
 from dials.util import Sorry
-import libtbx.smart_open
 from scitbx import matrix
 
 logger = logging.getLogger(__name__)
@@ -219,12 +221,13 @@ class reflection_table_aux(boost.python.injector, reflection_table):
         :return: The reflection table
 
         """
-        import six.moves.cPickle as pickle
-
         if filename and hasattr(filename, "__fspath__"):
             filename = filename.__fspath__()
         with libtbx.smart_open.for_reading(filename, "rb") as infile:
-            result = pickle.load(infile)
+            if six.PY3:
+                result = pickle.load(infile, encoding="bytes")
+            else:
+                result = pickle.load(infile)
             assert isinstance(result, reflection_table)
             return result
 
@@ -394,8 +397,6 @@ class reflection_table_aux(boost.python.injector, reflection_table):
         :param filename: The output filename
 
         """
-        import six.moves.cPickle as pickle
-
         # Clean up any removed experiments from the identifiers map
         self.clean_experiment_identifiers_map()
 


### PR DESCRIPTION
We call `dict.iteritems()` and `.next()` on its return value from within C++.
Both `.iteritems()` and `.next()` will be gone in Python 3.

As far as I can tell a _good_ solution for the 5 instances we do this would be to iterate over the dictionary, then use dictionary key access to get the relevant value.

However I could not figure this out, so I did something dumb instead: I call `six.iteritems()` on the dictionary, and `six.next()` on the return value. This is not optimal for many reasons, least of all the function lookup in the inner loop. However as far as I know the dictionaries in question have a fixed size and are relatively small, so the impact should be limited. This solution does have the benefit of working in both Python 2 and 3.

Maybe someone with better domain knowledge can come up with a better solution?