### PR TITLE
simplifying parts of the reeke algorithm

### DIFF
--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -260,8 +260,8 @@ class reeke_model:
 
         # Find distances between p = 0 and the plane passing through the
         # centre of the Ewald sphere
-        dp_beg = abs(v_beg.dot(self._source))
-        dp_end = abs(v_end.dot(self._source))
+        dp_beg = v_beg.dot(self._source)
+        dp_end = v_end.dot(self._source)
 
         # There are two planes of constant p that are tangential to the Ewald
         # sphere, on either side of the sphere. The smaller in magnitude of p
@@ -274,19 +274,24 @@ class reeke_model:
         # The correct sign is determined by whether the plane normal vector is
         # more closely parallel or antiparallel to the beam direction.
 
-        sign = cmp(v_beg.dot(self._source), 0)
+        sign = cmp(dp_beg, 0)
 
         limits = [
-            (sign * s * (self._source.length() + s * dp_beg) / p_dist) for s in (-1, 1)
+            (sign * s * (self._source.length() + s * abs(dp_beg)) / p_dist)
+            for s in (-1, 1)
         ]
 
         self._ewald_p_lim_beg = tuple(sorted(limits))
 
-        sign = cmp(v_end.dot(self._source), 0)
+        sign = cmp(dp_end, 0)
 
         limits = [
-            (sign * s * (self._source.length() + s * dp_end) / p_dist) for s in (-1, 1)
+            (sign * s * (self._source.length() + s * abs(dp_end)) / p_dist)
+            for s in (-1, 1)
         ]
+
+        dp_beg = abs(dp_beg)
+        dp_end = abs(dp_end)
 
         self._ewald_p_lim_end = tuple(sorted(limits))
 

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -332,13 +332,8 @@ class reeke_model:
             p_max_beg = min(max(self._res_p_lim_beg), max(self._ewald_p_lim_beg))
             p_max_end = min(max(self._res_p_lim_end), max(self._ewald_p_lim_end))
 
-        p_lim_beg = (p_min_beg, p_max_beg)
-        p_lim_end = (p_min_end, p_max_end)
-        # p_lim_beg = sorted(self._ewald_p_lim_beg + self._res_p_lim_beg)[1:3]
-        # p_lim_end = sorted(self._ewald_p_lim_end + self._res_p_lim_end)[1:3]
-
         # single set of limits covering overall range
-        p_lim = sorted(p_lim_beg + p_lim_end)[0::3]
+        p_lim = sorted((p_min_beg, p_max_beg, p_min_end, p_max_end))[0::3]
         p_lim[0] = int(p_lim[0]) - self._margin
         p_lim[1] = int(p_lim[1]) + self._margin
 

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -277,7 +277,7 @@ class reeke_model:
         sign = cmp(dp_beg, 0)
 
         limits = [
-            ((sign * s * self._source.length()) + (sign * s * s * abs(dp_beg))) / p_dist
+            ((sign * s * self._source.length()) + dp_beg) / p_dist
             for s in (-1, 1)
         ]
 
@@ -286,7 +286,7 @@ class reeke_model:
         sign = cmp(dp_end, 0)
 
         limits = [
-            ((sign * s * self._source.length()) + (sign * s * s * abs(dp_end))) / p_dist
+            ((sign * s * self._source.length()) + dp_end) / p_dist
             for s in (-1, 1)
         ]
 

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -277,7 +277,7 @@ class reeke_model:
         sign = cmp(dp_beg, 0)
 
         limits = [
-            (sign * s * (self._source.length() + s * abs(dp_beg)) / p_dist)
+            ((sign * s * self._source.length()) + (sign * s * s * abs(dp_beg))) / p_dist
             for s in (-1, 1)
         ]
 
@@ -286,7 +286,7 @@ class reeke_model:
         sign = cmp(dp_end, 0)
 
         limits = [
-            (sign * s * (self._source.length() + s * abs(dp_end)) / p_dist)
+            ((sign * s * self._source.length()) + (sign * s * s * abs(dp_end))) / p_dist
             for s in (-1, 1)
         ]
 

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -281,12 +281,17 @@ class reeke_model:
 
         self._ewald_p_lim_beg = tuple(sorted(limits))
 
-        sign = cmp(dp_end, 0)
-
         if dp_end == 0:
             limits = [0, 0]
         else:
             limits = [(dp_end + (s * self._source.length())) / p_dist for s in (-1, 1)]
+
+        if dp_end < 0:
+            sign = -1
+        elif dp_end == 0:
+            sign = 0
+        else:
+            sign = 1
 
         dp_beg = abs(dp_beg)
         dp_end = abs(dp_end)

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -293,9 +293,6 @@ class reeke_model:
         else:
             sign = 1
 
-        dp_beg = abs(dp_beg)
-        dp_end = abs(dp_end)
-
         self._ewald_p_lim_end = tuple(sorted(limits))
 
         # Now determine limits for the planes of p that touch the circle of
@@ -306,13 +303,13 @@ class reeke_model:
         assert abs(sin_theta) <= 1.0  # sanity check
         sin_2theta = math.sin(2.0 * math.asin(sin_theta))
 
-        e = 2.0 * sin_theta ** 2 * dp_beg
+        e = 2.0 * abs(dp_beg) * sin_theta ** 2
         f = sin_2theta * math.sqrt(max(1.0 / self._wavelength_sq - dp_beg ** 2, 0.0))
         limits = [(sign * e + s * f) / p_dist for s in (-1, 1)]
 
         self._res_p_lim_beg = tuple(sorted(limits))
 
