### PR TITLE
Deprecation warnings

### DIFF
--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -963,22 +963,6 @@ class Indexer(object):
                 xs.sites_mod_short()
                 f.write(xs.as_pdb_file())
 
-    def debug_write_ccp4_map(self, map_data, file_name):
-        from iotbx import ccp4_map
-
-        gridding_first = (0, 0, 0)
-        gridding_last = map_data.all()
-        labels = ["cctbx.miller.fft_map"]
-        ccp4_map.write_ccp4_map(
-            file_name=file_name,
-            unit_cell=self.fft_cell,
-            space_group=sgtbx.space_group("P1"),
-            gridding_first=gridding_first,
-            gridding_last=gridding_last,
-            map_data=map_data,
-            labels=flex.std_string(labels),
-        )
-
     def export_as_json(
         self, experiments, file_name="indexed_experiments.json", compact=False
     ):

--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -982,10 +982,8 @@ class Indexer(object):
     def export_as_json(
         self, experiments, file_name="indexed_experiments.json", compact=False
     ):
-        from dxtbx.serialize import dump
-
         assert experiments.is_consistent()
-        dump.experiment_list(experiments, file_name)
+        experiments.as_file(file_name)
 
     def export_reflections(self, reflections, file_name="reflections.pickle"):
         reflections.as_file(file_name)

--- a/algorithms/scaling/scaling_utilities.py
+++ b/algorithms/scaling/scaling_utilities.py
@@ -12,7 +12,6 @@ from time import time
 from dials.array_family import flex
 from cctbx import miller
 from cctbx import uctbx
-from dxtbx.model.experiment_list import ExperimentListDumper
 from dials_scaling_ext import (
     create_sph_harm_table,
     calc_theta_phi,
@@ -75,9 +74,7 @@ def save_experiments(experiments, filename):
     """Save the experiments json."""
     st = time()
     logger.info("Saving the experiments to %s", filename)
-    dump = ExperimentListDumper(experiments)
-    with open(filename, "w") as outfile:
-        outfile.write(dump.as_json(split=True))
+    experiments.as_file(filename, split=True)
     logger.info("Time taken: %g", (time() - st))
 
 

--- a/command_line/analyse_output.py
+++ b/command_line/analyse_output.py
@@ -20,6 +20,7 @@ import matplotlib
 
 import libtbx.phil
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 
 # Offline backend
 matplotlib.use("Agg")
@@ -1430,9 +1431,5 @@ def run():
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/apply_mask.py
+++ b/command_line/apply_mask.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# aaply_mask.py
+#  apply_mask.py
 #
 #  Copyright (C) 2013 Diamond Light Source
 #
@@ -106,8 +106,7 @@ class Script(object):
 
         # Dump the experiments
         print("Writing experiments to %s" % params.output.experiments)
-        dump = ExperimentListDumper(experiments)
-        dump.as_json(filename=params.output.experiments)
+        experiments.as_file(filename=params.output.experiments)
 
 
 if __name__ == "__main__":

--- a/command_line/apply_mask.py
+++ b/command_line/apply_mask.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, division, print_function
 
 from six.moves import cPickle as pickle
 
+from dials.util import show_mail_on_error
 from dxtbx.format.image import ImageBool
 from iotbx.phil import parse
 
@@ -71,7 +72,6 @@ class Script(object):
     def run(self):
         """ Run the script. """
         from dials.util.options import flatten_experiments
-        from dxtbx.model.experiment_list import ExperimentListDumper
         from dials.util import Sorry
 
         # Parse the command line arguments
@@ -111,10 +111,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/apply_mask.py
+++ b/command_line/apply_mask.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-#  apply_mask.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from six.moves import cPickle as pickle
@@ -59,12 +48,9 @@ class Script(object):
     def __init__(self):
         """ Initialise the script. """
         from dials.util.options import OptionParser
-        import libtbx.load_env
 
         # Create the parser
-        usage = (
-            "usage: %s models.expt input.mask=pixels.mask" % libtbx.env.dispatcher_name
-        )
+        usage = "dials.apply_mask models.expt input.mask=pixels.mask"
         self.parser = OptionParser(
             usage=usage, epilog=help_message, phil=phil_scope, read_experiments=True
         )

--- a/command_line/combine_experiments.py
+++ b/command_line/combine_experiments.py
@@ -738,11 +738,9 @@ class Script(object):
 
     def _save_output(self, experiments, reflections, exp_name, refl_name):
         # save output
-        from dxtbx.model.experiment_list import ExperimentListDumper
 
         print("Saving combined experiments to {}".format(exp_name))
-        dump = ExperimentListDumper(experiments)
-        dump.as_json(exp_name)
+        experiments.as_file(exp_name)
         print("Saving combined reflections to {}".format(refl_name))
         reflections.as_file(refl_name)
 

--- a/command_line/complete_full_sphere.py
+++ b/command_line/complete_full_sphere.py
@@ -257,9 +257,7 @@ class Script(object):
         return obs, shadowed
 
     def write_expt(self, experiments, filename):
-
         experiments.as_file(filename)
-        return
 
 
 if __name__ == "__main__":

--- a/command_line/complete_full_sphere.py
+++ b/command_line/complete_full_sphere.py
@@ -8,6 +8,7 @@ import logging
 from libtbx.phil import parse
 
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 
 
 logger = logging.getLogger("dials.command_line.complete_full_sphere")
@@ -264,10 +265,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/complete_full_sphere.py
+++ b/command_line/complete_full_sphere.py
@@ -257,10 +257,8 @@ class Script(object):
         return obs, shadowed
 
     def write_expt(self, experiments, filename):
-        from dxtbx.model.experiment_list import ExperimentListDumper
 
-        dump = ExperimentListDumper(experiments)
-        dump.as_json(filename)
+        experiments.as_file(filename)
         return
 
 

--- a/command_line/compute_delta_cchalf.py
+++ b/command_line/compute_delta_cchalf.py
@@ -509,12 +509,9 @@ class Script(object):
                 self.params.output.reflections,
             )
             self.reflections[0].as_file(self.params.output.reflections)
