### PR TITLE
Low res spot match indexing

### DIFF
--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -449,6 +449,16 @@ class Indexer(object):
 
                 idxr = BasisVectorSearch(reflections, experiments, params=params)
 
+            if params.indexing.method in ("low_res_spot_match",):
+                if use_stills_indexer:
+                    from dials.algorithms.indexing.stills_indexer import (
+                        StillsIndexerLatticeSearch as LatticeSearch,
+                    )
+                else:
+                    from dials.algorithms.indexing.lattice_search import LatticeSearch
+
+                idxr = LatticeSearch(reflections, experiments, params=params)
+
         return idxr
 
     def _setup_symmetry(self):

--- a/algorithms/indexing/lattice_search.py
+++ b/algorithms/indexing/lattice_search.py
@@ -129,6 +129,7 @@ class LatticeSearch(indexer.Indexer):
         if strategy_class is not None:
             self._lattice_search_strategy = strategy_class(
                 target_symmetry_primitive=self._symmetry_handler.target_symmetry_primitive,
+                max_lattices=self.params.basis_vector_combinations.max_refine,
                 params=getattr(self.params, entry_point.name),
             )
         else:
@@ -136,11 +137,12 @@ class LatticeSearch(indexer.Indexer):
 
     def find_candidate_crystal_models(self):
 
