### PR TITLE
Python3: libfuturize.fixes.fix_cmp

### DIFF
--- a/algorithms/refinement/reflection_manager.py
+++ b/algorithms/refinement/reflection_manager.py
@@ -2,6 +2,7 @@
 principally ReflectionManager."""
 from __future__ import absolute_import, division, print_function
 
+from past.builtins import cmp
 import copy
 import logging
 import math

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -3,6 +3,7 @@ prediction based on the Reeke algorithm (see Mosflm)"""
 
 from __future__ import absolute_import, division, print_function
 
+from past.builtins import cmp
 import math
 
 from scitbx import matrix

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -16,9 +16,7 @@ def solve_quad(a, b, c):
     discriminant = b ** 2 - 4 * a * c
 
     if discriminant > 0:
-        sign = cmp(b, 0)
-        if sign == 0:
-            sign = 1.0
+        sign = math.copysign(1, b)
         q = -0.5 * (b + sign * math.sqrt(discriminant))
         x1 = q / a if a != 0 else None
         x2 = c / q if q != 0 else None

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -9,12 +9,11 @@
 #  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
-from past.builtins import cmp
-import os
 import builtins
 import collections
 import logging
 import operator
+import os
 import warnings
 
 import boost.python
@@ -495,7 +494,6 @@ class reflection_table_aux(boost.python.injector, reflection_table):
         :param name: The name of the column
         :param reverse: Reverse the sort order
         :param order: For multi element items specify order
-
         """
 
         if type(self[name]) in [
@@ -506,7 +504,7 @@ class reflection_table_aux(boost.python.injector, reflection_table):
             miller_index,
         ]:
             data = self[name]
-            if order is None:
+            if not order:
                 perm = flex.size_t(
                     builtins.sorted(
                         range(len(self)), key=lambda x: data[x], reverse=reverse
@@ -514,17 +512,10 @@ class reflection_table_aux(boost.python.injector, reflection_table):
                 )
             else:
                 assert len(order) == len(data[0])
-
-                def compare(x, y):
-                    a = tuple(x[i] for i in order)
-                    b = tuple(y[i] for i in order)
-                    return cmp(a, b)
-
                 perm = flex.size_t(
                     builtins.sorted(
                         range(len(self)),
-                        key=lambda x: data[x],
-                        cmp=compare,
+                        key=lambda x: tuple(data[x][i] for i in order),
                         reverse=reverse,
                     )
                 )
@@ -533,8 +524,8 @@ class reflection_table_aux(boost.python.injector, reflection_table):
         self.reorder(perm)
 
     """
-  Sorting the reflection table within an already sorted column
-  """
+    Sorting the reflection table within an already sorted column
+    """
 
     def subsort(self, key0, key1, reverse=False):
         """

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -9,6 +9,7 @@
 #  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
+from past.builtins import cmp
 import os
 import builtins
 import collections

--- a/test/array_family/test_reflection_table.py
+++ b/test/array_family/test_reflection_table.py
@@ -572,23 +572,37 @@ def test_del_selected():
 
 def test_sort():
     table = flex.reflection_table()
-    table["a"] = flex.int([2, 4, 3, 1, 5])
-    table["b"] = flex.vec2_double([(3, 2), (3, 1), (1, 3), (4, 5), (4, 3)])
+    table["a"] = flex.int([2, 4, 3, 1, 5, 6])
+    table["b"] = flex.vec2_double([(3, 2), (3, 1), (1, 3), (4, 5), (4, 3), (2, 0)])
     table["c"] = flex.miller_index(
-        [(3, 2, 1), (3, 1, 1), (2, 4, 2), (2, 1, 1), (1, 1, 1)]
+        [(3, 2, 1), (3, 1, 1), (2, 4, 2), (2, 1, 1), (1, 1, 1), (1, 1, 2)]
     )
 
     table.sort("a")
-    assert list(table["a"]) == [1, 2, 3, 4, 5]
+    assert list(table["a"]) == [1, 2, 3, 4, 5, 6]
 
     table.sort("b")
-    assert list(table["b"]) == [(1, 3), (3, 1), (3, 2), (4, 3), (4, 5)]
+    assert list(table["b"]) == [(1, 3), (2, 0), (3, 1), (3, 2), (4, 3), (4, 5)]
 
     table.sort("c")
-    assert list(table["c"]) == [(1, 1, 1), (2, 1, 1), (2, 4, 2), (3, 1, 1), (3, 2, 1)]
+    assert list(table["c"]) == [
+        (1, 1, 1),
+        (1, 1, 2),
+        (2, 1, 1),
+        (2, 4, 2),
+        (3, 1, 1),
+        (3, 2, 1),
+    ]
 
     table.sort("c", order=(1, 2, 0))
-    assert list(table["c"]) == [(1, 1, 1), (2, 1, 1), (3, 1, 1), (3, 2, 1), (2, 4, 2)]
+    assert list(table["c"]) == [
+        (1, 1, 1),
+        (2, 1, 1),
+        (3, 1, 1),
+        (1, 1, 2),
+        (3, 2, 1),
+        (2, 4, 2),
+    ]
 
 
 def test_flags():


### PR DESCRIPTION
This pull request is based on the `libfuturize.fixes.fix_cmp` fixer. In Python 3 `cmp()` is gone. Sorting should be done by using `key=` instead. The automatic fixer provides a backport for `cmp()`, which we still use in some no-comparative scenarios.