-            from dxtbx.model.experiment_list import ExperimentListDumper
 
             logger.info("Saving the experiments to %s", self.params.output.experiments)
-            dump = ExperimentListDumper(self.experiments)
-            with open(self.params.output.experiments, "w") as outfile:
-                outfile.write(dump.as_json())
+            self.experiments.as_file(self.params.output.experiments)
 
     def plot_data(self):
         """Plot histogram and line plot of cc half values."""

--- a/command_line/create_profile_model.py
+++ b/command_line/create_profile_model.py
@@ -71,7 +71,6 @@ class Script(object):
         from dials.util.command_line import Command
         from dials.array_family import flex
         from dials.util.options import flatten_reflections, flatten_experiments
-        from dxtbx.model.experiment_list import ExperimentListDumper
         from dials.util import Sorry
         from dials.util import log
 
@@ -148,9 +147,7 @@ class Script(object):
 
         # Write the parameters
         Command.start("Writing experiments to %s" % params.output)
-        dump = ExperimentListDumper(experiments)
-        with open(params.output, "w") as outfile:
-            outfile.write(dump.as_json())
+        experiments.as_file(params.output)
         Command.end("Wrote experiments to %s" % params.output)
 
     def process_reference(self, reference, params):

--- a/command_line/create_profile_model.py
+++ b/command_line/create_profile_model.py
@@ -87,7 +87,7 @@ class Script(object):
             raise Sorry("exactly 1 reflection table must be specified")
         if len(experiments) == 0:
             raise Sorry("no experiments were specified")
-        if (not "background.mean" in reflections[0]) and params.subtract_background:
+        if ("background.mean" not in reflections[0]) and params.subtract_background:
             raise Sorry("for subtract_background need background.mean in reflections")
 
         reflections, _ = self.process_reference(reflections[0], params)
@@ -163,9 +163,9 @@ class Script(object):
         logger.info("Processing reference reflections")
         logger.info(" read %d strong spots" % len(reference))
         mask = reference.get_flags(reference.flags.indexed)
-        rubbish = reference.select(mask == False)
+        rubbish = reference.select(~mask)
         if mask.count(False) > 0:
-            reference.del_selected(mask == False)
+            reference.del_selected(~mask)
             logger.info(" removing %d unindexed reflections" % mask.count(False))
         if len(reference) == 0:
             raise Sorry(

--- a/command_line/create_profile_model.py
+++ b/command_line/create_profile_model.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
+from dials.util import show_mail_on_error
 from libtbx.phil import parse
 
 logger = logging.getLogger("dials.command_line.create_profile_model")
@@ -236,10 +237,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -17,7 +17,6 @@ import libtbx.load_env
 from dials.util import show_mail_on_error, Sorry
 from dxtbx.model.experiment_list import Experiment
 from dxtbx.model.experiment_list import ExperimentList
-from dxtbx.model.experiment_list import ExperimentListDumper
 from dxtbx.model.experiment_list import ExperimentListFactory
 from dxtbx.model.experiment_list import ExperimentListTemplateImporter
 from dxtbx.imageset import ImageGrid
@@ -839,8 +838,9 @@ class Script(object):
         if params.output.experiments:
             logger.info("-" * 80)
             logger.info("Writing experiments to %s" % params.output.experiments)
-            dump = ExperimentListDumper(experiments)
-            dump.as_file(params.output.experiments, compact=params.output.compact)
+            experiments.as_file(
+                params.output.experiments, compact=params.output.compact
+            )
 
     def assert_single_sweep(self, experiments, params):
         """

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 
 import libtbx.load_env
-from dials.util import Sorry
+from dials.util import show_mail_on_error, Sorry
 from dxtbx.model.experiment_list import Experiment
 from dxtbx.model.experiment_list import ExperimentList
 from dxtbx.model.experiment_list import ExperimentListDumper
@@ -897,10 +897,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/find_shared_models.py
+++ b/command_line/find_shared_models.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
+from dials.util import show_mail_on_error
+
 logger = logging.getLogger("dials.command_line.find_shared_models")
 
 help_message = """
@@ -183,10 +185,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/find_spots.py
+++ b/command_line/find_spots.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
+from dials.util import show_mail_on_error
+
 logger = logging.getLogger("dials.command_line.find_spots")
 
 help_message = """
@@ -213,10 +215,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/find_spots.py
+++ b/command_line/find_spots.py
@@ -116,7 +116,6 @@ class Script(object):
 
     def run(self, args=None):
         """Execute the script."""
-        from dxtbx.model.experiment_list import ExperimentListDumper
         from dials.array_family import flex
         from dials.util.options import flatten_experiments
         from time import time
@@ -185,8 +184,7 @@ class Script(object):
         # Save the experiments
         if params.output.experiments:
             logger.info("Saving experiments to {}".format(params.output.experiments))
-            dump = ExperimentListDumper(experiments)
-            dump.as_file(params.output.experiments)
+            experiments.as_file(params.output.experiments)
 
         # Print some per image statistics
         if params.per_image_statistics:

--- a/command_line/import_stream.py
+++ b/command_line/import_stream.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 
 from libtbx.phil import parse
-from dials.util import Sorry
+from dials.util import show_mail_on_error, Sorry
 from dxtbx.model.experiment_list import ExperimentListDumper
 from dxtbx.model.experiment_list import ExperimentListFactory
 
@@ -193,10 +193,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/import_stream.py
+++ b/command_line/import_stream.py
@@ -14,7 +14,6 @@ import logging
 
 from libtbx.phil import parse
 from dials.util import show_mail_on_error, Sorry
-from dxtbx.model.experiment_list import ExperimentListDumper
 from dxtbx.model.experiment_list import ExperimentListFactory
 
 logger = logging.getLogger("dials.command_line.import_stream")
@@ -188,8 +187,9 @@ class Script(object):
         if params.output.experiments:
             logger.info("-" * 80)
             logger.info("Writing experiments to %s" % params.output.experiments)
-            dump = ExperimentListDumper(experiments)
-            dump.as_file(params.output.experiments, compact=params.output.compact)
+            experiments.as_file(
+                params.output.experiments, compact=params.output.compact
+            )
 
 
 if __name__ == "__main__":

--- a/command_line/import_xds.py
+++ b/command_line/import_xds.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 
 
 class SpotXDSImporter(object):
@@ -476,10 +477,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/import_xds.py
+++ b/command_line/import_xds.py
@@ -178,7 +178,6 @@ class XDSFileImporter(object):
 
     def __call__(self, params, options):
         from dxtbx.model.experiment_list import ExperimentListFactory
-        from dxtbx.model.experiment_list import ExperimentListDumper
 
         # Get the XDS.INP file
         xds_inp = os.path.join(self.args[0], "XDS.INP")
@@ -253,15 +252,13 @@ class XDSFileImporter(object):
             params.output.filename = "xds_models.expt"
         print("-" * 80)
         print("Writing experiments to %s" % params.output.filename)
-        dump = ExperimentListDumper(experiments)
-        dump.as_file(params.output.filename)
+        experiments.as_file(params.output.filename)
 
         # Optionally save as a data block
         if params.output.xds_experiments:
             print("-" * 80)
             print("Writing data block to %s" % params.output.xds_experiments)
-            dump = ExperimentListDumper(experiments)
-            dump.as_file(params.output.xds_experiments)
+            experiments.as_file(params.output.xds_experiments)
 
     @staticmethod
     def find_best_xds_file(xds_dir):

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -6,7 +6,6 @@ import copy
 import logging
 
 import iotbx.phil
-from dxtbx.serialize import dump
 from dxtbx.model.experiment_list import ExperimentList
 from dials.algorithms.indexing import indexer
 from dials.algorithms.indexing import DialsIndexError
@@ -217,7 +216,7 @@ class Index(object):
         logger.info("Saving refined experiments to %s" % filename)
 
         assert experiments.is_consistent()
-        dump.experiment_list(experiments, filename)
+        experiments.as_file(filename)
 
     def export_reflections(self, filename):
         logger.info("Saving refined reflections to %s" % filename)

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 
 from dials.array_family import flex
-from dials.util import Sorry
+from dials.util import show_mail_on_error, Sorry
 
 logger = logging.getLogger("dials.command_line.integrate")
 # DIALS_ENABLE_COMMAND_LINE_COMPLETION
@@ -686,10 +686,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -526,13 +526,10 @@ class Script(object):
     def save_experiments(self, experiments, filename):
         """ Save the profile model parameters. """
         from time import time
-        from dxtbx.model.experiment_list import ExperimentListDumper
 
         st = time()
         logger.info("Saving the experiments to %s" % filename)
-        dump = ExperimentListDumper(experiments)
-        with open(filename, "w") as outfile:
-            outfile.write(dump.as_json())
+        experiments.as_file(filename)
         logger.info(" time taken: %g" % (time() - st))
 
     def sample_predictions(self, experiments, predicted, params):

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -448,9 +448,9 @@ class Script(object):
         logger.info("Processing reference reflections")
         logger.info(" read %d strong spots" % len(reference))
         mask = reference.get_flags(reference.flags.indexed)
-        rubbish = reference.select(mask == False)
+        rubbish = reference.select(~mask)
         if mask.count(False) > 0:
-            reference.del_selected(mask == False)
+            reference.del_selected(~mask)
             logger.info(" removing %d unindexed reflections" % mask.count(False))
         if len(reference) == 0:
             raise Sorry(

--- a/command_line/merge_reflection_lists.py
+++ b/command_line/merge_reflection_lists.py
@@ -13,6 +13,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from dials.util import show_mail_on_error
 from libtbx.phil import parse
 
 # Create the help message
@@ -100,10 +101,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/model_background.py
+++ b/command_line/model_background.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
+from dials.util import show_mail_on_error
+
 logger = logging.getLogger("dials.command_line.model_background")
 
 help_message = """
@@ -409,10 +411,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/model_background.py
+++ b/command_line/model_background.py
@@ -137,7 +137,7 @@ class ImageGenerator(object):
         for i in range(len(self.model)):
             min_image = self.model[i].min_image
             vmax = sorted(list(min_image))[int(0.99 * len(min_image))]
-            figure = pylab.figure(figsize=(6, 4))
+            pylab.figure(figsize=(6, 4))
             pylab.imshow(
                 min_image.as_numpy_array(), interpolation="none", vmin=0, vmax=vmax
             )
@@ -159,7 +159,7 @@ class ImageGenerator(object):
         for i in range(len(self.model)):
             max_image = self.model[i].max_image
             vmax = sorted(list(max_image))[int(0.99 * len(max_image))]
-            figure = pylab.figure(figsize=(6, 4))
+            pylab.figure(figsize=(6, 4))
             pylab.imshow(
                 max_image.as_numpy_array(), interpolation="none", vmin=0, vmax=vmax
             )
@@ -181,7 +181,7 @@ class ImageGenerator(object):
         for i in range(len(self.model)):
             mean = self.model[i].mean
             vmax = sorted(list(mean))[int(0.99 * len(mean))]
-            figure = pylab.figure(figsize=(6, 4))
+            pylab.figure(figsize=(6, 4))
             pylab.imshow(mean.as_numpy_array(), interpolation="none", vmin=0, vmax=vmax)
             ax1 = pylab.gca()
             ax1.get_xaxis().set_visible(False)
@@ -203,7 +203,7 @@ class ImageGenerator(object):
         for i in range(len(self.model)):
             variance = self.model[i].variance
             vmax = sorted(list(variance))[int(0.99 * len(variance))]
-            figure = pylab.figure(figsize=(6, 4))
+            pylab.figure(figsize=(6, 4))
             pylab.imshow(
                 variance.as_numpy_array(), interpolation="none", vmin=0, vmax=vmax
             )
@@ -226,7 +226,7 @@ class ImageGenerator(object):
 
         for i in range(len(self.model)):
             dispersion = self.model[i].dispersion
-            figure = pylab.figure(figsize=(6, 4))
+            pylab.figure(figsize=(6, 4))
             pylab.imshow(
                 dispersion.as_numpy_array(), interpolation="none", vmin=0, vmax=2
             )
@@ -249,7 +249,7 @@ class ImageGenerator(object):
 
         for i in range(len(self.model)):
             mask = self.model[i].mask
-            figure = pylab.figure(figsize=(6, 4))
+            pylab.figure(figsize=(6, 4))
             pylab.imshow(mask.as_numpy_array(), interpolation="none")
             ax1 = pylab.gca()
             ax1.get_xaxis().set_visible(False)
@@ -269,7 +269,7 @@ class ImageGenerator(object):
         for i in range(len(self.model)):
             model = self.model[i].model
             vmax = sorted(list(model))[int(0.99 * len(model))]
-            figure = pylab.figure(figsize=(6, 4))
+            pylab.figure(figsize=(6, 4))
             pylab.imshow(
                 model.as_numpy_array(), interpolation="none", vmin=0, vmax=vmax
             )
@@ -292,7 +292,7 @@ class ImageGenerator(object):
 
         for i in range(len(self.model)):
             polar_model = self.model[i].polar_model
-            figure = pylab.figure(figsize=(6, 4))
+            pylab.figure(figsize=(6, 4))
             pylab.imshow(polar_model.as_numpy_array(), interpolation="none")
             ax1 = pylab.gca()
             ax1.get_xaxis().set_visible(False)

--- a/command_line/modify_geometry.py
+++ b/command_line/modify_geometry.py
@@ -53,11 +53,9 @@ def run(args):
         imageset.set_goniometer(imageset_new.get_goniometer())
         imageset.set_scan(imageset_new.get_scan())
 
-    from dxtbx.serialize import dump
-
     if len(experiments):
         print("Saving modified experiments to %s" % params.output.experiments)
-        dump.experiment_list(experiments, params.output.experiments)
+        experiments.as_file(params.output.experiments)
 
 
 if __name__ == "__main__":

--- a/command_line/predict.py
+++ b/command_line/predict.py
@@ -11,6 +11,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from dials.util import show_mail_on_error
 from libtbx.phil import parse
 
 help_message = """
@@ -151,10 +152,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -442,10 +442,7 @@ def run(args=None, phil=working_phil):
     # Save the refined experiments to file
     output_experiments_filename = params.output.experiments
     logger.info("Saving refined experiments to {}".format(output_experiments_filename))
-    from dxtbx.model.experiment_list import ExperimentListDumper
-
-    dump = ExperimentListDumper(experiments)
-    dump.as_json(output_experiments_filename)
+    experiments.as_file(output_experiments_filename)
 
     # Save reflections with updated predictions if requested (allow to switch
     # this off if it is a time-consuming step)

--- a/command_line/refine_bravais_settings.py
+++ b/command_line/refine_bravais_settings.py
@@ -237,14 +237,13 @@ def run(args=None):
     logger.info("Saving summary as %s" % summary_file)
     with open(os.path.join(params.output.directory, summary_file), "w") as fh:
         json.dump(Lfat.as_dict(), fh)
-    from dxtbx.serialize import dump
 
     for subgroup in Lfat:
         expts = subgroup.refined_experiments
         soln = int(subgroup.setting_number)
         bs_json = "%sbravais_setting_%i.expt" % (prefix, soln)
         logger.info("Saving solution %i as %s" % (soln, bs_json))
-        dump.experiment_list(expts, os.path.join(params.output.directory, bs_json))
+        expts.as_file(os.path.join(params.output.directory, bs_json))
 
 
 if __name__ == "__main__":

--- a/command_line/reindex.py
+++ b/command_line/reindex.py
@@ -20,9 +20,9 @@ from libtbx import easy_pickle
 import iotbx.phil
 from cctbx import sgtbx
 from dxtbx.model import Crystal
-from dxtbx.serialize import dump
 
 # from dials.util.command_line import Importer
+from dials.algorithms.indexing.assign_indices import AssignIndicesGlobal
 from dials.array_family import flex
 from dials.util.options import OptionParser
 from dials.util.options import flatten_reflections, flatten_experiments
@@ -286,9 +286,8 @@ experiments file must also be specified with the option: reference= """
 
             # index the reflection list using the input experiments list
             refl_copy["id"] = flex.int(len(refl_copy), -1)
-            from dials.algorithms.indexing import index_reflections
-
-            index_reflections(refl_copy, experiments, tolerance=0.2)
+            index = AssignIndicesGlobal(tolerance=0.2)
+            index(refl_copy, experiments)
             hkl_expt = refl_copy["miller_index"]
             hkl_input = reflections[0]["miller_index"]
 
@@ -324,7 +323,7 @@ experiments file must also be specified with the option: reference= """
             print()
 
         print("Saving reindexed experimental models to %s" % params.output.experiments)
-        dump.experiment_list(experiments, params.output.experiments)
+        experiments.as_file(params.output.experiments)
 
     if len(reflections):
         assert len(reflections) == 1

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -37,6 +37,7 @@ from dials.report.plots import (
     i_over_sig_i_vs_batch_plot,
     i_over_sig_i_vs_i_plot,
 )
+from dials.util import show_mail_on_error
 from dials.util.command_line import Command
 from dials.util.batch_handling import batch_manager
 
@@ -2465,10 +2466,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -21,7 +21,6 @@ from rstbx.indexing_api import dps_extended
 from rstbx.indexing_api.lattice import DPS_primitive_lattice
 from rstbx.dps_core import Direction, Directional_FFT
 
-from dxtbx.serialize import dump
 from dials.algorithms.indexing.indexer import find_max_cell
 from dials.util import log
 from dials.util import Sorry
@@ -586,7 +585,7 @@ def run(args):
         logger.info("")
 
     logger.info("Saving optimized experiments to %s" % params.output.experiments)
-    dump.experiment_list(experiments, params.output.experiments)
+    experiments.as_file(params.output.experiments)
 
 
 if __name__ == "__main__":

--- a/command_line/show_extensions.py
+++ b/command_line/show_extensions.py
@@ -1,18 +1,8 @@
-#!/usr/bin/env python
-#
-# show_extensions.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
+# LIBTBX_SET_DISPATCHER_NAME dev.dials.show_extensions
+
 from __future__ import absolute_import, division, print_function
 
 from dials.util import show_mail_on_error
-
-# LIBTBX_SET_DISPATCHER_NAME dev.dials.show_extensions
 
 
 class Script(object):
@@ -22,7 +12,6 @@ class Script(object):
         """ Initialise the script. """
         from dials.util.options import OptionParser
         from libtbx.phil import parse
-        import libtbx.load_env
 
         # Create the phil parameters
         phil_scope = parse(
@@ -34,7 +23,7 @@ class Script(object):
         )
 
         # Create the option parser
-        usage = "usage: %s [options] /path/to/image/files" % libtbx.env.dispatcher_name
+        usage = "dev.dials.show_extensions [options] /path/to/image/files"
         self.parser = OptionParser(usage=usage, phil=phil_scope)
 
     def run(self):

--- a/command_line/show_extensions.py
+++ b/command_line/show_extensions.py
@@ -10,6 +10,8 @@
 #  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
+from dials.util import show_mail_on_error
+
 # LIBTBX_SET_DISPATCHER_NAME dev.dials.show_extensions
 
 
@@ -89,10 +91,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/slice_sweep.py
+++ b/command_line/slice_sweep.py
@@ -16,7 +16,7 @@ from os.path import basename, splitext
 
 from dials.algorithms.refinement.refinement_helpers import calculate_frame_numbers
 from dxtbx.model.experiment_list import ExperimentList
-from dials.util import Sorry
+from dials.util import show_mail_on_error, Sorry
 from dials.util.slice import slice_experiments, slice_reflections
 
 help_message = """
@@ -251,10 +251,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/slice_sweep.py
+++ b/command_line/slice_sweep.py
@@ -222,10 +222,7 @@ class Script(object):
                 output_experiments_filename = bname + ext
             print("Saving sliced experiments to {}".format(output_experiments_filename))
 
-            from dxtbx.model.experiment_list import ExperimentListDumper
-
-            dump = ExperimentListDumper(sliced_experiments)
-            dump.as_json(output_experiments_filename)
+            sliced_experiments.as_file(output_experiments_filename)
 
         # Save sliced reflections
         if slice_refs:

--- a/command_line/sort_reflections.py
+++ b/command_line/sort_reflections.py
@@ -42,28 +42,28 @@ class Sort(object):
         phil_scope = parse(
             """
 
-      key = 'miller_index'
-        .type = str
-        .help = "The chosen sort key. This should be a column of "
-                "the reflection table."
+            key = 'miller_index'
+                .type = str
+                .help = "The chosen sort key. This should be a column of "
+                        "the reflection table."
 
-      reverse = False
-        .type = bool
-        .help = "Reverse the sort direction"
+            reverse = False
+                .type = bool
+                .help = "Reverse the sort direction"
 
-      output = sorted.refl
-        .type = str
-        .help = "The output reflection filename"
+            output = sorted.refl
+                .type = str
+                .help = "The output reflection filename"
 
-    """
+            """
         )
 
         # The script usage
         usage = (
             """
-      usage: %s [options] observations.refl
+            usage: %s [options] observations.refl
 
-    """
+            """
             % libtbx.env.dispatcher_name
         )
 
@@ -103,10 +103,10 @@ class Sort(object):
         reflections = reflections.select(perm)
 
         if options.verbose > 0:
-            print("Head of sorted list " + attr + ":")
+            print("Head of sorted list " + params.key + ":")
             n = min(len(reflections), 10)
             for i in range(n):
-                print(reflections[i][attr])
+                print(reflections[i][params.key])
 
         # Save sorted reflections to file
         if params.output:

--- a/command_line/sort_reflections.py
+++ b/command_line/sort_reflections.py
@@ -1,34 +1,19 @@
-#!/usr/bin/env python
-#
-# dials.sort_reflections.py
-#
-#  Copyright (C) 2013 STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 # LIBTBX_SET_DISPATCHER_NAME dev.dials.sort_reflections
 
 from __future__ import absolute_import, division, print_function
 
-import libtbx.load_env
+import dials.util
 from dials.array_family import flex
-from dials.util import show_mail_on_error
 
-help_message = (
-    """
+help_message = """
 
 Utility script to sort reflection tables by the values in a column.
 
 Example::
 
-  %s key=miller_index output=sorted.refl
+  dev.dials.sort_reflections key=miller_index output=sorted.refl
 
 """
-    % libtbx.env.dispatcher_name
-)
 
 
 class Sort(object):
@@ -58,14 +43,7 @@ class Sort(object):
             """
         )
 
-        # The script usage
-        usage = (
-            """
-            usage: %s [options] observations.refl
-
-            """
-            % libtbx.env.dispatcher_name
-        )
+        usage = "dev.dials.sort_reflections [options] observations.refl"
 
         # Initialise the base class
         self.parser = OptionParser(
@@ -80,9 +58,7 @@ class Sort(object):
 
     def run(self):
         """Execute the script."""
-        from dials.array_family import flex  # noqa: F401, import dependency
         from dials.util.options import flatten_reflections
-        from dials.util import Sorry
 
         # Parse the command line
         params, options = self.parser.parse_args(show_diff_phil=True)
@@ -91,7 +67,7 @@ class Sort(object):
             self.parser.print_help()
             return
         if len(reflections) != 1:
-            raise Sorry("exactly 1 reflection table must be specified")
+            raise dials.util.Sorry("exactly 1 reflection table must be specified")
         reflections = reflections[0]
 
         # Check the key is valid
@@ -115,6 +91,6 @@ class Sort(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with dials.util.show_mail_on_error():
         script = Sort()
         script.run()

--- a/command_line/sort_reflections.py
+++ b/command_line/sort_reflections.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 import libtbx.load_env
 from dials.array_family import flex
+from dials.util import show_mail_on_error
 
 help_message = (
     """
@@ -114,10 +115,6 @@ class Sort(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Sort()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/space_group.py
+++ b/command_line/space_group.py
@@ -25,7 +25,6 @@ from dials.algorithms.symmetry.absences.laue_groups_info import (
 )
 from dials.algorithms.symmetry.absences.screw_axes import ScrewAxisObserver
 from cctbx import sgtbx
-from dxtbx.model.experiment_list import ExperimentListDumper
 from libtbx import phil
 from libtbx.table_utils import simple_table
 
@@ -230,10 +229,8 @@ def run(args=None):
         ScrewAxisObserver().generate_html_report(params.output.html)
 
     if params.output.experiments:
-        logger.info("\nWriting experiments to %s", (params.output.experiments))
-        dump = ExperimentListDumper(experiments)
-        with open(params.output.experiments, "w") as outfile:
-            outfile.write(dump.as_json(split=True))
+        logger.info("\nWriting experiments to %s", params.output.experiments)
+        experiments.as_file(params.output.experiments, split=True)
 
 
 if __name__ == "__main__":

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -111,7 +111,6 @@ input data and filtering settings e.g partiality_threshold"""
         self._export_experiments_reflections(experiments, reflections, result)
 
     def _export_experiments_reflections(self, experiments, reflections, result):
-        from dxtbx.serialize import dump
         from rstbx.symmetry.constraints import parameter_reduction
 
         reindexed_experiments = copy.deepcopy(experiments)
@@ -143,7 +142,7 @@ input data and filtering settings e.g partiality_threshold"""
         logger.info(
             "Saving reindexed experiments to %s" % self._params.output.experiments
         )
-        dump.experiment_list(reindexed_experiments, self._params.output.experiments)
+        reindexed_experiments.as_file(self._params.output.experiments)
         logger.info(
             "Saving %s reindexed reflections to %s"
             % (len(reindexed_reflections), self._params.output.reflections)

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -1,10 +1,8 @@
 from __future__ import division, absolute_import, print_function
 
-import logging
-
-logger = logging.getLogger("dials.command_line.symmetry")
-
 import copy
+import logging
+import random
 
 from cctbx import sgtbx
 import iotbx.phil
@@ -19,6 +17,7 @@ from dials.util.multi_dataset_handling import (
 from dials.util.filter_reflections import filtered_arrays_from_experiments_reflections
 from dials.algorithms.symmetry.determine_space_group import determine_space_group
 
+logger = logging.getLogger("dials.command_line.symmetry")
 
 phil_scope = iotbx.phil.parse(
     """\
@@ -140,12 +139,13 @@ input data and filtering settings e.g partiality_threshold"""
             )
             reindexed_reflections.extend(reindexed_refl)
         logger.info(
-            "Saving reindexed experiments to %s" % self._params.output.experiments
+            "Saving reindexed experiments to %s", self._params.output.experiments
         )
         reindexed_experiments.as_file(self._params.output.experiments)
         logger.info(
-            "Saving %s reindexed reflections to %s"
-            % (len(reindexed_reflections), self._params.output.reflections)
+            "Saving %s reindexed reflections to %s",
+            len(reindexed_reflections),
+            self._params.output.reflections,
         )
         reindexed_reflections.as_file(self._params.output.reflections)
 
@@ -197,8 +197,6 @@ def run(args):
         logger.info(diff_phil)
 
     if params.seed is not None:
-        import random
-
         flex.set_random_seed(params.seed)
         random.seed(params.seed)
 

--- a/command_line/two_theta_offset.py
+++ b/command_line/two_theta_offset.py
@@ -42,7 +42,6 @@ class Script(object):
     def __init__(self):
         """Initialise the script."""
         from dials.util.options import OptionParser
-        from libtbx.phil import parse
         import libtbx.load_env
 
         # The script usage

--- a/command_line/two_theta_offset.py
+++ b/command_line/two_theta_offset.py
@@ -11,6 +11,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from dials.util import show_mail_on_error
 from libtbx.phil import parse
 
 help_message = """
@@ -184,10 +185,6 @@ def find_centre_of_rotation(x1, x2, y1, y2):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/command_line/two_theta_refine.py
+++ b/command_line/two_theta_refine.py
@@ -549,10 +549,7 @@ class Script(object):
         logger.info(
             "Saving refined experiments to {}".format(output_experiments_filename)
         )
-        from dxtbx.model.experiment_list import ExperimentListDumper
-
-        dump = ExperimentListDumper(experiments)
-        dump.as_json(output_experiments_filename)
+        experiments.as_file(output_experiments_filename)
 
         # Create correlation plots
         if params.output.correlation_plot.filename is not None:

--- a/command_line/two_theta_refine.py
+++ b/command_line/two_theta_refine.py
@@ -20,7 +20,7 @@ from time import time
 from dials.array_family import flex
 from dials.util import log
 from dials.util.version import dials_version
-from dials.util import Sorry
+from dials.util import show_mail_on_error, Sorry
 from dials.util.filter_reflections import filter_reflection_table
 from dials.algorithms.refinement.corrgram import create_correlation_plots
 from dxtbx.model.experiment_list import Experiment, ExperimentList
@@ -574,10 +574,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/doc/examples/read_experiment_and_data/example_experiment_data.py
+++ b/doc/examples/read_experiment_and_data/example_experiment_data.py
@@ -13,6 +13,8 @@
 # framework
 
 from __future__ import absolute_import, division, print_function
+
+from dials.util import show_mail_on_error
 from libtbx.phil import parse
 
 help_message = """
@@ -124,10 +126,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    from dials.util import halraiser
-
-    try:
+    with show_mail_on_error():
         script = Script()
         script.run()
-    except Exception as e:
-        halraiser(e)

--- a/doc/examples/read_experiment_and_data/example_experiment_data.py
+++ b/doc/examples/read_experiment_and_data/example_experiment_data.py
@@ -1,13 +1,4 @@
-#!/usr/bin/env dials.python
-#
 # example_experiment_data.py
-#
-#  Copyright (C) 2017 Diamond Light Source
-#
-#  Author: Graeme Winter
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 #
 # Example code for how to load experiments and reflections in the DIALS
 # framework
@@ -38,11 +29,8 @@ class Script(object):
 
     def __init__(self):
         from dials.util.options import OptionParser
-        import libtbx.load_env
 
-        usage = (
-            "usage: %s [options] indexed.expt indexed.refl" % libtbx.env.dispatcher_name
-        )
+        usage = "dials.example_experiment_data [options] indexed.expt indexed.refl"
 
         self.parser = OptionParser(
             usage=usage,

--- a/doc/examples/read_experiment_and_data/example_experiment_data.py
+++ b/doc/examples/read_experiment_and_data/example_experiment_data.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # example_experiment_data.py
 #
 # Example code for how to load experiments and reflections in the DIALS
@@ -16,10 +17,10 @@ pass experiment.expt indexed.refl
 
 phil_scope = parse(
     """
-png = 'example.png'
-  .type = str
-  .help = 'Output name for .png'
-""",
+    png = 'example.png'
+      .type = str
+      .help = 'Output name for .png'
+    """,
     process_includes=True,
 )
 
@@ -42,7 +43,6 @@ class Script(object):
         )
 
     def run(self):
-        from dials.array_family import flex  # noqa F401 import dependency
         from scitbx import matrix
         from dials.util.options import flatten_experiments
         from dials.util.options import flatten_reflections
@@ -83,14 +83,18 @@ class Script(object):
 
         # now perform some calculations - the only things different from one
         # experiment to the next will be crystal models
-        crystals = [experiment.crystal for experiment in experiments]  # noqa F841
+        print("Crystals:")
+        [experiment.crystal.show() for experiment in experiments]
         detector = experiments[0].detector
         beam = experiments[0].beam
         imageset = experiments[0].imageset
 
         # derived quantities
-        wavelength = beam.get_wavelength()  # noqa F841
-        s0 = matrix.col(beam.get_s0())  # noqa F841
+        wavelength = beam.get_wavelength()
+        s0 = matrix.col(beam.get_s0())
+
+        print(u"Wavelength: {:g}Å".format(wavelength))
+        print("Beam vector s0:\n{}".format(s0))
 
         # in here do some jiggery-pokery to cope with this being interpreted as
         # a rotation image in here i.e. if scan is not None; derive goniometer
@@ -106,11 +110,11 @@ class Script(object):
             axis = matrix.col(goniometer.get_rotation_axis_datum())
             F = matrix.sqr(goniometer.get_fixed_rotation())
             S = matrix.sqr(goniometer.get_setting_rotation())
-            R = (
-                S * axis.axis_and_angle_as_r3_rotation_matrix(angle, deg=True) * F
-            )  # noqa F841
+            R = S * axis.axis_and_angle_as_r3_rotation_matrix(angle, deg=True) * F
         else:
-            R = matrix.sqr((1, 0, 0, 0, 1, 0, 0, 0, 1))  # noqa F841
+            R = matrix.sqr((1, 0, 0, 0, 1, 0, 0, 0, 1))
+
+        print("Rotation matrix:\n{}".format(R))
 
         assert len(detector) == 1
 

--- a/doc/examples/read_experiment_and_data/example_experiment_data.py
+++ b/doc/examples/read_experiment_and_data/example_experiment_data.py
@@ -84,7 +84,8 @@ class Script(object):
         # now perform some calculations - the only things different from one
         # experiment to the next will be crystal models
         print("Crystals:")
-        [experiment.crystal.show() for experiment in experiments]
+        for experiment in experiments:
+            print(experiment.crystal)
         detector = experiments[0].detector
         beam = experiments[0].beam
         imageset = experiments[0].imageset

--- a/doc/examples/read_experiment_and_data/example_experiment_data.py
+++ b/doc/examples/read_experiment_and_data/example_experiment_data.py
@@ -54,7 +54,7 @@ class Script(object):
         )
 
     def run(self):
-        from dials.array_family import flex  # import dependency
+        from dials.array_family import flex  # noqa F401 import dependency
         from scitbx import matrix
         from dials.util.options import flatten_experiments
         from dials.util.options import flatten_reflections
@@ -95,14 +95,14 @@ class Script(object):
 
         # now perform some calculations - the only things different from one
         # experiment to the next will be crystal models
-        crystals = [experiment.crystal for experiment in experiments]
+        crystals = [experiment.crystal for experiment in experiments]  # noqa F841
         detector = experiments[0].detector
         beam = experiments[0].beam
         imageset = experiments[0].imageset
 
         # derived quantities
-        wavelength = beam.get_wavelength()
-        s0 = matrix.col(beam.get_s0())
+        wavelength = beam.get_wavelength()  # noqa F841
+        s0 = matrix.col(beam.get_s0())  # noqa F841
 
         # in here do some jiggery-pokery to cope with this being interpreted as
         # a rotation image in here i.e. if scan is not None; derive goniometer
@@ -118,9 +118,11 @@ class Script(object):
             axis = matrix.col(goniometer.get_rotation_axis_datum())
             F = matrix.sqr(goniometer.get_fixed_rotation())
             S = matrix.sqr(goniometer.get_setting_rotation())
-            R = S * axis.axis_and_angle_as_r3_rotation_matrix(angle, deg=True) * F
+            R = (
+                S * axis.axis_and_angle_as_r3_rotation_matrix(angle, deg=True) * F
+            )  # noqa F841
         else:
-            R = matrix.sqr((1, 0, 0, 0, 1, 0, 0, 0, 1))
+            R = matrix.sqr((1, 0, 0, 0, 1, 0, 0, 0, 1))  # noqa F841
 
         assert len(detector) == 1
 

--- a/doc/examples/read_experiment_and_data/experiment_data.py
+++ b/doc/examples/read_experiment_and_data/experiment_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# example_experiment_data.py
+# experiment_data.py
 #
 # Example code for how to load experiments and reflections in the DIALS
 # framework

--- a/test/command_line/test_sort_reflections.py
+++ b/test/command_line/test_sort_reflections.py
@@ -65,6 +65,21 @@ def test_default_sort_on_miller_index(dials_data, tmpdir):
     assert mi1.all_eq(mi2)
 
 
+def test_default_sort_on_miller_index_verbose(dials_data, tmpdir):
+    result = procrunner.run(
+        [
+            "dev.dials.sort_reflections",
+            dials_data("centroid_test_data").join("integrated.pickle").strpath,
+            "output=sorted4.refl",
+            "-v",
+        ],
+        working_directory=tmpdir.strpath,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("sorted4.refl").check(file=1)
+    assert "Head of sorted list miller_index:" in result.stdout
+
+
 def assert_sorted(data, reverse=False):
     assert len(data) > 0
     elem = data[0]


### PR DESCRIPTION
While working in xia2, I noticed a deprecation warning, so I did a little semi-automatic tidy-up.  This PR does the following, based on the advice in the deprecation warnings:
* Replace `dials.util.halraiser` with `dials.util.show_mail_on_error` context manager;
* Replace `dxtbx.model.experiment_list.ExperimentListDumper` and `dxtbx.serialize.dump` with `as_file` method of experiment list;
* Replace `dials.algorithms.indexing.index_reflections` with `dials.algorithms.indexing.assign_indices.AssignIndicesGlobal`;
* Remove some unused imports and variables to satisfy flake8.

Any objections?

There is a  corresponding PR in xia2 (https://github.com/xia2/xia2/pull/325), and others to follow in dials_scratch & dxtbx.