-        e = 2.0 * sin_theta ** 2 * dp_end
+        e = 2.0 * abs(dp_end) * sin_theta ** 2
         f = sin_2theta * math.sqrt(max(1.0 / self._wavelength_sq - dp_end ** 2, 0))
         limits = [(sign * e + s * f) / p_dist for s in (-1, 1)]
 

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -274,21 +274,19 @@ class reeke_model:
         # The correct sign is determined by whether the plane normal vector is
         # more closely parallel or antiparallel to the beam direction.
 
-        sign = cmp(dp_beg, 0)
-
-        limits = [
-            ((sign * s * self._source.length()) + dp_beg) / p_dist
-            for s in (-1, 1)
-        ]
+        if dp_beg == 0:
+            limits = [0, 0]
+        else:
+            limits = [(dp_beg + (s * self._source.length())) / p_dist for s in (-1, 1)]
 
         self._ewald_p_lim_beg = tuple(sorted(limits))
 
         sign = cmp(dp_end, 0)
 
-        limits = [
-            ((sign * s * self._source.length()) + dp_end) / p_dist
-            for s in (-1, 1)
-        ]
+        if dp_end == 0:
+            limits = [0, 0]
+        else:
+            limits = [(dp_end + (s * self._source.length())) / p_dist for s in (-1, 1)]
 
         dp_beg = abs(dp_beg)
         dp_end = abs(dp_end)

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -258,7 +258,7 @@ class reeke_model:
         # Find distance between the planes of p
         p_dist = abs(self._rlv_beg[0].dot(v_beg))
 
-        # Find distances between p = 0 and the plane passing through the
+        # Find signed distances between p = 0 and the plane passing through the
         # centre of the Ewald sphere
         dp_beg = v_beg.dot(self._source)
         dp_end = v_end.dot(self._source)
@@ -274,18 +274,11 @@ class reeke_model:
         # The correct sign is determined by whether the plane normal vector is
         # more closely parallel or antiparallel to the beam direction.
 
-        # FIXME: is the == 0 case actually relevant?
-        if dp_beg == 0:
-            limits = [0, 0]
-        else:
-            limits = [(dp_beg + (s * self._source.length())) / p_dist for s in (-1, 1)]
+        limits = [(dp_beg + (s * self._source.length())) / p_dist for s in (-1, 1)]
 
         self._ewald_p_lim_beg = tuple(sorted(limits))
 
-        if dp_end == 0:
-            limits = [0, 0]
-        else:
-            limits = [(dp_end + (s * self._source.length())) / p_dist for s in (-1, 1)]
+        limits = [(dp_end + (s * self._source.length())) / p_dist for s in (-1, 1)]
 
         self._ewald_p_lim_end = tuple(sorted(limits))
 
@@ -307,15 +300,9 @@ class reeke_model:
         # 'sign' in the final expression replaced by 1, similar to the second
         # block dealing with dp_end.
         # Note the value of 'sign' is still used further down the line.
-        e = 2.0 * abs(dp_beg) * sin_theta ** 2
+        e = 2.0 * dp_beg * sin_theta ** 2
         f = sin_2theta * math.sqrt(max(1.0 / self._wavelength_sq - dp_beg ** 2, 0.0))
-        if dp_end < 0:
-            sign = -1
-        elif dp_end == 0:
-            sign = 0
-        else:
-            sign = 1
-        limits = [(sign * e + s * f) / p_dist for s in (-1, 1)]
+        limits = [(e + s * f) / p_dist for s in (-1, 1)]
 
         self._res_p_lim_beg = tuple(sorted(limits))
 
@@ -326,7 +313,7 @@ class reeke_model:
         self._res_p_lim_end = tuple(sorted(limits))
 
         # select between Ewald and resolution limits on the basis of sign
-        if sign < 0:  # p axis aligned with beam, against source
+        if dp_end < 0:  # p axis aligned with beam, against source
 
             p_min_beg = max(min(self._res_p_lim_beg), min(self._ewald_p_lim_beg))
             p_min_end = max(min(self._res_p_lim_end), min(self._ewald_p_lim_end))

--- a/algorithms/spot_prediction/reeke.py
+++ b/algorithms/spot_prediction/reeke.py
@@ -290,16 +290,6 @@ class reeke_model:
         assert abs(sin_theta) <= 1.0  # sanity check
         sin_2theta = math.sin(2.0 * math.asin(sin_theta))
 
-        # FIXME
-        # I assume the sign trickery in the following block was done in error
-        # and should not really happen: The original code redefined 'sign' in
-        # the block above this code and as a result ends up attaching the sign
-        # of dp_end to the absolute value of db_beg. I have faithfully retained
-        # this behaviour below.
-        # I suspect in reality the abs() in e=... should be dropped and the
-        # 'sign' in the final expression replaced by 1, similar to the second
-        # block dealing with dp_end.
-        # Note the value of 'sign' is still used further down the line.
         e = 2.0 * dp_beg * sin_theta ** 2
         f = sin_2theta * math.sqrt(max(1.0 / self._wavelength_sq - dp_beg ** 2, 0.0))
         limits = [(e + s * f) / p_dist for s in (-1, 1)]


### PR DESCRIPTION
This came up as part of getting rid of `cmp()` for Python 3 (#897), but really warrants its own PR.

The changes in this pull request result in mathematically identical code, which raised some questions with the original code, which likely contains at least one bug.