-        self.candidate_crystal_models = []
-        if self._basis_vector_search_strategy:
-            self.candidate_crystal_models = self._basis_vector_search_strategy.find_crystal_models(
-                self.reflections
+        candidate_crystal_models = []
+        if self._lattice_search_strategy:
+            candidate_crystal_models = self._lattice_search_strategy.find_crystal_models(
+                self.reflections, self.experiments
             )
+        return candidate_crystal_models
 
     def find_lattices(self):
         self.candidate_crystal_models = self.find_candidate_crystal_models()

--- a/algorithms/indexing/lattice_search.py
+++ b/algorithms/indexing/lattice_search.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import, division
 from __future__ import print_function
 
+import itertools
 import logging
 import math
 
@@ -86,8 +87,9 @@ basis_vector_search_phil_scope = libtbx.phil.parse(basis_vector_search_phil_str)
 import pkg_resources
 
 methods = []
-for entry_point in pkg_resources.iter_entry_points(
-    "dials.index.basis_vector_search_strategy"
+for entry_point in itertools.chain(
+    pkg_resources.iter_entry_points("dials.index.basis_vector_search_strategy"),
+    pkg_resources.iter_entry_points("dials.index.lattice_search_strategy"),
 ):
     scope = (
         """\

--- a/algorithms/indexing/lattice_search_strategies.py
+++ b/algorithms/indexing/lattice_search_strategies.py
@@ -1,0 +1,79 @@
+"""Lattice search strategies."""
+
+from __future__ import absolute_import, division
+from __future__ import print_function
+
+import abc
+import logging
+
+from libtbx import phil
+
+logger = logging.getLogger(__name__)
+
+
+class Strategy(object):
+    """A base class for lattice search strategies."""
+
+    __metaclass__ = abc.ABCMeta
+
+    phil_scope = None
+
+    def __init__(self, params=None, *args, **kwargs):
+        """Construct the strategy.
+
+        Args:
+            params: an extracted PHIL scope containing the parameters
+
+        """
+        self._params = params
+        if self._params is None and self.phil_scope is not None:
+            self._params = self.phil_scope.extract()
+
+    @abc.abstractmethod
+    def find_crystal_models(self, reflections):
+        """Find a list of likely crystal models.
+
+        Args:
+            reflections (dials.array_family.flex.reflection_table):
+                The found spots centroids and associated data
+
+        Returns:
+            A list of candidate crystal models.
+
+        """
+        pass
+
+
+low_res_spot_match_phil_str = """\
+
+"""
+
+
+class LowResSpotMatch(Strategy):
+    """Lattice search by matching low resolution spots to candidate indices
+    based on resolution and reciprocal space distance between observed spots.
+    """
+
+    phil_scope = phil.parse(low_res_spot_match_phil_str)
+
+    def __init__(self, target_symmetry_primitive, params=None, *args, **kwargs):
+        """Construct a real_space_grid_search object.
+
+        Args:
+            target_symmetry_primitive (cctbx.crystal.symmetry): The target
+                crystal symmetry and unit cell
+
+        """
+        super(LowResSpotMatch, self).__init__(params=params, *args, **kwargs)
+        self._target_symmetry_primitive = target_symmetry_primitive
+
+    def find_crystal_models(self, reflections):
+        """Find a list of candidate crystal models.
+
+        Args:
+            reflections (dials.array_family.flex.reflection_table):
+                The found spots centroids and associated data
+
+        """
+
+        return []

--- a/algorithms/indexing/lattice_search_strategies.py
+++ b/algorithms/indexing/lattice_search_strategies.py
@@ -6,7 +6,18 @@ from __future__ import print_function
 import abc
 import logging
 
+import copy
+from math import pi, sqrt
+import cctbx.miller
+from dials.array_family import flex
+import operator
+from scitbx import matrix
+from scitbx.math import superpose, least_squares_plane
+from dxtbx.model import Crystal
 from libtbx import phil
+
+TWO_PI = 2.0 * pi
+FIVE_DEG = TWO_PI * 5.0 / 360.0
 
 logger = logging.getLogger(__name__)
 
@@ -30,12 +41,15 @@ class Strategy(object):
             self._params = self.phil_scope.extract()
 
     @abc.abstractmethod
-    def find_crystal_models(self, reflections):
+    def find_crystal_models(self, reflections, experiments):
         """Find a list of likely crystal models.
 
         Args:
             reflections (dials.array_family.flex.reflection_table):
                 The found spots centroids and associated data
+
+            experiments (dxtbx.model.experiment_list.ExperimentList):
+                The experimental geometry models
 
         Returns:
             A list of candidate crystal models.
@@ -44,8 +58,98 @@ class Strategy(object):
         pass
 
 
-low_res_spot_match_phil_str = """\
+class CompleteGraph(object):
+    def __init__(self, seed_vertex):
 
+        self.vertices = [seed_vertex]
+        self.weight = [{0: 0.0}]
+        self.total_weight = 0.0
+
+    def factory_add_vertex(self, vertex, weights_to_other):
+        # Return a new graph as a copy of this with an extra vertex added. This
+        # is a factory rather than a change in-place because CompleteGraph ought
+        # to be immutable to implement __hash__
+        g = copy.deepcopy(self)
+
+        current_len = len(g.vertices)
+        assert len(weights_to_other) == current_len
+        g.vertices.append(vertex)
+        node = current_len
+
+        # Update distances from other nodes to the new one
+        for i, w in enumerate(weights_to_other):
+            g.weight[i][node] = w
+
+        # Add distances to other nodes from this one
+        weights_to_other.append(0.0)
+        to_other = {}
+        for i, w in enumerate(weights_to_other):
+            to_other[i] = w
+        g.weight.append(to_other)
+
+        # Update the total weight
+        g.total_weight += sum(weights_to_other)
+
+        # Sort the vertices and weights by spot_id
+        l = zip(g.vertices, g.weight)
+        l.sort(key=lambda v_w: v_w[0]["spot_id"])
+        v, w = zip(*l)
+        g.vertices = [e for e in v]
+        g.weight = [e for e in w]
+
+        return g
+
+    def __hash__(self):
+        h = tuple((e["spot_id"], e["miller_index"]) for e in self.vertices)
+        return hash(h)
+
+    def __eq__(self, other):
+        for a, b in zip(self.vertices, other.vertices):
+            if a["spot_id"] != b["spot_id"]:
+                return False
+            if a["miller_index"] != b["miller_index"]:
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not self == other
+
+
+low_res_spot_match_phil_str = """\
+candidate_spots
+{
+    limit_resolution_by = *n_spots d_min
+    .type = choice
+
+    d_min = 15.0
+    .type = float(value_min=0)
+
+    n_spots = 10
+    .type = int
+
+    dstar_tolerance = 4.0
+    .help = "Number of sigmas from the centroid position for which to"
+            "calculate d* bands"
+    .type = float
+}
+
+use_P1_indices_as_seeds = False
+    .type = bool
+
+search_depth = *triplets quads
+    .type = choice
+
+bootstrap_crystal = False
+    .type = bool
+
+max_pairs = 200
+    .type = int
+
+max_triplets = 600
+    .type = int
+
+max_quads = 600
+    .type = int
 """
 
 
@@ -56,24 +160,452 @@ class LowResSpotMatch(Strategy):
 
     phil_scope = phil.parse(low_res_spot_match_phil_str)
 
-    def __init__(self, target_symmetry_primitive, params=None, *args, **kwargs):
+    def __init__(
+        self, target_symmetry_primitive, max_lattices, params=None, *args, **kwargs
+    ):
         """Construct a real_space_grid_search object.
 
         Args:
             target_symmetry_primitive (cctbx.crystal.symmetry): The target
                 crystal symmetry and unit cell
 
+            max_lattices (int): The maximum number of lattice models to find
+
         """
         super(LowResSpotMatch, self).__init__(params=params, *args, **kwargs)
         self._target_symmetry_primitive = target_symmetry_primitive
+        self._max_lattices = max_lattices
 
-    def find_crystal_models(self, reflections):
+        # Set reciprocal space orthogonalisation matrix
+        uc = self._target_symmetry_primitive.unit_cell()
+        self.Bmat = matrix.sqr(uc.fractionalization_matrix()).transpose()
+
+    def find_crystal_models(self, reflections, experiments):
         """Find a list of candidate crystal models.
 
         Args:
             reflections (dials.array_family.flex.reflection_table):
                 The found spots centroids and associated data
 
+            experiments (dxtbx.model.experiment_list.ExperimentList):
+                The experimental geometry models
+
         """
 
-        return []
+        # Take a subset of the observations at the same resolution and calculate
+        # some values that will be needed for the search
+        self._calc_obs_data(reflections, experiments)
+
+        # Construct a library of candidate low res indices with their d* values
+        self._calc_candidate_hkls()
+
+        # First search: match each observation with candidate indices within the
+        # acceptable resolution band
+        self._calc_seeds_and_stems()
+        if self._params.use_P1_indices_as_seeds:
+            seeds = self.stems
+        else:
+            seeds = self.seeds
+        logger.info("Using {0} seeds".format(len(seeds)))
+
+        # Second search: match seed spots with another spot from a different
+        # reciprocal lattice row, such that the observed reciprocal space distances
+        # are within tolerances
+        pairs = []
+        for seed in seeds:
+            pairs.extend(self._pairs_with_seed(seed))
+        logger.info("Found {0} pairs".format(len(pairs)))
+        pairs = list(set(pairs))  # filter duplicates
+
+        if self._params.max_pairs:
+            pairs.sort(key=operator.attrgetter("total_weight"))
+            idx = self._params.max_pairs
+            pairs = pairs[0:idx]
+        logger.info("Using {0} highest-scoring pairs".format(len(pairs)))
+
+        # Further search iterations: extend to more spots within tolerated distances
+        triplets = []
+        for pair in pairs:
+            triplets.extend(self._extend_by_candidates(pair))
+        logger.info("Found {0} triplets".format(len(triplets)))
+        triplets = list(set(triplets))  # filter duplicates
+        if self._params.max_triplets:
+            triplets.sort(key=operator.attrgetter("total_weight"))
+            idx = self._params.max_triplets
+            triplets = triplets[0:idx]
+        logger.info("Using {0} highest-scoring triplets".format(len(triplets)))
+
+        branches = triplets
+        if self._params.search_depth == "quads":
+            quads = []
+            for triplet in triplets:
+                quads.extend(self._extend_by_candidates(triplet))
+            logger.info("{0} quads".format(len(quads)))
+            quads = list(set(quads))  # filter duplicates
+            if self._params.max_quads:
+                quads.sort(key=operator.attrgetter("total_weight"))
+                idx = self._params.max_quads
+                quads = quads[0:idx]
+            logger.info("Using {0} highest-scoring quads".format(len(quads)))
+            branches = quads
+
+        # Sort branches by total deviation of observed distances from expected
+        branches.sort(key=operator.attrgetter("total_weight"))
+
+        candidate_crystal_models = []
+        for branch in branches:
+            model = self._fit_crystal_model(branch)
+            if model:
+                candidate_crystal_models.append(model)
+            if len(candidate_crystal_models) == self._max_lattices:
+                break
+
+        self.candidate_crystal_models = candidate_crystal_models
+        return self.candidate_crystal_models
+
+    def _calc_candidate_hkls(self):
+        # 1 ASU
+        hkl_list = cctbx.miller.build_set(
+            self._target_symmetry_primitive,
+            anomalous_flag=False,
+            d_min=self._params.candidate_spots.d_min,
+        )
+        rt = flex.reflection_table()
+        rt["miller_index"] = hkl_list.indices()
+        rt["dstar"] = 1.0 / hkl_list.d_spacings().data()
+        rt["rlp_datum"] = self.Bmat.elems * rt["miller_index"].as_vec3_double()
+        self.candidate_hkls = rt
+
+        # P1 indices with separate Friedel pairs
+        hkl_list = cctbx.miller.build_set(
+            self._target_symmetry_primitive,
+            anomalous_flag=True,
+            d_min=self._params.candidate_spots.d_min,
+        )
+        hkl_list_p1 = hkl_list.expand_to_p1()
+        rt = flex.reflection_table()
+        rt["miller_index"] = hkl_list_p1.indices()
+        rt["dstar"] = 1.0 / hkl_list_p1.d_spacings().data()
+        rt["rlp_datum"] = self.Bmat.elems * rt["miller_index"].as_vec3_double()
+        self.candidate_hkls_p1 = rt
+        return
+
+    def _calc_obs_data(self, reflections, experiments):
+        """Calculates a set of low resolution observations to try to match to
+    indices. Each observation will record its d* value as well as
+    tolerated d* bands and a 'clock angle'"""
+
+        spot_dstar = reflections["rlp"].norms()
+        if self._params.candidate_spots.limit_resolution_by == "n_spots":
+            n_spots = self._params.candidate_spots.n_spots
+            n_spots = min(n_spots, len(reflections) - 1)
+            dstar_max = flex.sorted(spot_dstar)[n_spots - 1]
+            self._params.candidate_spots.d_min = 1.0 / dstar_max
+
+        # First select low resolution spots only
+        spot_dstar = reflections["rlp"].norms()
+        dstar_max = 1.0 / self._params.candidate_spots.d_min
+        sel = spot_dstar <= dstar_max
+        self.spots = reflections.select(sel)
+        self.spots["dstar"] = spot_dstar.select(sel)
+
+        # XXX In what circumstance might there be more than one experiment?
+        detector = experiments.detectors()[0]
+        beam = experiments.beams()[0]
+
+        # Lab coordinate of the beam centre, using the first spot's panel
+        panel = detector[self.spots[0]["panel"]]
+        bc = panel.get_ray_intersection(beam.get_s0())
+        bc_lab = panel.get_lab_coord(bc)
+
+        # Lab coordinate of each spot
+        spot_lab = flex.vec3_double(len(self.spots))
+        pnl_ids = set(self.spots["panel"])
+        for pnl in pnl_ids:
+            sel = self.spots["panel"] == pnl
+            panel = detector[pnl]
+            obs = self.spots["xyzobs.mm.value"].select(sel)
+            x_mm, y_mm, _ = obs.parts()
+            spot_lab.set_selected(
+                sel, panel.get_lab_coord(flex.vec2_double(x_mm, y_mm))
+            )
+
+        # Radius vectors for each spot
+        radius = spot_lab - bc_lab
+
+        # Usually the radius vectors would all be in a single plane, but this might
+        # not be the case if the spots are on different panels. To put them on the
+        # same plane, project onto fast/slow of the panel used to get the beam
+        # centre
+        df = flex.vec3_double(len(self.spots), detector[0].get_fast_axis())
+        ds = flex.vec3_double(len(self.spots), detector[0].get_slow_axis())
+        clock_dirs = (radius.dot(df) * df + radius.dot(ds) * ds).each_normalize()
+
+        # From this, find positive angles of each vector around a clock, using the
+        # fast axis as 12 o'clock
+        angs = clock_dirs.angle(detector[0].get_fast_axis())
+        dots = clock_dirs.dot(detector[0].get_slow_axis())
+        sel = dots < 0  # select directions in the second half of the clock face
+        angs.set_selected(sel, (TWO_PI - angs.select(sel)))
+        self.spots["clock_angle"] = angs
+
+        # Project radius vectors onto fast/slow of the relevant panels
+        df = flex.vec3_double(len(self.spots))
+        ds = flex.vec3_double(len(self.spots))
+        for pnl in pnl_ids:
+            sel = self.spots["panel"] == pnl
+            panel = detector[pnl]
+            df.set_selected(sel, panel.get_fast_axis())
+            ds.set_selected(sel, panel.get_slow_axis())
+        panel_dirs = (radius.dot(df) * df + radius.dot(ds) * ds).each_normalize()
+
+        # Calc error along each panel direction with simple error propagation
+        # that assumes no covariance between x and y centroid errors.
+        x = panel_dirs.dot(df)
+        y = panel_dirs.dot(ds)
+        x2, y2 = flex.pow2(x), flex.pow2(y)
+        r2 = x2 + y2
+        sig_x2, sig_y2, _ = self.spots["xyzobs.mm.variance"].parts()
+        var_r = (x2 / r2) * sig_x2 + (y2 / r2) * sig_y2
+        sig_r = flex.sqrt(var_r)
+
+        # Pixel coordinates at limits of the band
+        tol = self._params.candidate_spots.dstar_tolerance
+        outer_spot_lab = spot_lab + panel_dirs * (tol * sig_r)
+        inner_spot_lab = spot_lab - panel_dirs * (tol * sig_r)
+
+        # Set d* at band limits
+        inv_lambda = 1.0 / beam.get_wavelength()
+        s1_outer = outer_spot_lab.each_normalize() * inv_lambda
+        s1_inner = inner_spot_lab.each_normalize() * inv_lambda
+        self.spots["dstar_outer"] = (s1_outer - beam.get_s0()).norms()
+        self.spots["dstar_inner"] = (s1_inner - beam.get_s0()).norms()
+        self.spots["dstar_band2"] = flex.pow2(
+            self.spots["dstar_outer"] - self.spots["dstar_inner"]
+        )
+
+        return
+
+    def _calc_seeds_and_stems(self):
+        # As the first stage of search, determine a list of seed spots for further
+        # stages. Order these by distance of observed d* from the candidate
+        # reflection's canonical d*
+
+        # First the 'seeds' (in 1 ASU)
+        result = []
+        for i, spot in enumerate(self.spots):
+            sel = (self.candidate_hkls["dstar"] <= spot["dstar_outer"]) & (
+                self.candidate_hkls["dstar"] >= spot["dstar_inner"]
+            )
+            cands = self.candidate_hkls.select(sel)
+            for c in cands:
+                r_dst = abs(c["dstar"] - spot["dstar"])
+                result.append(
+                    {
+                        "spot_id": i,
+                        "miller_index": c["miller_index"],
+                        "rlp_datum": matrix.col(c["rlp_datum"]),
+                        "residual_dstar": r_dst,
+                        "clock_angle": spot["clock_angle"],
+                    }
+                )
+
+        result.sort(key=operator.itemgetter("residual_dstar"))
+        self.seeds = result
+
+        # Now the 'stems' to use in second search level, using all indices in P 1
+        result = []
+        for i, spot in enumerate(self.spots):
+            sel = (self.candidate_hkls_p1["dstar"] <= spot["dstar_outer"]) & (
+                self.candidate_hkls_p1["dstar"] >= spot["dstar_inner"]
+            )
+            cands = self.candidate_hkls_p1.select(sel)
+            for c in cands:
+                r_dst = abs(c["dstar"] - spot["dstar"])
+                result.append(
+                    {
+                        "spot_id": i,
+                        "miller_index": c["miller_index"],
+                        "rlp_datum": matrix.col(c["rlp_datum"]),
+                        "residual_dstar": r_dst,
+                        "clock_angle": spot["clock_angle"],
+                    }
+                )
+
+        result.sort(key=operator.itemgetter("residual_dstar"))
+        self.stems = result
+        return
+
+    def _pairs_with_seed(self, seed):
+
+        seed_rlp = matrix.col(self.spots[seed["spot_id"]]["rlp"])
+
+        result = []
+        for cand in self.stems:
+            # Don't check the seed spot itself
+            if cand["spot_id"] == seed["spot_id"]:
+                continue
+
+            # Skip spots at a very similar clock angle, which probably belong to the
+            # same line of indices from the origin
+            angle_diff = cand["clock_angle"] - seed["clock_angle"]
+            angle_diff = abs(((angle_diff + pi) % TWO_PI) - pi)
+            if angle_diff < FIVE_DEG:
+                continue
+
+            # Calculate the plane normal for the plane containing the seed and stem.
+            # Skip pairs of Miller indices that belong to the same line
+            seed_vec = seed["rlp_datum"]
+            cand_vec = cand["rlp_datum"]
+            try:
+                seed_vec.cross(cand_vec).normalize()
+            except ZeroDivisionError:
+                continue
+
+            # Compare expected reciprocal space distance with observed distance
+            cand_rlp = matrix.col(self.spots[cand["spot_id"]]["rlp"])
+            obs_dist = (cand_rlp - seed_rlp).length()
+            exp_dist = (seed_vec - cand_vec).length()
+            r_dist = abs(obs_dist - exp_dist)
+
+            # If the distance difference is larger than the sum in quadrature of the
+            # tolerated d* bands then reject the candidate
+            sq_band1 = self.spots[seed["spot_id"]]["dstar_band2"]
+            sq_band2 = self.spots[cand["spot_id"]]["dstar_band2"]
+            if r_dist > sqrt(sq_band1 + sq_band2):
+                continue
+
+            # Store the seed-stem match as a 2-node graph
+            g = CompleteGraph(
+                {
+                    "spot_id": seed["spot_id"],
+                    "miller_index": seed["miller_index"],
+                    "rlp_datum": seed["rlp_datum"],
+                }
+            )
+            g = g.factory_add_vertex(
+                {
+                    "spot_id": cand["spot_id"],
+                    "miller_index": cand["miller_index"],
+                    "rlp_datum": cand["rlp_datum"],
+                },
+                weights_to_other=[r_dist],
+            )
+            result.append(g)
+        return result
+
+    def _extend_by_candidates(self, graph):
+
+        existing_ids = [e["spot_id"] for e in graph.vertices]
+        obs_relps = [matrix.col(self.spots[e]["rlp"]) for e in existing_ids]
+        exp_relps = [e["rlp_datum"] for e in graph.vertices]
+
+        result = []
+
+        for cand in self.stems:
+            # Don't check spots already matched
+            if cand["spot_id"] in existing_ids:
+                continue
+
+            # Compare expected reciprocal space distances with observed distances
+            cand_rlp = matrix.col(self.spots[cand["spot_id"]]["rlp"])
+            cand_vec = cand["rlp_datum"]
+
+            obs_dists = [(cand_rlp - rlp).length() for rlp in obs_relps]
+            exp_dists = [(vec - cand_vec).length() for vec in exp_relps]
+
+            residual_dist = [abs(a - b) for (a, b) in zip(obs_dists, exp_dists)]
+
+            # If any of the distance differences is larger than the sum in quadrature
+            # of the tolerated d* bands then reject the candidate
+            sq_candidate_band = self.spots[cand["spot_id"]]["dstar_band2"]
+            bad_candidate = False
+            for r_dist, spot_id in zip(residual_dist, existing_ids):
+                sq_relp_band = self.spots[spot_id]["dstar_band2"]
+                if r_dist > sqrt(sq_relp_band + sq_candidate_band):
+                    bad_candidate = True
+                    break
+            if bad_candidate:
+                continue
+
+            # Calculate co-planarity of the relps, including the origin
+            points = flex.vec3_double(exp_relps + [cand_vec, (0.0, 0.0, 0.0)])
+            plane = least_squares_plane(points)
+            plane_score = flex.sum_sq(
+                points.dot(plane.normal) - plane.distance_to_origin
+            )
+
+            # Reject if the group of relps are too far from lying in a single plane.
+            # This cut-off was determined by trial and error using simulated images.
+            if plane_score > 6e-7:
+                continue
+
+            # Construct a graph including the accepted candidate node
+            g = graph.factory_add_vertex(
+                {
+                    "spot_id": cand["spot_id"],
+                    "miller_index": cand["miller_index"],
+                    "rlp_datum": cand["rlp_datum"],
+                },
+                weights_to_other=residual_dist,
+            )
+
+            result.append(g)
+
+        return result
+
+    @staticmethod
+    def _fit_U_from_superposed_points(reference, other):
+
+        # Add the origin to both sets of points
+        origin = flex.vec3_double(1)
+        reference.extend(origin)
+        other.extend(origin)
+
+        # Find U matrix that takes ideal relps to the reference
+        fit = superpose.least_squares_fit(reference, other)
+        return fit.r
+
+    def _fit_crystal_model(self, graph):
+
+        vertices = graph.vertices
+
+        # Reciprocal lattice points of the observations
+        sel = flex.size_t([e["spot_id"] for e in vertices])
+        reference = self.spots["rlp"].select(sel)
+
+        # Ideal relps from the known cell
+        other = flex.vec3_double([e["rlp_datum"] for e in vertices])
+
+        U = self._fit_U_from_superposed_points(reference, other)
+        UB = U * self.Bmat
+
+        if self._params.bootstrap_crystal:
+
+            # Attempt to index the low resolution spots
+            from dials_algorithms_indexing_ext import AssignIndices
+
+            phi = self.spots["xyzobs.mm.value"].parts()[2]
+            UB_matrices = flex.mat3_double([UB])
+            result = AssignIndices(self.spots["rlp"], phi, UB_matrices, tolerance=0.3)
+            hkl = result.miller_indices()
+            sel = hkl != (0, 0, 0)
+            hkl_vec = hkl.as_vec3_double().select(sel)
+
+            # Use the result to get a new UB matrix
+            reference = self.spots["rlp"].select(sel)
+            other = self.Bmat.elems * hkl_vec
+            U = self._fit_U_from_superposed_points(reference, other)
+            UB = U * self.Bmat
+
+        # Calculate RMSD of the fit
+        other_rotated = U.elems * other
+        rms = reference.rms_difference(other_rotated)
+
+        # Construct a crystal model
+        xl = Crystal(A=UB, space_group_symbol="P1")
+
+        # Monkey-patch crystal to return rms of the fit (useful?)
+        xl.rms = rms
+
+        return xl

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -12,7 +12,7 @@ from dxtbx.model.experiment_list import Experiment, ExperimentList
 from dials.array_family import flex
 from dials.algorithms.indexing.indexer import Indexer
 from dials.algorithms.indexing.known_orientation import IndexerKnownOrientation
-from dials.algorithms.indexing.lattice_search import BasisVectorSearch
+from dials.algorithms.indexing.lattice_search import BasisVectorSearch, LatticeSearch
 from dials.algorithms.indexing.nave_parameters import NaveParameters
 from dials.algorithms.indexing import DialsIndexError, DialsIndexRefineError
 
@@ -800,4 +800,8 @@ class StillsIndexerKnownOrientation(IndexerKnownOrientation, StillsIndexer):
 
 
 class StillsIndexerBasisVectorSearch(StillsIndexer, BasisVectorSearch):
+    pass
+
+
+class StillsIndexerLatticeSearch(StillsIndexer, LatticeSearch):
     pass

--- a/algorithms/indexing/test_index.py
+++ b/algorithms/indexing/test_index.py
@@ -857,10 +857,9 @@ def test_stills_indexer_multi_lattice_bug_MosaicSauter2014(dials_regression, tmp
 @pytest.mark.parametrize("indexer_type,fix_cell", (("sweeps", False), ("stills", True)))
 def test_index_ED_still_low_res_spot_match(dials_data, tmpdir, indexer_type, fix_cell):
 
-    data_dir = dials_data("smv_image_examples")
     # test indexing from a single simulated lysozyme ED still
 
-    image_path = os.path.join(str(data_dir), "noiseimage_001.img")
+    image_path = dials_data("smv_image_examples").join("noiseimage_001.img").strpath
 
     command = ["dials.import", image_path]
     result = procrunner.run(command, working_directory=tmpdir)

--- a/algorithms/indexing/test_index.py
+++ b/algorithms/indexing/test_index.py
@@ -854,7 +854,8 @@ def test_stills_indexer_multi_lattice_bug_MosaicSauter2014(dials_regression, tmp
         assert isinstance(crys, dxtbx_model_ext.MosaicCrystalSauter2014)
 
 
-def test_index_ED_still_low_res_spot_match(dials_data, tmpdir):
+@pytest.mark.parametrize("indexer_type,fix_cell", (("sweeps", False), ("stills", True)))
+def test_index_ED_still_low_res_spot_match(dials_data, tmpdir, indexer_type, fix_cell):
 
     data_dir = dials_data("smv_image_examples")
     # test indexing from a single simulated lysozyme ED still
@@ -882,6 +883,8 @@ def test_index_ED_still_low_res_spot_match(dials_data, tmpdir):
         "n_macro_cycles=2",
         "detector.fix_list=Dist",
     ]
+    if fix_cell:
+        extra_args += ["crystal.fix=cell"]
 
     expected_unit_cell = uctbx.unit_cell((78.84, 78.84, 38.29, 90, 90, 90))
     expected_rmsds = (0.007, 0.006, 0.000)

--- a/algorithms/indexing/test_lattice_search.py
+++ b/algorithms/indexing/test_lattice_search.py
@@ -99,3 +99,37 @@ def test_stills_indexer_BasisVectorSearch_i04_weak_data(
     assert indexed_experiments[0].crystal.get_unit_cell().parameters() == pytest.approx(
         (57.752, 57.776, 150.013, 90.0101, 89.976, 90.008), rel=1e-2
     )
+
+
+@pytest.mark.parametrize(
+    "indexing_method,space_group,unit_cell",
+    (("low_res_spot_match", "P422", (57.8, 57.8, 150.0, 90, 90, 90)),),
+)
+def test_stills_indexer_LatticeSearch_i04_weak_data(
+    i04_weak_data, indexing_method, space_group, unit_cell
+):
+    reflections = slice_reflections(i04_weak_data["reflections"], [(1, 2)])
+    experiments = slice_experiments(i04_weak_data["experiments"], [(1, 2)])
+    for experiment in experiments:
+        experiment.imageset = ImageSet(
+            experiment.imageset.data(), experiment.imageset.indices()
+        )
+        experiment.imageset.set_scan(None)
+        experiment.imageset.set_goniometer(None)
+        experiment.scan = None
+        experiment.goniometer = None
+    params = phil_scope.fetch().extract()
+    params.indexing.method = indexing_method
+    params.indexing.basis_vector_combinations.max_refine = 5
+    if unit_cell is not None:
+        params.indexing.known_symmetry.unit_cell = uctbx.unit_cell(unit_cell)
+    if space_group is not None:
+        params.indexing.known_symmetry.space_group = sgtbx.space_group_info(space_group)
+    idxr = stills_indexer.StillsIndexerLatticeSearch(reflections, experiments, params)
+    idxr.index()
+
+    indexed_experiments = idxr.refined_experiments
+    assert len(indexed_experiments) == 1
+    assert indexed_experiments[0].crystal.get_unit_cell().parameters() == pytest.approx(
+        (57.752, 57.776, 150.013, 90.0101, 89.976, 90.008), rel=1e-2
+    )

--- a/algorithms/indexing/test_lattice_search.py
+++ b/algorithms/indexing/test_lattice_search.py
@@ -67,9 +67,10 @@ def test_BasisVectorSearch_i04_weak_data(
         ("fft3d", "P422", (57.8, 57.8, 150.0, 90, 90, 90)),
         ("fft1d", "P422", (57.8, 57.8, 150.0, 90, 90, 90)),
         ("real_space_grid_search", "P422", (57.8, 57.8, 150.0, 90, 90, 90)),
+        ("low_res_spot_match", "P422", (57.8, 57.8, 150.0, 90, 90, 90)),
     ),
 )
-def test_stills_indexer_BasisVectorSearch_i04_weak_data(
+def test_stills_indexer_methods_i04_weak_data(
     i04_weak_data, indexing_method, space_group, unit_cell
 ):
     reflections = slice_reflections(i04_weak_data["reflections"], [(1, 2)])
@@ -89,43 +90,14 @@ def test_stills_indexer_BasisVectorSearch_i04_weak_data(
         params.indexing.known_symmetry.unit_cell = uctbx.unit_cell(unit_cell)
     if space_group is not None:
         params.indexing.known_symmetry.space_group = sgtbx.space_group_info(space_group)
-    idxr = stills_indexer.StillsIndexerBasisVectorSearch(
-        reflections, experiments, params
-    )
-    idxr.index()
-
-    indexed_experiments = idxr.refined_experiments
-    assert len(indexed_experiments) == 1
-    assert indexed_experiments[0].crystal.get_unit_cell().parameters() == pytest.approx(
-        (57.752, 57.776, 150.013, 90.0101, 89.976, 90.008), rel=1e-2
-    )
-
-
-@pytest.mark.parametrize(
-    "indexing_method,space_group,unit_cell",
-    (("low_res_spot_match", "P422", (57.8, 57.8, 150.0, 90, 90, 90)),),
-)
-def test_stills_indexer_LatticeSearch_i04_weak_data(
-    i04_weak_data, indexing_method, space_group, unit_cell
-):
-    reflections = slice_reflections(i04_weak_data["reflections"], [(1, 2)])
-    experiments = slice_experiments(i04_weak_data["experiments"], [(1, 2)])
-    for experiment in experiments:
-        experiment.imageset = ImageSet(
-            experiment.imageset.data(), experiment.imageset.indices()
+    try:
+        idxr = stills_indexer.StillsIndexerBasisVectorSearch(
+            reflections, experiments, params
         )
-        experiment.imageset.set_scan(None)
-        experiment.imageset.set_goniometer(None)
-        experiment.scan = None
-        experiment.goniometer = None
-    params = phil_scope.fetch().extract()
-    params.indexing.method = indexing_method
-    params.indexing.basis_vector_combinations.max_refine = 5
-    if unit_cell is not None:
-        params.indexing.known_symmetry.unit_cell = uctbx.unit_cell(unit_cell)
-    if space_group is not None:
-        params.indexing.known_symmetry.space_group = sgtbx.space_group_info(space_group)
-    idxr = stills_indexer.StillsIndexerLatticeSearch(reflections, experiments, params)
+    except RuntimeError:
+        idxr = stills_indexer.StillsIndexerLatticeSearch(
+            reflections, experiments, params
+        )
     idxr.index()
 
     indexed_experiments = idxr.refined_experiments

--- a/command_line/plugins.py
+++ b/command_line/plugins.py
@@ -45,6 +45,10 @@ known_entry_points = {
         "description": "Basis vector search strategies",
         "required": ["fft1d", "fft3d", "real_space_grid_search"],
     },
+    "dials.index.lattice_search_strategy": {
+        "description": "Lattice search strategies",
+        "required": ["low_res_spot_match"],
+    },
 }
 
 if __name__ == "__main__":

--- a/libtbx_refresh.py
+++ b/libtbx_refresh.py
@@ -32,7 +32,8 @@ try:
 except Exception:
     pass
 
-dials.precommitbx.nagger.nag()
+if dials.precommitbx.nagger.not_configured(["phenix_regression"]):
+    dials.precommitbx.nagger.nag()
 
 
 def _install_dials_autocompletion():

--- a/libtbx_refresh.py
+++ b/libtbx_refresh.py
@@ -18,6 +18,9 @@ libtbx.pkg_utils.define_entry_points(
             "fft3d = dials.algorithms.indexing.basis_vector_search.strategies:FFT3D",
             "real_space_grid_search = dials.algorithms.indexing.basis_vector_search.strategies:RealSpaceGridSearch",
         ],
+        "dials.index.lattice_search_strategy": [
+            "low_res_spot_match = dials.algorithms.indexing.lattice_search_strategies:LowResSpotMatch"
+        ],
     }
 )
 

--- a/precommitbx/nagger.py
+++ b/precommitbx/nagger.py
@@ -84,3 +84,16 @@ def nag():
 
     # import time
     # time.sleep(0.3)
+
+
+def not_configured(module_list):
+    """Are no modules in module_list configured"""
+    import libtbx.load_env
+
+    for module_name in module_list:
+        try:
+            _ = libtbx.env.dist_path(module_name)
+            return False
+        except KeyError:
+            pass
+    return True


### PR DESCRIPTION
This branch extends #882 by actually implementing a `LatticeSearch` strategy using entry points along the same lines as done for the existing `BasisVectorSearch` strategies. The method implemented is particularly designed for use with electron diffraction still images, where low resolution reflections are available and a known space group and unit cell can be provided. This algorithm was originally developed in [indigo.py](https://github.com/dials/dials_scratch/blob/master/dgw/indigo.py), but this PR moves it to DIALS for future development. At the moment, a single test is added, to ensure indexing using the new algorithm works as expected for a simulated test image.