### PR TITLE
ignore all forms of refinement in stills indexer

### DIFF
--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -169,12 +169,13 @@ indexing {
     .type = bool
     .expert_level = 1
   refinement_protocol {
-    mode = *refine_shells repredict_only
+    mode = *refine_shells repredict_only None
       .type = choice
       .expert_level = 1
       .help = "refine_shells: refine in increasing resolution cutoffs after indexing."
               "repredict_only: do not refine after indexing, just update spot"
               "predictions."
+              "None: turns off all forms of refinement (currently only applies to stills_indexer)"
     n_macro_cycles = 5
       .type = int(value_min=1)
       .help = "Maximum number of macro cycles of refinement, reindexing all"

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -358,6 +358,9 @@ class StillsIndexer(Indexer):
                 )
                 ref_predictor(refined_reflections)
 
+            elif self.params.refinement_protocol.mode is None:
+                refined_experiments, refined_reflections = experiments, reflections_for_refinement
+
             else:
                 try:
                     refined_experiments, refined_reflections = self.refine(


### PR DESCRIPTION
This is useful when one wants to use stills
indexer yet only wants the orientation matrices
and does not wish to bother with refinement
of orientation matrix or nave parameters

To add to this, I am currently using code that involves using dials to grab the orientation matrices after spot finding... Its using an modification of real space grid search, where one has multiple beams per crystal (for e.g. two color MAD images) ..  

You can see the basic idea [here](https://github.com/dermen/cxid9114/blob/master/indexing/msi.py)

Currently stills_indexer fails with ```refinement_protocol = repredict_only``` because nave parameter refinement that is used for the predictions does not handle the case of two beams and one crystal (and besides that I don't wish to use the nave parameters predictions even if they were to work). Further, refinement has a high failure rate with the *multiple beams / one crystal* type of experiments.. Therefore I wish to just snag the orientation matrix and get out of the indexer... 