### PR TITLE
Implement unique experiment identifiers

### DIFF
--- a/algorithms/indexing/assign_indices.py
+++ b/algorithms/indexing/assign_indices.py
@@ -60,6 +60,10 @@ class AssignIndicesGlobal(AssignIndicesStrategy):
                 sel_cryst = crystal_ids == i_cryst
                 for i_expt in experiments.where(crystal=cryst, imageset=imgset):
                     expt_ids.set_selected(sel_cryst, i_expt)
+                    if experiments[i_expt].identifier:
+                        reflections.experiment_identifiers()[i_expt] = experiments[
+                            i_expt
+                        ].identifier
 
             reflections["miller_index"].set_selected(
                 isel.select(sel_imgset), miller_indices
@@ -147,6 +151,9 @@ class AssignIndicesLocal(AssignIndicesStrategy):
                 cryst_sel, flex.miller_index(list(h.iround()))
             )
             refs["id"].set_selected(cryst_sel, i_cryst)
+            identifier = experiments[i_cryst].identifier
+            if identifier:
+                reflections.experiment_identifiers()[i_cryst] = identifier
 
         crystal_ids.set_selected(crystal_ids < 0, -1)
         refs["id"] = crystal_ids

--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -562,11 +562,22 @@ class Indexer(object):
             if self.d_min is None:
                 self.d_min = self.params.refinement_protocol.d_min_start
 
+            def assign_unique_identifiers(experiments):
+                """Assign unique identifiers to each experiment."""
+                import uuid
+
+                for expt in experiments:
+                    expt.identifier = str(uuid.uuid4())
+                    print("assigned %s" % expt.identifier)
+
             if len(experiments) == 0:
-                experiments.extend(self.find_lattices())
+                new_exp = self.find_lattices()
+                assign_unique_identifiers(new_exp)
+                experiments.extend(new_exp)
             else:
                 try:
                     new = self.find_lattices()
+                    assign_unique_identifiers(new)
                     experiments.extend(new)
                 except Sorry:
                     logger.info("Indexing remaining reflections failed")

--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -28,6 +28,7 @@ from dials.algorithms.indexing.symmetry import SymmetryHandler
 from dials.algorithms.indexing.max_cell import find_max_cell
 from dials.algorithms.refinement import DialsRefineConfigError, DialsRefineRuntimeError
 from dials.util import Sorry
+from dials.util.multi_dataset_handling import generate_experiment_identifiers
 from dxtbx.model import ExperimentList
 
 logger = logging.getLogger(__name__)
@@ -562,22 +563,14 @@ class Indexer(object):
             if self.d_min is None:
                 self.d_min = self.params.refinement_protocol.d_min_start
 
-            def assign_unique_identifiers(experiments):
-                """Assign unique identifiers to each experiment."""
-                import uuid
-
-                for expt in experiments:
-                    expt.identifier = str(uuid.uuid4())
-                    print("assigned %s" % expt.identifier)
-
             if len(experiments) == 0:
                 new_exp = self.find_lattices()
-                assign_unique_identifiers(new_exp)
+                generate_experiment_identifiers(new_exp)
                 experiments.extend(new_exp)
             else:
                 try:
                     new = self.find_lattices()
-                    assign_unique_identifiers(new)
+                    generate_experiment_identifiers(new)
                     experiments.extend(new)
                 except Sorry:
                     logger.info("Indexing remaining reflections failed")

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -15,6 +15,7 @@ from dials.algorithms.indexing.known_orientation import IndexerKnownOrientation
 from dials.algorithms.indexing.lattice_search import BasisVectorSearch, LatticeSearch
 from dials.algorithms.indexing.nave_parameters import NaveParameters
 from dials.algorithms.indexing import DialsIndexError, DialsIndexRefineError
+from dials.util.multi_dataset_handling import generate_experiment_identifiers
 
 logger = logging.getLogger(__name__)
 
@@ -138,12 +139,15 @@ class StillsIndexer(Indexer):
 
             # index multiple lattices per shot
             if len(experiments) == 0:
-                experiments.extend(self.find_lattices())
+                new = self.find_lattices()
+                generate_experiment_identifiers(new)
+                experiments.extend(new)
                 if len(experiments) == 0:
                     raise DialsIndexError("No suitable lattice could be found.")
             else:
                 try:
                     new = self.find_lattices()
+                    generate_experiment_identifiers(new)
                     experiments.extend(new)
                 except Exception as e:
                     logger.info("Indexing remaining reflections failed")

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -104,14 +104,15 @@ class ScalingSummaryGenerator(Observer):
         valid_ranges = get_valid_image_ranges(scaling_script.experiments)
         image_ranges = get_image_ranges(scaling_script.experiments)
         msg = []
-        for (img, valid, exp) in zip(
-            image_ranges, valid_ranges, scaling_script.experiments
+        for (img, valid, refl) in zip(
+            image_ranges, valid_ranges, scaling_script.reflections
         ):
             if valid:
+                id_ = list(set(refl["id"]).difference(set([-1])))[0]
                 if len(valid) > 1 or valid[0][0] != img[0] or valid[-1][1] != img[1]:
                     msg.append(
-                        "Excluded images for experiment identifier: %s, image range: %s, limited range: %s"
-                        % (exp.identifier, list(img), list(valid))
+                        "Excluded images for dataset %s; image range: %s, limited range: %s"
+                        % (id_, list(img), list(valid))
                     )
         if msg:
             msg = ["Summary of image ranges removed:"] + msg
@@ -212,8 +213,7 @@ class ScalingModelObserver(Observer):
         if not active_scalers:
             active_scalers = [scaler]
         for s in active_scalers:
-            id_ = s.experiment.identifier
-            self.data[id_] = s.experiment.scaling_model.to_dict()
+            self.data[s.id_] = s.experiment.scaling_model.to_dict()
 
     def make_plots(self):
         """Generate scaling model component plot data."""
@@ -272,14 +272,13 @@ class ScalingOutlierObserver(Observer):
         if not active_scalers:
             active_scalers = [scaler]
         for scaler in active_scalers:
-            id_ = scaler.experiment.identifier
             outlier_isel = scaler.suitable_refl_for_scaling_sel.iselection().select(
                 scaler.outliers
             )
             x, y, z = (
                 scaler.reflection_table["xyzobs.px.value"].select(outlier_isel).parts()
             )
-            self.data[id_] = {
+            self.data[scaler.id_] = {
                 "x": list(x),
                 "y": list(y),
                 "z": list(z),

--- a/algorithms/scaling/scaler_factory.py
+++ b/algorithms/scaling/scaler_factory.py
@@ -78,9 +78,6 @@ class ScalerFactory(object):
         id_vals = list(reflection_table.experiment_identifiers().values())
         assert experiment.identifier in id_vals, (experiment.identifier, list(id_vals))
         assert len(id_vals) == 1, list(id_vals)
-        logger.info(
-            "The experiment identifier for this dataset is %s", experiment.identifier
-        )
 
 
 class SingleScalerFactory(ScalerFactory):
@@ -95,7 +92,7 @@ class SingleScalerFactory(ScalerFactory):
         logger.info(
             "Preprocessing data for scaling. The id assigned to this \n"
             "dataset is %s, and the scaling model type being applied is %s. \n",
-            list(reflection_table.experiment_identifiers().values())[0],
+            list(reflection_table.experiment_identifiers().keys())[0],
             experiment.scaling_model.id_,
         )
 

--- a/algorithms/scaling/scaling_library.py
+++ b/algorithms/scaling/scaling_library.py
@@ -36,7 +36,7 @@ def set_image_ranges_in_scaling_models(experiments):
     for exp in experiments:
         if exp.scan:
             valid_image_ranges = exp.scan.get_valid_image_ranges(exp.identifier)
-            if not "valid_image_range" in exp.scaling_model.configdict:
+            if "valid_image_range" not in exp.scaling_model.configdict:
                 # only set if not currently set i.e. set initial
                 exp.scaling_model.set_valid_image_range(exp.scan.get_image_range())
             if exp.scaling_model.configdict["valid_image_range"] != [
@@ -71,7 +71,7 @@ def choose_scaling_intensities(reflection_table, intensity_choice="profile"):
     reflection_table = calculate_prescaling_correction(reflection_table)
     conv = reflection_table["prescaling_correction"]
     intstr = "intensity." + intensity_choice + ".value"
-    if not intstr in reflection_table:
+    if intstr not in reflection_table:
         # Can't find selection, try to choose prf, if not then sum (also catches combine
         # which should not be used at this point)
         if "intensity.prf.value" in reflection_table:
@@ -274,7 +274,7 @@ def create_Ih_table(experiments, reflections, selections=None, n_blocks=1):
     input_tables = []
     indices_lists = []
     for i, reflection in enumerate(reflections):
-        if not "inverse_scale_factor" in reflection:
+        if "inverse_scale_factor" not in reflection:
             reflection["inverse_scale_factor"] = flex.double(reflection.size(), 1.0)
         if selections:
             input_tables.append(reflection.select(selections[i]))

--- a/algorithms/scaling/scaling_library.py
+++ b/algorithms/scaling/scaling_library.py
@@ -11,6 +11,7 @@ ExperimentLists.
 from __future__ import absolute_import, division, print_function
 from copy import deepcopy
 import logging
+import uuid
 import pkg_resources
 from libtbx import phil
 from mock import Mock
@@ -26,7 +27,6 @@ from dials.algorithms.scaling.scaling_utilities import (
     calculate_prescaling_correction,
     DialsMergingStatisticsError,
 )
-from dials.util.multi_dataset_handling import get_next_unique_id
 
 logger = logging.getLogger("dials")
 
@@ -478,11 +478,9 @@ def create_datastructures_for_target_mtz(experiments, mtz_file):
 
     exp = Experiment()
     exp.crystal = deepcopy(experiments[0].crystal)
-    used_ids = experiments.identifiers()
-    unique_id = get_next_unique_id(len(used_ids), used_ids)
-    exp.identifier = str(unique_id)
-    r_t.experiment_identifiers()[unique_id] = str(unique_id)
-    r_t["id"] = flex.int(r_t.size(), unique_id)
+    exp.identifier = str(uuid.uuid4())
+    r_t.experiment_identifiers()[len(experiments)] = exp.identifier
+    r_t["id"] = flex.int(r_t.size(), len(experiments))
 
     # create a new KB scaling model for the target and set as scaled to fix scale
     # for targeted scaling.
@@ -543,10 +541,8 @@ def create_datastructures_for_structural_model(reflections, experiments, cif_fil
     rt["intensity"] = icalc
     rt["miller_index"] = miller_idx
 
-    used_ids = experiments.identifiers()
-    unique_id = get_next_unique_id(len(used_ids), used_ids)
-    exp.identifier = str(unique_id)
-    rt.experiment_identifiers()[unique_id] = str(unique_id)
-    rt["id"] = flex.int(rt.size(), unique_id)
+    exp.identifier = str(uuid.uuid4())
+    rt.experiment_identifiers()[len(experiments)] = exp.identifier
+    rt["id"] = flex.int(rt.size(), len(experiments))
 
     return exp, rt

--- a/algorithms/scaling/test_observers.py
+++ b/algorithms/scaling/test_observers.py
@@ -94,10 +94,11 @@ def test_ScalingModelObserver():
     scaler1 = mock.Mock()
     scaler1.experiment = experiment
     scaler1.active_scalers = None
+    scaler1.id_ = 0
 
     observer = ScalingModelObserver()
     observer.update(scaler1)
-    assert observer.data["0"] == KB_dict
+    assert observer.data[0] == KB_dict
 
     msg = observer.return_model_error_summary()
     assert msg != ""
@@ -118,13 +119,14 @@ def test_ScalingModelObserver():
     scaler2 = mock.Mock()
     scaler2.experiment = experiment2
     scaler2.active_scalers = None
+    scaler2.id_ = 1
 
     multiscaler = mock.Mock()
     multiscaler.active_scalers = [scaler1, scaler2]
     observer.data = {}
     observer.update(multiscaler)
-    assert observer.data["0"] == KB_dict
-    assert observer.data["1"] == KB_dict
+    assert observer.data[0] == KB_dict
+    assert observer.data[1] == KB_dict
 
     mock_func = mock.Mock()
     mock_func.return_value = {"plot": {"layout": {"title": ""}}}
@@ -153,17 +155,19 @@ def test_ScalingOutlierObserver():
     scaler.reflection_table = {
         "xyzobs.px.value": flex.vec3_double(
             [(0, 1, 2), (10, 11, 12), (20, 21, 22), (30, 31, 32)]
-        )
+        ),
+        "id": flex.int([0, 0, 0, 0]),
     }
     scaler.experiment.identifier = "0"
     scaler.experiment.detector = [mock_detector]
     scaler.experiment.scan = mock_scan
     scaler.active_scalers = None
+    scaler.id_ = 0
 
     observer = ScalingOutlierObserver()
     observer.update(scaler)
     assert observer.data == {
-        "0": {
+        0: {
             "x": [10],
             "y": [11],
             "z": [12],
@@ -181,7 +185,7 @@ def test_ScalingOutlierObserver():
     with mock.patch("dials.algorithms.scaling.observers.plot_outliers", new=mock_func):
         r = observer.make_plots()
         assert mock_func.call_count == 1
-        assert mock_func.call_args_list == [mock.call(observer.data["0"])]
+        assert mock_func.call_args_list == [mock.call(observer.data[0])]
         assert all(
             i in r["outlier_plots"] for i in ["outlier_plot_0", "outlier_plot_z0"]
         )

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -157,42 +157,40 @@ def test_scale_script_prepare_input():
         _ = Script(params, exp, reflections)
 
     params, exp, reflections = generate_test_input()
-    # Try to use use_datasets when not identifiers set
-    params.dataset_selection.use_datasets = ["0"]
-    with pytest.raises(Sorry):
-        _ = Script(params, exp, reflections)
-    # Try to use use_datasets when not identifiers set
-    params.dataset_selection.use_datasets = None
-    params.dataset_selection.exclude_datasets = ["0"]
-    with pytest.raises(Sorry):
-        _ = Script(params, exp, reflections)
 
     # Now make two experiments with identifiers and select on them
     params, exp, reflections = generate_test_input(n=2)
     exp[0].identifier = "0"
+    joint_refl = flex.reflection_table()
     reflections[0].experiment_identifiers()[0] = "0"
     exp[1].identifier = "1"
-    reflections[1].experiment_identifiers()[0] = "1"
+    reflections[1]["id"] = flex.int(reflections[1].size(), 1)
+    reflections[1].experiment_identifiers()[1] = "1"
     list1 = ExperimentList().append(exp[0])
     list2 = ExperimentList().append(exp[1])
     reflections[0].assert_experiment_identifiers_are_consistent(list1)
     reflections[1].assert_experiment_identifiers_are_consistent(list2)
-    params.dataset_selection.use_datasets = ["0"]
-    params, exp, script_reflections = Script.prepare_input(params, exp, reflections)
+    joint_refl.extend(reflections[0])
+    joint_refl.extend(reflections[1])
+    params.dataset_selection.use_datasets = [0]
+    params, exp, script_reflections = Script.prepare_input(params, exp, [joint_refl])
 
     assert len(script_reflections) == 1
 
     # Try again, this time excluding
     params, exp, reflections = generate_test_input(n=2)
+    joint_refl = flex.reflection_table()
     exp[0].identifier = "0"
     reflections[0].experiment_identifiers()[0] = "0"
     exp[1].identifier = "1"
-    reflections[1].experiment_identifiers()[0] = "1"
-    params.dataset_selection.exclude_datasets = ["0"]
-    params, exp, script_reflections = Script.prepare_input(params, exp, reflections)
+    reflections[1]["id"] = flex.int(reflections[1].size(), 1)
+    reflections[1].experiment_identifiers()[1] = "1"
+    joint_refl.extend(reflections[0])
+    joint_refl.extend(reflections[1])
+    params.dataset_selection.exclude_datasets = [0]
+    params, exp, script_reflections = Script.prepare_input(params, exp, [joint_refl])
 
     assert len(script_reflections) == 1
-    assert script_reflections[0] is reflections[1]
 
     # Try having two unequal space groups
     params, exp, reflections = generate_test_input(n=2)

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -413,7 +413,7 @@ def test_scale_and_filter_dataset_mode(dials_data, tmpdir):
     assert tmpdir.join("analysis_results.json").check()
     with open(tmpdir.join("analysis_results.json").strpath) as f:
         analysis_results = json.load(f)
-    assert analysis_results["cycle_results"]["1"]["removed_datasets"] == ["4"]
+    assert analysis_results["cycle_results"]["1"]["removed_datasets"] == [4]
 
 
 def test_scale_optimise_errors(dials_regression, tmpdir):

--- a/algorithms/scaling/test_scale_and_filter.py
+++ b/algorithms/scaling/test_scale_and_filter.py
@@ -164,7 +164,7 @@ def test_compute_delta_cchalf_returned_results():
     )
     assert "experiments_fully_removed" in results_summary["dataset_removal"]
     assert "n_reflections_removed" in results_summary["dataset_removal"]
-    assert results_summary["dataset_removal"]["experiments_fully_removed"] == ["0"]
+    assert results_summary["dataset_removal"]["experiments_fully_removed"] == [0]
     assert results_summary["dataset_removal"]["n_reflections_removed"] == 10
 
     # Check for correct recording for image group mode.
@@ -190,7 +190,7 @@ def test_compute_delta_cchalf_returned_results():
     assert "experiments_fully_removed" in results_summary["dataset_removal"]
     assert "n_reflections_removed" in results_summary["dataset_removal"]
     assert "image_ranges_removed" in results_summary["dataset_removal"]
-    assert results_summary["dataset_removal"]["experiments_fully_removed"] == ["0"]
+    assert results_summary["dataset_removal"]["experiments_fully_removed"] == [0]
     assert results_summary["dataset_removal"]["n_reflections_removed"] == 10
     assert results_summary["dataset_removal"]["image_ranges_removed"] == [
         [(6, 10), 0],

--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -769,8 +769,8 @@ class SpotFinder(object):
             logger.info("")
             table, hot_mask = self._find_spots_in_imageset(imageset)
             table["id"] = flex.int(table.nrows(), i)
+            table.experiment_identifiers()[i] = experiment.identifier
             reflections.extend(table)
-
             # Write a hot pixel mask
             if self.write_hot_mask:
                 if not imageset.external_lookup.mask.data.empty():

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -1377,6 +1377,25 @@ Found %s"""
             del self.experiment_identifiers()[id_val]
         return self
 
+    def select_on_id_values(self, values):
+        """Select a subset of the reflection table based on the "id" column
+        values.
+
+        The experiment identifiers map is also updated.
+
+        Args:
+            value (list): a list of integers
+
+        Returns:
+            A reflection table containing a subset of the data
+        """
+        sel = flex.bool(self.size(), False)
+        for val in values:
+            sel |= self["id"] == val
+        selected_table = self.select(sel)
+        selected_table.clean_experiment_identifiers_map()
+        return selected_table
+
     def clean_experiment_identifiers_map(self):
         """
         Remove any entries from the identifier map that do not have any

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -1265,7 +1265,7 @@ class reflection_table_aux(boost.python.injector, reflection_table):
             values = list(identifiers.values())
             assert len(set(values)) == len(values), (len(set(values)), len(values))
             if "id" in self:
-                index = set(self["id"])
+                index = set(self["id"]).difference({-1})
                 for i in index:
                     assert i in identifiers, (i, list(identifiers))
         if experiments is not None:

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -21,10 +21,10 @@ import cctbx
 import libtbx.smart_open
 import six
 import six.moves.cPickle as pickle
-from cctbx.array_family.flex import *
+from cctbx.array_family.flex import *  # noqa: F403
 from cctbx.array_family import flex
 from cctbx import miller
-from dials_array_family_flex_ext import *
+from dials_array_family_flex_ext import *  # noqa: F403
 from dials.util import Sorry
 from scitbx import matrix
 

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -170,6 +170,8 @@ class reflection_table_aux(boost.python.injector, reflection_table):
                 padding=padding,
             )
             rlist["id"] = flex.int(len(rlist), i)
+            if e.identifier:
+                rlist.experiment_identifiers()[i] = e.identifier
             result.extend(rlist)
         return result
 

--- a/command_line/assign_experiment_identifiers.py
+++ b/command_line/assign_experiment_identifiers.py
@@ -6,7 +6,7 @@ import sys
 
 from libtbx import phil
 from dials.util import show_mail_on_error, Sorry
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.array_family import flex
 from dials.algorithms.scaling.scaling_utilities import (
     save_experiments,
@@ -56,8 +56,9 @@ def run(args=None):
         parser.print_help()
         sys.exit()
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     reflections = parse_multiple_datasets(reflections)
     if len(experiments) != len(reflections):

--- a/command_line/augment_spots.py
+++ b/command_line/augment_spots.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import iotbx.phil
-from dials.util.options import OptionParser
-from dials.util.options import flatten_experiments
-from dials.util.options import flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.array_family import flex
 
 help_message = """
@@ -112,8 +110,9 @@ def run(args):
 
     params, options = parser.parse_args(show_diff_phil=True)
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(reflections) != 1:
         raise Sorry("Exactly one reflection file needed")

--- a/command_line/check_indexing_symmetry.py
+++ b/command_line/check_indexing_symmetry.py
@@ -25,8 +25,7 @@ from cctbx.miller import set as miller_set
 from cctbx.sgtbx import space_group as sgtbx_space_group
 from dials.algorithms.symmetry import origin
 from dials.array_family import flex
-from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util import log
 from dials.util.version import dials_version
 from libtbx.utils import format_float_with_standard_uncertainty
@@ -338,8 +337,9 @@ def run(args):
     log.config(info=params.output.log, debug=params.output.debug_log)
     logger.info(dials_version())
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if len(reflections) == 0 or len(experiments) == 0:
         parser.print_help()
         return

--- a/command_line/compute_delta_cchalf.py
+++ b/command_line/compute_delta_cchalf.py
@@ -402,9 +402,10 @@ class Script(object):
                         image_range,
                         identifier,
                     )
+                    index = list(experiments.identifiers()).index(identifier)
                     exclude_images.append(
                         [
-                            identifier
+                            str(index)
                             + ":"
                             + str(image_range[0])
                             + ":"
@@ -493,7 +494,7 @@ class Script(object):
         ).count(False)
         results_summary["dataset_removal"].update(
             {
-                "experiments_fully_removed": datasets_to_remove,
+                "experiments_fully_removed": list(ids_to_remove),
                 "n_reflections_removed": n_valid_reflections
                 - n_valid_filtered_reflections,
             }

--- a/command_line/compute_delta_cchalf.py
+++ b/command_line/compute_delta_cchalf.py
@@ -538,9 +538,7 @@ class Script(object):
 def run(args=None, phil=phil_scope):
     """Run the command-line script."""
     import dials.util.log
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_reflections
-    from dials.util.options import flatten_experiments
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
     usage = "dials.compute_delta_cchalf [options] scaled.expt scaled.refl"
 
@@ -557,8 +555,9 @@ def run(args=None, phil=phil_scope):
 
     dials.util.log.config(info=params.output.log, debug=params.output.debug_log)
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     script = Script(params, experiments, reflections)
     script.run()

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -7,7 +7,7 @@ import iotbx.phil
 from cctbx import sgtbx
 from dials.array_family import flex
 from dials.util import show_mail_on_error, Sorry
-from dials.util.options import flatten_experiments, flatten_reflections
+from dials.util.options import reflections_and_experiments_from_files
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
     parse_multiple_datasets,
@@ -344,8 +344,9 @@ def run(args):
         parser.print_help()
         sys.exit()
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     reflections = parse_multiple_datasets(reflections)
     if len(experiments) != len(reflections):

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -11,7 +11,7 @@ from dials.util.options import flatten_experiments, flatten_reflections
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
     parse_multiple_datasets,
-    select_datasets_on_ids,
+    select_datasets_on_identifiers,
 )
 from dials.util.observer import Subject
 from dials.util.filter_reflections import filtered_arrays_from_experiments_reflections
@@ -96,7 +96,7 @@ class cosym(Subject):
                     len(identifiers),
                     str(identifiers),
                 )
-                self._experiments, self._reflections = select_datasets_on_ids(
+                self._experiments, self._reflections = select_datasets_on_identifiers(
                     self._experiments, self._reflections, use_datasets=identifiers
                 )
 
@@ -218,7 +218,7 @@ class cosym(Subject):
             expt.crystal = expt.crystal.change_basis(cb_op_to_primitive)
             identifiers.append(expt.identifier)
 
-        return select_datasets_on_ids(
+        return select_datasets_on_identifiers(
             experiments, reflections, use_datasets=identifiers
         )
 
@@ -229,7 +229,7 @@ class cosym(Subject):
             if len(refl) >= self.params.min_reflections:
                 identifiers.append(expt.identifier)
 
-        return select_datasets_on_ids(
+        return select_datasets_on_identifiers(
             experiments, reflections, use_datasets=identifiers
         )
 

--- a/command_line/create_profile_model.py
+++ b/command_line/create_profile_model.py
@@ -70,7 +70,7 @@ class Script(object):
         from dials.algorithms.profile_model.factory import ProfileModelFactory
         from dials.util.command_line import Command
         from dials.array_family import flex
-        from dials.util.options import flatten_reflections, flatten_experiments
+        from dials.util.options import reflections_and_experiments_from_files
         from dials.util import Sorry
         from dials.util import log
 
@@ -78,8 +78,9 @@ class Script(object):
 
         # Parse the command line
         params, options = self.parser.parse_args(show_diff_phil=True)
-        reflections = flatten_reflections(params.input.reflections)
-        experiments = flatten_experiments(params.input.experiments)
+        reflections, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
         if len(reflections) == 0 and len(experiments) == 0:
             self.parser.print_help()
             return

--- a/command_line/detect_blanks.py
+++ b/command_line/detect_blanks.py
@@ -196,11 +196,8 @@ def blank_regions_from_sel(d):
 
 def run(args):
 
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     from dials.util import log
-    import libtbx.load_env
 
     usage = "dials.detect_blanks [options] models.expt observations.refl"
 
@@ -214,8 +211,9 @@ def run(args):
     )
 
     params, options = parser.parse_args()
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -12,16 +12,16 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-import uuid
 import libtbx.load_env
 from dials.util import show_mail_on_error, Sorry
+from dials.util.options import flatten_experiments
+from dials.util.multi_dataset_handling import generate_experiment_identifiers
 from dxtbx.model.experiment_list import Experiment
 from dxtbx.model.experiment_list import ExperimentList
 from dxtbx.model.experiment_list import ExperimentListFactory
 from dxtbx.model.experiment_list import ExperimentListTemplateImporter
 from dxtbx.imageset import ImageGrid
 from dxtbx.imageset import ImageSweep
-from dials.util.options import flatten_experiments
 
 logger = logging.getLogger("dials.command_line.import")
 
@@ -237,22 +237,13 @@ class ImageSetImporter(object):
                 raise Sorry("No experiments found")
 
         if self.params.identifier_type:
-            assign_unique_identifiers(experiments, self.params.identifier_type)
+            generate_experiment_identifiers(experiments, self.params.identifier_type)
 
         # Get a list of all imagesets
         imageset_list = experiments.imagesets()
 
         # Return the experiments
         return imageset_list
-
-
-def assign_unique_identifiers(experiments, identifier_type):
-    """Assign unique identifiers to each experiment."""
-    if identifier_type == "uuid":
-        for expt in experiments:
-            expt.identifier = str(uuid.uuid4())
-    elif identifier_type == "timestamp":
-        pass
 
 
 class ReferenceGeometryUpdater(object):
@@ -588,7 +579,7 @@ class MetaDataUpdater(object):
                         )
                     )
         if self.params.identifier_type:
-            assign_unique_identifiers(experiments, self.params.identifier_type)
+            generate_experiment_identifiers(experiments, self.params.identifier_type)
         # Return the experiments
         return experiments
 

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -680,11 +680,7 @@ class JsonExporter(object):
 
 
 if __name__ == "__main__":
-    from dials.util.options import (
-        OptionParser,
-        flatten_experiments,
-        flatten_reflections,
-    )
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     from dials.util.version import dials_version
     from dials.util import log
     from dials.util import Sorry
@@ -733,8 +729,9 @@ if __name__ == "__main__":
         sys.exit()
 
     # Get the experiments and reflections
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     # do auto intepreting of intensity choice:
     # note that this may still fail certain checks further down the processing,

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -336,7 +336,7 @@ class SadabsExporter(object):
     def export(self):
         from dials.util.export_sadabs import export_sadabs
 
-        if not "profile" in params.intensity and not "sum" in params.intensity:
+        if "profile" not in params.intensity and "sum" not in params.intensity:
             raise Sorry(
                 """Only intensity options containing sum or profile are compatible with
 export to sadabs format."""
@@ -387,7 +387,7 @@ class XDSASCIIExporter(object):
     def export(self):
         from dials.util.export_xds_ascii import export_xds_ascii
 
-        if not "profile" in params.intensity and not "sum" in params.intensity:
+        if "profile" not in params.intensity and "sum" not in params.intensity:
             raise Sorry(
                 """Only intensity options containing sum or profile are compatible with
 export to xds_ascii format."""

--- a/command_line/filter_reflections.py
+++ b/command_line/filter_reflections.py
@@ -11,7 +11,7 @@ from StringIO import StringIO
 
 from dials.util import Sorry, log, show_mail_on_error
 from dials.util.filter_reflections import SumAndPrfIntensityReducer, SumIntensityReducer
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.array_family import flex
 from dials.algorithms.integration import filtering
 from dials.algorithms.spot_finding.per_image_analysis import map_to_reciprocal_space
@@ -430,8 +430,9 @@ def run():
     )
 
     params, options = parser.parse_args(show_diff_phil=True)
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     log.config(verbosity=options.verbose)
 

--- a/command_line/find_hot_pixels.py
+++ b/command_line/find_hot_pixels.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 
 import iotbx.phil
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
 logger = logging.getLogger("dials.command_line.find_hot_pixels")
 
@@ -75,8 +75,9 @@ def run(args):
         logger.info("The following parameters have been modified:\n")
         logger.info(diff_phil)
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 and len(reflections) == 0:
         parser.print_help()

--- a/command_line/image_viewer.py
+++ b/command_line/image_viewer.py
@@ -154,9 +154,7 @@ if __name__ == "__main__":
         #       without having to alter the package
         wx.SystemSettings_GetColour = wx.SystemSettings.GetColour
 
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_reflections
-    from dials.util.options import flatten_experiments
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
     dials.util.log.print_banner()
     usage_message = "dials.image_viewer models.expt [observations.refl]"
@@ -170,13 +168,14 @@ if __name__ == "__main__":
     )
     params, options = parser.parse_args(show_diff_phil=True)
     experiments = [x.data for x in params.input.experiments]
-    reflections = flatten_reflections(params.input.reflections)
 
     if len(experiments) == 0:
         parser.print_help()
         exit(0)
 
-    flat_expts = flatten_experiments(params.input.experiments)
+    reflections, flat_expts = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if params.load_models:
         if any(e.detector is None for e in flat_expts):
             sys.exit("Error: experiment has no detector")

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -11,7 +11,7 @@ from dials.algorithms.indexing import indexer
 from dials.algorithms.indexing import DialsIndexError
 from dials.array_family import flex
 from dials.util.slice import slice_reflections
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util import Sorry
 from dials.util.multi_dataset_handling import renumber_table_id_columns
 
@@ -252,8 +252,9 @@ def run(phil=working_phil, args=None):
         logger.info("The following parameters have been modified:\n")
         logger.info(diff_phil)
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0:
         parser.print_help()

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -137,6 +137,7 @@ class Index(object):
             reflections[0]["imageset_id"] = reflections[0]["id"]
         elif len(reflections) > 1:
             assert len(reflections) == len(experiments)
+            reflections = renumber_table_id_columns(reflections)
             for i in range(len(reflections)):
                 reflections[i]["imageset_id"] = flex.int(len(reflections[i]), i)
                 if i > 0:

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -158,7 +158,7 @@ class Script(object):
     def run(self, args=None):
         """ Perform the integration. """
         from dials.util.command_line import heading
-        from dials.util.options import flatten_reflections, flatten_experiments
+        from dials.util.options import reflections_and_experiments_from_files
         from dials.util import log
         from time import time
         from dials.util import Sorry
@@ -168,8 +168,9 @@ class Script(object):
 
         # Parse the command line
         params, options = self.parser.parse_args(args=args, show_diff_phil=False)
-        reference = flatten_reflections(params.input.reflections)
-        experiments = flatten_experiments(params.input.experiments)
+        reference, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
         if len(reference) == 0 and len(experiments) == 0:
             self.parser.print_help()
             return

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -405,7 +405,12 @@ class Script(object):
                 refls = filtered_refls.select(filtered_refls["id"] == expt_id)
                 if len(refls) > 0:
                     accepted_expts.append(expt)
-                    refls["id"] = flex.int(len(refls), len(accepted_expts) - 1)
+                    current_id = expt_id
+                    new_id = len(accepted_expts) - 1
+                    refls["id"] = flex.int(len(refls), new_id)
+                    if expt.identifier:
+                        del refls.experiment_identifiers()[current_id]
+                        refls.experiment_identifiers()[new_id] = expt.identifier
                     accepted_refls.extend(refls)
                 else:
                     logger.info(
@@ -417,6 +422,7 @@ class Script(object):
                 raise Sorry("No reflections left after applying significance filter")
             experiments = accepted_expts
             reflections = accepted_refls
+            reflections.assert_experiment_identifiers_are_consistent(experiments)
 
         # Delete the shoeboxes used for intermediate calculations, if requested
         if params.integration.debug.delete_shoeboxes and "shoebox" in reflections:

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -8,7 +8,7 @@ import logging
 import sys
 from cStringIO import StringIO
 from dials.util import log, show_mail_on_error, Sorry
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 from dials.util.export_mtz import match_wavelengths
 from dials.algorithms.merging.merge import (
@@ -125,8 +125,9 @@ def run(args=None):
         parser.print_help()
         sys.exit()
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     log.config(verbosity=options.verbose, logfile=params.output.log)
     logger.info(dials_version())

--- a/command_line/plot_reflections.py
+++ b/command_line/plot_reflections.py
@@ -34,9 +34,7 @@ output {
 
 def run(args):
     usage = "dials.plot_reflections models.expt observations.refl [options]"
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     from scitbx.array_family import flex
     from scitbx import matrix
 
@@ -49,8 +47,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=True)
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if len(experiments.imagesets()) > 0:
         imageset = experiments.imagesets()[0]
         imageset.set_detector(experiments[0].detector)

--- a/command_line/reciprocal_lattice_viewer.py
+++ b/command_line/reciprocal_lattice_viewer.py
@@ -11,7 +11,7 @@ from scitbx.array_family import flex
 import wxtbx.app
 
 from dials.util.reciprocal_lattice.viewer import ReciprocalLatticeViewer, phil_scope
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
 import dials.util.banner  # noqa: F401; prints banner as side effect
 
@@ -40,8 +40,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=True)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -327,9 +327,7 @@ def run(args=None, phil=working_phil):
     """
 
     import dials.util.log
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_reflections
-    from dials.util.options import flatten_experiments
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     import libtbx.load_env
 
     start_time = time()
@@ -352,8 +350,9 @@ def run(args=None, phil=working_phil):
 
     # Parse the command line
     params, options = parser.parse_args(args=args, show_diff_phil=False)
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     # Configure the logging
     dials.util.log.config(verbosity=options.verbose, logfile=params.output.log)

--- a/command_line/refine_bravais_settings.py
+++ b/command_line/refine_bravais_settings.py
@@ -9,9 +9,7 @@ import iotbx.phil
 import libtbx
 from dials.array_family import flex
 from dials.util import Sorry
-from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections
-from dials.util.options import flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
 logger = logging.getLogger("dials.command_line.refine_bravais_settings")
 help_message = """
@@ -155,8 +153,9 @@ def run(args=None):
         logger.info("The following parameters have been modified:\n")
         logger.info(diff_phil)
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if len(reflections) == 0 or len(experiments) == 0:
         parser.print_help()
         return

--- a/command_line/reindex.py
+++ b/command_line/reindex.py
@@ -24,8 +24,7 @@ from dxtbx.model import Crystal
 # from dials.util.command_line import Importer
 from dials.algorithms.indexing.assign_indices import AssignIndicesGlobal
 from dials.array_family import flex
-from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.filter_reflections import filtered_arrays_from_experiments_reflections
 
 help_message = """
@@ -151,8 +150,9 @@ def run(args):
 
     params, options = parser.parse_args(show_diff_phil=True)
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if len(experiments) == 0 and len(reflections) == 0:
         parser.print_help()
         return

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -2439,7 +2439,7 @@ class Script(object):
 
     def run(self):
         """ Run the script. """
-        from dials.util.options import flatten_reflections, flatten_experiments
+        from dials.util.options import reflections_and_experiments_from_files
 
         # Parse the command line arguments
         params, options = self.parser.parse_args(show_diff_phil=True)
@@ -2449,8 +2449,9 @@ class Script(object):
             self.parser.print_help()
             exit(0)
 
-        reflections = flatten_reflections(params.input.reflections)
-        experiments = flatten_experiments(params.input.experiments)
+        reflections, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
 
         # Analyse the reflections
         analyse = Analyser(

--- a/command_line/rl_csv.py
+++ b/command_line/rl_csv.py
@@ -2,8 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 import iotbx.phil
-from dials.util.options import OptionParser
-from dials.util.options import flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
 phil_scope = iotbx.phil.parse(
     """
@@ -36,8 +35,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=False)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) or len(reflections) == 0:
         parser.print_help()

--- a/command_line/rl_png.py
+++ b/command_line/rl_png.py
@@ -129,9 +129,7 @@ class PngScene(object):
 
 
 def run():
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     from dials.util import log
 
     usage = "dials.rl_png [options] experiments.json observations.refl"
@@ -146,8 +144,9 @@ def run():
     )
 
     params, options = parser.parse_args()
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -11,7 +11,7 @@ from libtbx import phil
 from six.moves import cStringIO as StringIO
 from dials.util import log, show_mail_on_error, Sorry
 from dials.array_family import flex
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 from dials.algorithms.scaling.scaling_library import (
     create_scaling_model,
@@ -722,8 +722,9 @@ def run(args=None):
         parser.print_help()
         sys.exit()
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     log.config(verbosity=options.verbose, logfile=params.output.log)
     logger.info(dials_version())

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -24,8 +24,7 @@ from rstbx.dps_core import Direction, Directional_FFT
 from dials.algorithms.indexing.indexer import find_max_cell
 from dials.util import log
 from dials.util import Sorry
-from dials.util.options import OptionParser
-from dials.util.options import flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.slice import slice_reflections
 
 logger = logging.getLogger("dials.command_line.search_beam_position")
@@ -527,8 +526,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=False)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/show.py
+++ b/command_line/show.py
@@ -173,9 +173,7 @@ def show_goniometer(goniometer):
 
 def run(args):
     import dials.util.banner  # noqa: F401 - Importing means that it prints
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
     usage = "dials.show [options] models.expt | image_*.cbf"
 
@@ -190,8 +188,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=True)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 and len(reflections) == 0:
         parser.print_help()

--- a/command_line/slice_sweep.py
+++ b/command_line/slice_sweep.py
@@ -131,12 +131,13 @@ class Script(object):
     def run(self):
         """Execute the script."""
 
-        from dials.util.options import flatten_reflections, flatten_experiments
+        from dials.util.options import reflections_and_experiments_from_files
 
         # Parse the command line
         params, options = self.parser.parse_args(show_diff_phil=True)
-        reflections = flatten_reflections(params.input.reflections)
-        experiments = flatten_experiments(params.input.experiments)
+        reflections, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
 
         # Try to load the models and data
         slice_exps = len(experiments) > 0

--- a/command_line/space_group.py
+++ b/command_line/space_group.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import sys
 from dials.util import log, show_mail_on_error, Sorry
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 from dials.util.filter_reflections import filter_reflection_table
 from dials.array_family import flex
@@ -190,8 +190,9 @@ def run(args=None):
         parser.print_help()
         sys.exit()
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     log.config(verbosity=options.verbose, logfile=params.output.log)
     logger.info(dials_version())

--- a/command_line/spot_counts_per_image.py
+++ b/command_line/spot_counts_per_image.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import, division, print_function
 import sys
 
 import iotbx.phil
-from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.algorithms.spot_finding import per_image_analysis
 
 help_message = """
@@ -54,8 +53,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=False)
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if not any([reflections, experiments]):
         parser.print_help()

--- a/command_line/spot_resolution_shells.py
+++ b/command_line/spot_resolution_shells.py
@@ -52,9 +52,7 @@ def spot_resolution_shells(imagesets, reflections, params):
 
 
 def run(args):
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
     usage = "dials.spot_resolution_shells [options] models.expt observations.refl"
 
@@ -68,8 +66,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=True)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -9,7 +9,7 @@ import iotbx.phil
 
 from dials.array_family import flex
 from dials.util import log, Sorry
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
     parse_multiple_datasets,
@@ -204,8 +204,9 @@ def run(args):
         parser.print_help()
         sys.exit()
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     reflections = parse_multiple_datasets(reflections)
     if len(experiments) != len(reflections):

--- a/test/command_line/test_assign_experiment_identifiers.py
+++ b/test/command_line/test_assign_experiment_identifiers.py
@@ -39,9 +39,9 @@ def test_assign_identifiers(dials_regression, run_in_tmpdir):
     r = flex.reflection_table.from_file("assigned.refl")
     e = load.experiment_list("assigned.expt", check_format=False)
     r.assert_experiment_identifiers_are_consistent(e)
-    assert list(r.experiment_identifiers().values()) == ["0", "1"]
+    assert list(r.experiment_identifiers().values()) != ["", ""]
     assert list(r.experiment_identifiers().keys()) == [0, 1]
-    assert list(e.identifiers()) == ["0", "1"]
+    assert list(e.identifiers()) == list(r.experiment_identifiers().values())
 
     # now run again, with already assigned data
     pickle_path_list = ["assigned.refl"]
@@ -51,9 +51,9 @@ def test_assign_identifiers(dials_regression, run_in_tmpdir):
     r = flex.reflection_table.from_file("assigned.refl")
     e = load.experiment_list("assigned.expt", check_format=False)
     r.assert_experiment_identifiers_are_consistent(e)
-    assert list(r.experiment_identifiers().values()) == ["0", "1"]
+    assert list(r.experiment_identifiers().values()) != ["", ""]
     assert list(r.experiment_identifiers().keys()) == [0, 1]
-    assert list(e.identifiers()) == ["0", "1"]
+    assert list(e.identifiers()) == list(r.experiment_identifiers().values())
 
     # now run again, with adding more data
     pickle_path_list = ["assigned.refl"]

--- a/test/command_line/test_export.py
+++ b/test/command_line/test_export.py
@@ -6,7 +6,10 @@ import os
 import procrunner
 import pytest
 from dials.array_family import flex
-from dials.util.multi_dataset_handling import assign_unique_identifiers
+from dials.util.multi_dataset_handling import (
+    assign_unique_identifiers,
+    renumber_table_id_columns,
+)
 from dxtbx.serialize.load import _decode_dict
 from dxtbx.serialize import load
 from iotbx import mtz
@@ -56,6 +59,7 @@ def test_mtz_multi_wavelength(dials_data, run_in_tmpdir):
 
     exp_1.extend(exp_2)
     reflection_list = [refl_1, refl_2]
+    reflection_list = renumber_table_id_columns(reflection_list)
     exps, refls = assign_unique_identifiers(exp_1, reflection_list)
     joint_refl = flex.reflection_table()
     for r in refls:

--- a/test/command_line/test_import.py
+++ b/test/command_line/test_import.py
@@ -4,6 +4,7 @@ import os
 
 import procrunner
 import pytest
+from dxtbx.serialize import load
 
 
 def test_multiple_sweep_import_fails_without_allow_parameter(dials_data, tmpdir):
@@ -39,12 +40,12 @@ def test_multiple_sweep_import_suceeds_with_allow_parameter(dials_data, tmpdir):
     assert not result.returncode and not result.stderr
     assert tmpdir.join("experiments_multiple_sweeps.expt").check(file=1)
 
-    from dxtbx.serialize import load
-
     experiments = load.experiment_list(
         tmpdir.join("experiments_multiple_sweeps.expt").strpath
     )
     assert len(experiments) == 2
+    for experiment in experiments:
+        assert experiment.identifier != ""
 
 
 def test_with_mask(dials_data, tmpdir):
@@ -64,11 +65,10 @@ def test_with_mask(dials_data, tmpdir):
     assert not result.returncode and not result.stderr
     assert tmpdir.join("experiments_with_mask.expt").check(file=1)
 
-    from dxtbx.serialize import load
-
     experiments = load.experiment_list(
         tmpdir.join("experiments_with_mask.expt").strpath
     )
+    assert experiments[0].identifier != ""
     assert (
         experiments[0].imageset.external_lookup.mask.filename == mask_filename.strpath
     )
@@ -121,9 +121,8 @@ def test_override_geometry(dials_data, tmpdir):
     assert not result.returncode and not result.stderr
     assert tmpdir.join("override_geometry.expt").check(file=1)
 
-    from dxtbx.serialize import load
-
     experiments = load.experiment_list(tmpdir.join("override_geometry.expt").strpath)
+    assert experiments[0].identifier != ""
     imgset = experiments[0].imageset
 
     beam = imgset.get_beam()
@@ -150,7 +149,7 @@ def test_override_geometry(dials_data, tmpdir):
     assert scan.get_oscillation() == (1, 2)
 
 
-def tst_import_beam_centre(dials_data, run_in_tmpdir):
+def tst_import_beam_centre(dials_data, tmpdir):
     # Find the image files
     image_files = dials_data("centroid_test_data").listdir("centroid*.cbf", sort=True)
 
@@ -167,9 +166,8 @@ def tst_import_beam_centre(dials_data, run_in_tmpdir):
     assert not result.returncode and not result.stderr
     assert tmpdir.join("mosflm_beam_centre.expt").check(file=1)
 
-    from dxtbx.serialize import load
-
     experiments = load.experiment_list(tmpdir.join("mosflm_beam_centre.expt").strpath)
+    assert experiments[0].identifier != ""
     imgset = experiments[0].imageset
     beam_centre = imgset.get_detector()[0].get_beam_centre(imgset.get_beam().get_s0())
     assert beam_centre == pytest.approx((200, 100))
@@ -192,7 +190,7 @@ def tst_import_beam_centre(dials_data, run_in_tmpdir):
     assert beam_centre == pytest.approx((200, 100))
 
 
-def test_slow_fast_beam_centre(dials_regression, run_in_tmpdir):
+def test_slow_fast_beam_centre(dials_regression, tmpdir):
     # test slow_fast_beam_centre with a multi-panel CS-PAD image
     impath = os.path.join(
         dials_regression,
@@ -211,9 +209,8 @@ def test_slow_fast_beam_centre(dials_regression, run_in_tmpdir):
     assert not result.returncode and not result.stderr
     assert os.path.exists("slow_fast_beam_centre.expt")
 
-    from dxtbx.serialize import load
-
     experiments = load.experiment_list("slow_fast_beam_centre.expt")
+    assert experiments[0].identifier != ""
     imgset = experiments[0].imageset
     # beam centre on 18th panel
     s0 = imgset.get_beam().get_s0()
@@ -258,6 +255,10 @@ def test_from_image_files(dials_data, tmpdir):
     assert not result.returncode
     assert tmpdir.join("imported.expt").check(file=1)
 
+    # check that an experiment identifier is assigned
+    exp = load.experiment_list(tmpdir.join("imported.expt").strpath)
+    assert exp[0].identifier != ""
+
 
 def test_from_template(dials_data, tmpdir):
     # Find the image files
@@ -274,6 +275,10 @@ def test_from_template(dials_data, tmpdir):
     )
     assert not result.returncode
     assert tmpdir.join("imported.expt").check(file=1)
+
+    # check that an experiment identifier is assigned
+    exp = load.experiment_list(tmpdir.join("imported.expt").strpath)
+    assert exp[0].identifier != ""
 
 
 def test_extrapolate_scan(dials_data, tmpdir):
@@ -292,3 +297,7 @@ def test_extrapolate_scan(dials_data, tmpdir):
     )
     assert not result.returncode
     assert tmpdir.join("import_extrapolate.expt").check(file=1)
+
+    # check that an experiment identifier is assigned
+    exp = load.experiment_list(tmpdir.join("import_extrapolate.expt").strpath)
+    assert exp[0].identifier != ""

--- a/test/command_line/test_preservation_of_experiment_identifiers.py
+++ b/test/command_line/test_preservation_of_experiment_identifiers.py
@@ -1,0 +1,212 @@
+"""Test for the preservation of identifiers in dials processing."""
+import procrunner
+from dxtbx.serialize import load
+from dials.array_family import flex
+
+
+def test_preservation_of_identifiers(dials_data, tmpdir):
+    """Run the dials processing workflow, checking for preservation of identifiers.
+
+    This is just a simple case. The individual programs that are expected to
+    change the identifiers are tested separately, this is to check that the
+    other programs maintain the identifiers through processing.
+    """
+
+    # First import - should set a unique id.
+    image_files = dials_data("centroid_test_data").listdir("centroid*.cbf", sort=True)
+    result = procrunner.run(
+        ["dials.import", "output.experiments=imported.expt"]
+        + [f.strpath for f in image_files],
+        working_directory=tmpdir.strpath,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("imported.expt").check(file=1)
+
+    imported_exp_path = tmpdir.join("imported.expt").strpath
+    experiments = load.experiment_list(imported_exp_path)
+    import_expt_id = experiments[0].identifier
+    assert import_expt_id != ""
+
+    # Now find spots.
+    result = procrunner.run(
+        ["dials.find_spots", imported_exp_path, "output.reflections=strong.refl"],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("strong.refl").check(file=1)
+
+    strong_refl_path = tmpdir.join("strong.refl").strpath
+    reflections = flex.reflection_table.from_file(strong_refl_path)
+    assert dict(reflections.experiment_identifiers()) == {0: import_expt_id}
+
+    # Now index
+    result = procrunner.run(
+        [
+            "dials.index",
+            strong_refl_path,
+            imported_exp_path,
+            "output.reflections=indexed.refl",
+            "output.experiments=indexed.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("indexed.refl").check(file=1)
+    assert tmpdir.join("indexed.expt").check(file=1)
+
+    indexed_exp_path = tmpdir.join("indexed.expt").strpath
+    experiments = load.experiment_list(indexed_exp_path)
+    indexed_refl_path = tmpdir.join("indexed.refl").strpath
+    reflections = flex.reflection_table.from_file(indexed_refl_path)
+
+    indexed_expt_id = experiments[0].identifier
+    assert indexed_expt_id != ""
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now refine bravais setting
+    result = procrunner.run(
+        ["dials.refine_bravais_settings", indexed_refl_path, indexed_exp_path],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("bravais_setting_9.expt").check(file=1)
+
+    bravais_exp_path = tmpdir.join("bravais_setting_9.expt").strpath
+    experiments = load.experiment_list(bravais_exp_path)
+    assert experiments[0].identifier == indexed_expt_id
+
+    # Now reindex
+    result = procrunner.run(
+        [
+            "dials.reindex",
+            indexed_refl_path,
+            indexed_exp_path,
+            "change_of_basis_op=b,c,a",
+            "output.reflections=reindexed.refl",
+            "output.experiments=reindexed.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("reindexed.expt").check(file=1)
+    assert tmpdir.join("reindexed.refl").check(file=1)
+
+    reindexed_exp_path = tmpdir.join("reindexed.expt").strpath
+    experiments = load.experiment_list(reindexed_exp_path)
+    reindexed_refl_path = tmpdir.join("reindexed.refl").strpath
+    reflections = flex.reflection_table.from_file(reindexed_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now refine
+    result = procrunner.run(
+        [
+            "dials.refine",
+            reindexed_refl_path,
+            reindexed_exp_path,
+            "output.reflections=refined.refl",
+            "output.experiments=refined.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("refined.expt").check(file=1)
+    assert tmpdir.join("refined.refl").check(file=1)
+
+    refined_exp_path = tmpdir.join("refined.expt").strpath
+    experiments = load.experiment_list(refined_exp_path)
+    refined_refl_path = tmpdir.join("refined.refl").strpath
+    reflections = flex.reflection_table.from_file(refined_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now integrate
+    result = procrunner.run(
+        [
+            "dials.integrate",
+            refined_refl_path,
+            refined_exp_path,
+            "output.reflections=integrated.refl",
+            "output.experiments=integrated.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("integrated.expt").check(file=1)
+    assert tmpdir.join("integrated.refl").check(file=1)
+
+    integrated_exp_path = tmpdir.join("integrated.expt").strpath
+    experiments = load.experiment_list(integrated_exp_path)
+    integrated_refl_path = tmpdir.join("integrated.refl").strpath
+    reflections = flex.reflection_table.from_file(integrated_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now run cosym (symmetry fails due to small amount of data)
+    result = procrunner.run(
+        [
+            "dials.symmetry",
+            integrated_refl_path,
+            integrated_exp_path,
+            "output.reflections=symmetrized.refl",
+            "output.experiments=symmetrized.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("symmetrized.expt").check(file=1)
+    assert tmpdir.join("symmetrized.refl").check(file=1)
+
+    symmetrized_exp_path = tmpdir.join("symmetrized.expt").strpath
+    experiments = load.experiment_list(symmetrized_exp_path)
+    symmetrized_refl_path = tmpdir.join("symmetrized.refl").strpath
+    reflections = flex.reflection_table.from_file(symmetrized_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now scale
+    result = procrunner.run(
+        [
+            "dials.scale",
+            symmetrized_refl_path,
+            symmetrized_exp_path,
+            "output.reflections=scaled.refl",
+            "output.experiments=scaled.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("scaled.expt").check(file=1)
+    assert tmpdir.join("scaled.refl").check(file=1)
+
+    scaled_exp_path = tmpdir.join("scaled.expt").strpath
+    experiments = load.experiment_list(scaled_exp_path)
+    scaled_refl_path = tmpdir.join("scaled.refl").strpath
+    reflections = flex.reflection_table.from_file(scaled_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now do two-theta refine
+    result = procrunner.run(
+        [
+            "dials.two_theta_refine",
+            scaled_refl_path,
+            scaled_exp_path,
+            "output.experiments=tt.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("tt.expt").check(file=1)
+
+    tt_exp_path = tmpdir.join("tt.expt").strpath
+    experiments = load.experiment_list(tt_exp_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]

--- a/test/command_line/test_spotfinder.py
+++ b/test/command_line/test_spotfinder.py
@@ -35,6 +35,8 @@ def test_find_spots_from_images(dials_data, tmpdir):
         (1399.1190476190477, 514.2142857142857, 0.5)
     )
     assert "shoebox" in reflections
+    assert list(reflections.experiment_identifiers().keys()) == [0]
+    assert reflections.experiment_identifiers().values()
 
 
 def test_find_spots_with_resolution_filter(dials_data, tmpdir):
@@ -59,6 +61,8 @@ def test_find_spots_with_resolution_filter(dials_data, tmpdir):
         reflections = pickle.load(f)
     assert len(reflections) in range(467, 469)
     assert "shoebox" not in reflections
+    assert list(reflections.experiment_identifiers().keys()) == [0]
+    assert reflections.experiment_identifiers().values()
 
 
 def test_find_spots_with_hot_mask(dials_data, tmpdir):
@@ -84,6 +88,8 @@ def test_find_spots_with_hot_mask(dials_data, tmpdir):
         reflections = pickle.load(f)
     assert len(reflections) in range(653, 655)
     assert "shoebox" not in reflections
+    assert list(reflections.experiment_identifiers().keys()) == [0]
+    assert reflections.experiment_identifiers().values()
 
     with tmpdir.join("hot_mask_0.pickle").open("rb") as f:
         mask = pickle.load(f)
@@ -115,6 +121,8 @@ def test_find_spots_with_hot_mask_with_prefix(dials_data, tmpdir):
         reflections = pickle.load(f)
     assert len(reflections) in range(653, 655)
     assert "shoebox" not in reflections
+    assert list(reflections.experiment_identifiers().keys()) == [0]
+    assert reflections.experiment_identifiers().values()
     with tmpdir.join("my_hot_mask_0.pickle").open("rb") as f:
         mask = pickle.load(f)
     assert len(mask) == 1
@@ -142,6 +150,8 @@ def test_find_spots_with_generous_parameters(dials_data, tmpdir):
     with tmpdir.join("spotfinder.refl").open("rb") as f:
         reflections = pickle.load(f)
     assert len(reflections) in range(678, 680)
+    assert list(reflections.experiment_identifiers().keys()) == [0]
+    assert reflections.experiment_identifiers().values()
 
 
 def test_find_spots_with_user_defined_mask(dials_data, tmpdir):
@@ -165,6 +175,8 @@ def test_find_spots_with_user_defined_mask(dials_data, tmpdir):
 
     with tmpdir.join("spotfinder.refl").open("rb") as f:
         reflections = pickle.load(f)
+    assert list(reflections.experiment_identifiers().keys()) == [0]
+    assert reflections.experiment_identifiers().values()
 
     from dxtbx.model.experiment_list import ExperimentListFactory
 
@@ -178,6 +190,7 @@ def test_find_spots_with_user_defined_mask(dials_data, tmpdir):
     for x, y, z in reflections["xyzobs.px.value"]:
         d = detector[0].get_resolution_at_pixel(beam.get_s0(), (x, y))
         assert d >= 3
+    reflections.assert_experiment_identifiers_are_consistent(experiments)
 
 
 def test_find_spots_with_user_defined_region(dials_data, tmpdir):
@@ -203,6 +216,8 @@ def test_find_spots_with_user_defined_region(dials_data, tmpdir):
     assert y.all_ge(800)
     assert x.all_lt(1200)
     assert y.all_lt(1200)
+    assert list(reflections.experiment_identifiers().keys()) == [0]
+    assert reflections.experiment_identifiers().values()
 
 
 def test_find_spots_with_xfel_stills(dials_regression, tmpdir):
@@ -226,3 +241,5 @@ def test_find_spots_with_xfel_stills(dials_regression, tmpdir):
     with tmpdir.join("spotfinder.refl").open("rb") as f:
         reflections = pickle.load(f)
     assert len(reflections) == 2643
+    assert list(reflections.experiment_identifiers().keys()) == [0]
+    assert reflections.experiment_identifiers().values()

--- a/test/util/__init__.py
+++ b/test/util/__init__.py
@@ -1,0 +1,25 @@
+"""Shared functions for tests."""
+from mock import Mock
+from dials.array_family import flex
+
+
+def mock_reflection_file_object(id_=0, identifier=True):
+    """Create a mock reflection_file_object."""
+    fileobj = Mock()
+    r = flex.reflection_table()
+    r["id"] = flex.int([-1, id_, id_])
+    if identifier:
+        r.experiment_identifiers()[id_] = str(id_)
+    fileobj.data = r
+    return fileobj
+
+
+def mock_two_reflection_file_object(ids=[0, 2]):
+    """Create a mock reflection_file_object with two datasets."""
+    fileobj = Mock()
+    r = flex.reflection_table()
+    r["id"] = flex.int([-1, ids[0], ids[0], ids[1], ids[1]])
+    r.experiment_identifiers()[ids[0]] = str(ids[0])
+    r.experiment_identifiers()[ids[1]] = str(ids[1])
+    fileobj.data = r
+    return fileobj

--- a/test/util/test_exclude_images.py
+++ b/test/util/test_exclude_images.py
@@ -30,7 +30,7 @@ def test_parse_exclude_images_commands():
     """Test for namesake function"""
     commands = [["1:101:200"], ["0:201:300"]]
     ranges = _parse_exclude_images_commands(commands)
-    assert ranges == [("1", (101, 200)), ("0", (201, 300))]
+    assert ranges == [(1, (101, 200)), (0, (201, 300))]
     with pytest.raises(ValueError):
         _ = _parse_exclude_images_commands([["1:101-200"]])
     with pytest.raises(ValueError):

--- a/test/util/test_multi_dataset_handling.py
+++ b/test/util/test_multi_dataset_handling.py
@@ -8,7 +8,7 @@ from dials.array_family import flex
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
     parse_multiple_datasets,
-    select_datasets_on_ids,
+    select_datasets_on_identifiers,
     sort_tables_to_experiments_order,
     renumber_table_id_columns,
 )
@@ -57,7 +57,7 @@ def reflections_024(reflections):
 
 def test_select_specific_datasets_using_id(experiments_024, reflections_024):
     use_datasets = ["0", "2"]
-    experiments, refl = select_datasets_on_ids(
+    experiments, refl = select_datasets_on_identifiers(
         experiments_024, reflections_024, use_datasets=use_datasets
     )
     assert len(experiments) == 2
@@ -66,7 +66,7 @@ def test_select_specific_datasets_using_id(experiments_024, reflections_024):
 
 
 def test_exclude_specific_datasets_using_id(experiments_024, reflections_024):
-    experiments, refl = select_datasets_on_ids(
+    experiments, refl = select_datasets_on_identifiers(
         experiments_024, reflections_024, exclude_datasets=["0"]
     )
     assert len(refl) == 2
@@ -78,7 +78,7 @@ def test_raise_exception_when_selecting_and_excluding_datasets_at_same_time(
     experiments_024, reflections_024
 ):
     with pytest.raises(ValueError):
-        experiments, refl = select_datasets_on_ids(
+        experiments, refl = select_datasets_on_identifiers(
             experiments_024,
             reflections_024,
             use_datasets=["2", "4"],
@@ -90,13 +90,13 @@ def test_raise_exception_when_excluding_non_existing_dataset(
     experiments_024, reflections_024
 ):
     with pytest.raises(ValueError):
-        experiments, refl = select_datasets_on_ids(
+        experiments, refl = select_datasets_on_identifiers(
             experiments_024, reflections_024, exclude_datasets=["1"]
         )
 
 
 def test_selecting_everything_is_identity_function(experiments_024, reflections_024):
-    exp, refl = select_datasets_on_ids(experiments_024, reflections_024)
+    exp, refl = select_datasets_on_identifiers(experiments_024, reflections_024)
     assert exp is experiments_024
     assert refl is reflections_024
 
@@ -105,7 +105,7 @@ def test_raise_exception_when_not_all_identifiers_set(experiments, reflections_0
     experiments[0].identifier = "0"
     experiments[1].identifier = "2"
     with pytest.raises(ValueError):
-        exp, refl = select_datasets_on_ids(
+        exp, refl = select_datasets_on_identifiers(
             experiments, reflections_024, use_datasets=["2"]
         )
 
@@ -114,7 +114,7 @@ def test_raise_exception_when_selecting_non_existing_dataset(
     experiments_024, reflections_024
 ):
     with pytest.raises(ValueError):
-        exp, refl = select_datasets_on_ids(
+        exp, refl = select_datasets_on_identifiers(
             experiments_024, reflections_024, use_datasets=["3"]
         )
 
@@ -125,7 +125,7 @@ def test_correct_handling_with_multi_dataset_table(experiments_024):
     reflections.experiment_identifiers()[0] = "0"
     reflections.experiment_identifiers()[1] = "2"
     reflections.experiment_identifiers()[2] = "4"
-    exp, refl = select_datasets_on_ids(
+    exp, refl = select_datasets_on_identifiers(
         experiments_024, [reflections], exclude_datasets=["2"]
     )
     assert list(refl[0].experiment_identifiers().values()) == ["0", "4"]

--- a/test/util/test_multi_dataset_handling.py
+++ b/test/util/test_multi_dataset_handling.py
@@ -133,30 +133,22 @@ def test_assignment_of_unique_identifiers_when_refl_table_ids_are_present(
     experiments, reflections
 ):
     assert list(experiments.identifiers()) == ["", "", ""]
-    exp, rts = assign_unique_identifiers(experiments, reflections)
-    expected_identifiers = ["0", "1", "2"]
-    expected_ids = [0, 1, 2]
-    # Check that identifiers are set in experiments and reflection table.
-    assert list(exp.identifiers()) == expected_identifiers
-    for i, refl in enumerate(rts):
-        assert refl.experiment_identifiers()[i] == expected_identifiers[i]
+    expts, rts = assign_unique_identifiers(experiments, reflections)
+    for i, (expt, refl) in enumerate(zip(expts, rts)):
         assert set(refl["id"]) == {i}
-        assert i == expected_ids[i]
+        assert expt.identifier != ""
+        assert refl.experiment_identifiers()[i] == expt.identifier
 
 
 def test_assign_identifiers_where_none_are_set_but_refl_table_ids_have_duplicates(
     experiments, reflections
 ):
     reflections[2]["id"] = flex.int([0, 0])
-    exp, rts = assign_unique_identifiers(experiments, reflections)
-    expected_identifiers = ["0", "1", "2"]
-    # Check that identifiers are set in experiments and reflection table.
-    assert list(exp.identifiers()) == expected_identifiers
-    expected_ids = [0, 1, 2]
-    for i, refl in enumerate(rts):
-        assert refl.experiment_identifiers()[i] == expected_identifiers[i]
+    expts, rts = assign_unique_identifiers(experiments, reflections)
+    for i, (expt, refl) in enumerate(zip(expts, rts)):
         assert set(refl["id"]) == {i}
-        assert i == expected_ids[i]
+        assert expt.identifier != ""
+        assert refl.experiment_identifiers()[i] == expt.identifier
 
 
 def test_raise_exception_when_existing_identifiers_are_inconsistent(
@@ -165,7 +157,7 @@ def test_raise_exception_when_existing_identifiers_are_inconsistent(
     reflections[1].experiment_identifiers()[0] = "5"
     # should raise an assertion error for inconsistent identifiers
     with pytest.raises(ValueError):
-        exp, rts = assign_unique_identifiers(experiments_024, reflections)
+        _, __ = assign_unique_identifiers(experiments_024, reflections)
 
 
 def test_cases_where_all_set_whether_reflection_table_is_split_or_not(
@@ -194,7 +186,7 @@ def test_raise_exception_if_unequal_experiments_and_reflections(experiments_024)
     del reflections_multi[0].experiment_identifiers()[4]
     del reflections_multi[0]["id"][2]
     with pytest.raises(ValueError):
-        exp, rts = assign_unique_identifiers(experiments_024, reflections_multi)
+        _, __ = assign_unique_identifiers(experiments_024, reflections_multi)
 
 
 def test_assigned_identifiers_are_kept_when_assigning_rest(experiments, reflections):
@@ -202,15 +194,12 @@ def test_assigned_identifiers_are_kept_when_assigning_rest(experiments, reflecti
     # set for the rest
     experiments[0].identifier = "1"
     reflections[0].experiment_identifiers()[0] = "1"
-    exp, rts = assign_unique_identifiers(experiments, reflections)
-    expected_identifiers = ["1", "0", "2"]
-    assert list(exp.identifiers()) == expected_identifiers
-    expected_ids = [0, 1, 2]
-    for i, refl in enumerate(rts):
-        id_ = refl["id"][0]
-        assert refl.experiment_identifiers()[id_] == expected_identifiers[i]
-        assert set(refl["id"]) == {id_}
-        assert id_ == expected_ids[i]
+    expts, rts = assign_unique_identifiers(experiments, reflections)
+    assert expts.identifiers()[0] == "1"
+    for i, (expt, refl) in enumerate(zip(expts, rts)):
+        assert set(refl["id"]) == {i}
+        assert expt.identifier != ""
+        assert refl.experiment_identifiers()[i] == expt.identifier
 
 
 def test_assigning_specified_identifiers(experiments, reflections):

--- a/test/util/test_options.py
+++ b/test/util/test_options.py
@@ -3,61 +3,57 @@ Tests for the functions in dials.util.options
 """
 from __future__ import absolute_import, division, print_function
 
-from dials.util.options import flatten_reflections, flatten_experiments, OptionParser
+from mock import Mock
+from dials.util.options import (
+    flatten_experiments,
+    OptionParser,
+    reflections_and_experiments_from_files,
+)
 from dials.test.util import mock_reflection_file_object, mock_two_reflection_file_object
+from dxtbx.model import Experiment, ExperimentList
 
 
 def test_can_read_headerless_h5_and_no_detector_is_present(dials_data):
     data_h5 = dials_data("vmxi_thaumatin").join("image_15799_data_000001.h5").strpath
     parser = OptionParser(read_experiments=True, read_experiments_from_images=True)
-    params, options = parser.parse_args([data_h5])
+    params, _ = parser.parse_args([data_h5])
     experiments = flatten_experiments(params.input.experiments)
     assert len(experiments) == 1
     assert not experiments[0].detector
 
 
-def test_flatten_experiments_updating_id_values():
-    """Test the correct handling of duplicate table id values.
-
-    Note that this function does not have the ability to update the
-    experiment string identifier, only ensure that the table id values
-    do not clash (it is not possible even to load multiple experiments
-    with the same identifier).
-    """
-    # Test the case of two single reflection tables.
-    file_list = [mock_reflection_file_object(id_=0), mock_reflection_file_object(id_=0)]
-    rs = flatten_reflections(file_list)
-    assert rs[0] is file_list[0].data
-    assert list(rs[0]["id"]) == [-1, 0, 0]
-    assert list(rs[0].experiment_identifiers().keys()) == [0]
-    assert list(rs[0].experiment_identifiers().values()) == ["0"]
-    assert rs[1] is file_list[1].data
-    assert list(rs[1]["id"]) == [-1, 1, 1]
-    assert list(rs[1].experiment_identifiers().keys()) == [1]
-    assert list(rs[1].experiment_identifiers().values()) == ["0"]
-
-    # Now test the case where one reflection table contains two experiments
-    file_list = [mock_two_reflection_file_object(), mock_reflection_file_object(id_=0)]
-    rs = flatten_reflections(file_list)
-    assert rs[0] is file_list[0].data
-    assert list(rs[0]["id"]) == [-1, 0, 0, 1, 1]
-    assert list(rs[0].experiment_identifiers().keys()) == [0, 1]
-    assert list(rs[0].experiment_identifiers().values()) == ["0", "2"]
-    assert rs[1] is file_list[1].data
-    assert list(rs[1]["id"]) == [-1, 2, 2]
-    assert list(rs[1].experiment_identifiers().keys()) == [2]
-    assert list(rs[1].experiment_identifiers().values()) == ["0"]
-
-    file_list = [
-        mock_reflection_file_object(id_=0),
-        mock_two_reflection_file_object(ids=[1, 2]),
+def test_reflections_and_experiments_from_files():
+    """Test correct extracting of reflections and experiments."""
+    # Test when input reflections order matches the experiments order
+    refl_file_list = [
+        mock_two_reflection_file_object(ids=[0, 1]),
+        mock_reflection_file_object(id_=2),
     ]
-    rs = flatten_reflections(file_list)
-    assert rs[0] is file_list[0].data
-    assert list(rs[0]["id"]) == [-1, 0, 0]
-    assert list(rs[0].experiment_identifiers().keys()) == [0]
-    assert list(rs[0].experiment_identifiers().values()) == ["0"]
-    assert rs[1] is file_list[1].data
-    assert list(rs[1]["id"]) == [-1, 1, 1, 2, 2]
-    assert list(rs[1].experiment_identifiers().keys()) == [1, 2]
-    assert list(rs[1].experiment_identifiers().values()) == ["1", "2"]
+
+    def mock_exp_obj(id_=0):
+        """Make a mock experiments file object."""
+        exp = Mock()
+        exp.data = ExperimentList()
+        exp.data.append(Experiment(identifier=str(id_)))
+        return exp
+
+    exp_file_list = [mock_exp_obj(id_=i) for i in [0, 1, 2]]
+
+    refls, expts = reflections_and_experiments_from_files(refl_file_list, exp_file_list)
+    assert refls[0] is refl_file_list[0].data
+    assert refls[1] is refl_file_list[1].data
+    assert expts[0].identifier == "0"
+    assert expts[1].identifier == "1"
+    assert expts[2].identifier == "2"
+
+    # Test when input reflections order does not match experiments order.
+    refl_file_list = [
+        mock_reflection_file_object(id_=2),
+        mock_two_reflection_file_object(ids=[0, 1]),
+    ]
+    refls, expts = reflections_and_experiments_from_files(refl_file_list, exp_file_list)
+    assert refls[0] is refl_file_list[1].data
+    assert refls[1] is refl_file_list[0].data
+    assert expts[0].identifier == "0"
+    assert expts[1].identifier == "1"
+    assert expts[2].identifier == "2"

--- a/test/util/test_options.py
+++ b/test/util/test_options.py
@@ -3,9 +3,8 @@ Tests for the functions in dials.util.options
 """
 from __future__ import absolute_import, division, print_function
 
-from mock import Mock
 from dials.util.options import flatten_reflections, flatten_experiments, OptionParser
-from dials.array_family import flex
+from dials.test.util import mock_reflection_file_object, mock_two_reflection_file_object
 
 
 def test_can_read_headerless_h5_and_no_detector_is_present(dials_data):
@@ -15,28 +14,6 @@ def test_can_read_headerless_h5_and_no_detector_is_present(dials_data):
     experiments = flatten_experiments(params.input.experiments)
     assert len(experiments) == 1
     assert not experiments[0].detector
-
-
-def mock_reflection_file_object(id_=0, identifier=True):
-    """Create a mock reflection_file_object."""
-    fileobj = Mock()
-    r = flex.reflection_table()
-    r["id"] = flex.int([-1, id_, id_])
-    if identifier:
-        r.experiment_identifiers()[id_] = str(id_)
-    fileobj.data = r
-    return fileobj
-
-
-def mock_two_reflection_file_object(ids=[0, 2]):
-    """Create a mock reflection_file_object with two datasets."""
-    fileobj = Mock()
-    r = flex.reflection_table()
-    r["id"] = flex.int([-1, ids[0], ids[0], ids[1], ids[1]])
-    r.experiment_identifiers()[ids[0]] = str(ids[0])
-    r.experiment_identifiers()[ids[1]] = str(ids[1])
-    fileobj.data = r
-    return fileobj
 
 
 def test_flatten_experiments_updating_id_values():

--- a/util/exclude_images.py
+++ b/util/exclude_images.py
@@ -82,7 +82,7 @@ def _parse_exclude_images_commands(commands):
         vals = com[0].split(":")
         if len(vals) != 3:
             raise ValueError("Exclude images must be input in the form exp:start:stop ")
-        ranges_to_remove.append((vals[0], (int(vals[1]), int(vals[2]))))
+        ranges_to_remove.append((int(vals[0]), (int(vals[1]), int(vals[2]))))
     return ranges_to_remove
 
 
@@ -91,7 +91,7 @@ def _remove_ranges_from_valid_image_ranges(experiments, ranges_to_remove):
     arithmetic to determine image ranges to keep and sets a new list of ranges in
     the scan.valid_image_ranges dict."""
     for r in ranges_to_remove:
-        exp = experiments[experiments.find(r[0])]
+        exp = experiments[r[0]]
         if not exp.scan:
             raise ValueError("Trying to exclude a scanless experiment")
         current_range = exp.scan.get_valid_image_ranges(

--- a/util/multi_dataset_handling.py
+++ b/util/multi_dataset_handling.py
@@ -193,7 +193,7 @@ def assign_unique_identifiers(experiments, reflections, identifiers=None):
         if n_datasets > 1:
             raise ValueError(
                 "Reflection table %s contains %s datasets (must contain a single dataset)"
-                % (i, n_datasest)
+                % (i, n_datasets)
             )
     # if identifiers given, use these to set the identifiers
     if identifiers:

--- a/util/multi_dataset_handling.py
+++ b/util/multi_dataset_handling.py
@@ -317,27 +317,28 @@ def select_datasets_on_ids(
     """
     Select a subset of experiments and reflection tables based on id values.
 
-    This performs a similar function to the select/remove_on_experiment_identifiers
-    methods of ExperimentList and reflection_table, with additional logic to handle
-    the case of a list of reflection tables, rather than a single one and to catch
-    bad input. Does not require reflection tables containing data from multiple
-    experiments to be split.
+    This function selects or removes datasets from the list of experiments and
+    reflection tables based on the "id" columns in the reflection tables.
+    Each table must only contain one dataset, and this function assumes that
+    the order of experiments and reflection tables are consistent.
 
     Args:
         experiments: An ExperimentList
-        reflection_table_list (list): a list of reflection tables
-        exclude_datasets (list): a list of experiment_identifiers to exclude
-        use_datasets (list): a list of experiment_identifiers to use
+        single_reflection_tables (list): a list of single-dataset reflection
+            tables
+        exclude_datasets (list): a list of numerical ids to exclude
+        use_datasets (list): a list of numerical ids to use
 
     Returns:
         (tuple): tuple containing:
             experiments: The updated ExperimentList
-            list_of_reflections (list): A list of the updated reflection tables
+            list_of_reflections (list): A list of the selected reflection tables
 
     Raises:
-        ValueError: If both use_datasets and exclude datasets are used, if not all
-            experiment identifiers are set, if an identifier in exclude_datasets
-            or use_datasets is not in the list.
+        ValueError: If both use_datasets and exclude datasets are used, if an
+            id value in exclude_datasets or use_datasets is not found in any
+            reflection table, if a reflection table is not a single-dataset
+            table.
     """
     assert len(experiments) == len(single_reflection_tables)
     # Assume in matched order (should be from loading correctly)
@@ -346,13 +347,6 @@ def select_datasets_on_ids(
     if (use_datasets is not None) and (exclude_datasets is not None):
         raise ValueError(
             "The options use_datasets and exclude_datasets cannot be used in conjuction."
-        )
-    if experiments.identifiers().count("") > 0:
-        raise ValueError(
-            """
-            Not all experiment identifiers set in the ExperimentList.
-            Current identifiers set as: %s"""
-            % list(experiments.identifiers())
         )
 
     list_of_reflections = []

--- a/util/multi_dataset_handling.py
+++ b/util/multi_dataset_handling.py
@@ -31,6 +31,15 @@ phil_scope = iotbx.phil.parse(
 )
 
 
+def generate_experiment_identifiers(experiments, identifier_type="uuid"):
+    """Generate unique identifiers for each experiment."""
+    if identifier_type == "uuid":
+        for expt in experiments:
+            expt.identifier = str(uuid.uuid4())
+    elif identifier_type == "timestamp":
+        pass
+
+
 def split_reflection_tables_on_ids(reflection_tables):
     """"Split a list of multi-dataset reflection tables, selecting on id.
 

--- a/util/multi_dataset_handling.py
+++ b/util/multi_dataset_handling.py
@@ -6,6 +6,7 @@ and experiment lists.
 from __future__ import absolute_import, division, print_function
 
 import logging
+import uuid
 from dials.array_family import flex
 
 logger = logging.getLogger("dials")
@@ -81,23 +82,6 @@ def parse_multiple_datasets(reflections):
     return single_reflection_tables
 
 
-def get_next_unique_id(unique_id, used_ids):
-    """
-    Test a list of used id strings to see if it contains str(unique_id)
-
-    Args:
-        unique_id (int): Integer value to be converted to str
-        used_ids (list): A list of strings
-
-    Returns:
-        (int): The lowest int >= unique_id for which str(int) is not in used_ids
-
-    """
-    while str(unique_id) in used_ids:
-        unique_id += 1
-    return unique_id
-
-
 def assign_unique_identifiers(experiments, reflections, identifiers=None):
     """
     Assign unique experiment identifiers to experiments and reflections lists.
@@ -152,14 +136,11 @@ def assign_unique_identifiers(experiments, reflections, identifiers=None):
     if len(set(used_str_ids)) != len(reflections):
         # if not all set, then need to fill in the rest. Keep the identifier if
         # it is already set, and reset table id column from 0..n-1
-        unique_id = 0
         for i, (exp, refl) in enumerate(zip(experiments, reflections)):
             if exp.identifier == "":
-                unique_id = get_next_unique_id(unique_id, used_str_ids)
-                strid = "%i" % unique_id
+                strid = str(uuid.uuid4())
                 exp.identifier = strid
                 refl.experiment_identifiers()[i] = strid
-                unique_id += 1
             else:
                 k = list(refl.experiment_identifiers().keys())[0]
                 expid = list(refl.experiment_identifiers().values())[0]

--- a/util/options.py
+++ b/util/options.py
@@ -19,6 +19,8 @@ except ImportError:
 
 import libtbx.phil
 from dials.util import Sorry
+from dials.util.multi_dataset_handling import sort_tables_to_experiments_order
+from dxtbx.model.experiment_list import ExperimentList
 
 tolerance_phil_scope = libtbx.phil.parse(
     """
@@ -1129,29 +1131,7 @@ def flatten_reflections(filename_object_list):
     :param filename_object_list: The parameter item
     :return: The flattened reflection table
     """
-    tables = [o.data for o in filename_object_list]
-    if len(tables) > 1:
-        new_id_ = 0
-        for table in tables:
-            table_id_values = sorted(list(set(table["id"]).difference({-1})))
-            highest_new_id = new_id_ + len(table_id_values) - 1
-            expt_ids_dict = table.experiment_identifiers()
-            new_ids_dict = {}
-            new_id_ = highest_new_id
-            while table_id_values:
-                val = table_id_values.pop()
-                sel = table["id"] == val
-                if val in expt_ids_dict:
-                    # only delete here, add new at end to avoid clashes of new/old ids
-                    new_ids_dict[new_id_] = expt_ids_dict[val]
-                    del expt_ids_dict[val]
-                table["id"].set_selected(sel.iselection(), new_id_)
-                new_id_ -= 1
-            new_id_ = highest_new_id + 1
-            if new_ids_dict:
-                for i, v in new_ids_dict.items():
-                    expt_ids_dict[i] = v
-    return tables
+    return [o.data for o in filename_object_list]
 
 
 def flatten_experiments(filename_object_list):
@@ -1161,9 +1141,28 @@ def flatten_experiments(filename_object_list):
     :param filename_object_list: The parameter item
     :return: The flattened experiment lists
     """
-    from dxtbx.model.experiment_list import ExperimentList
 
     result = ExperimentList()
     for o in filename_object_list:
         result.extend(o.data)
     return result
+
+
+def reflections_and_experiments_from_files(
+    reflection_file_object_list, experiment_file_object_list
+):
+    """Extract reflection tables and an experiment list from the files.
+
+    If experiment identifiers are set, the order of the reflection tables is
+    changed to match the order of experiments.
+    """
+    tables = [o.data for o in reflection_file_object_list]
+
+    experiments = ExperimentList()
+    for o in experiment_file_object_list:
+        experiments.extend(o.data)
+
+    if tables and experiments:
+        tables = sort_tables_to_experiments_order(tables, experiments)
+
+    return tables, experiments


### PR DESCRIPTION
**Overview**
This pull request implements the generation and use of unique experiment identifiers throughout the dials processing workflow. The motivation behind this is to allow matching of experiments and reflection tables without relying on the ordering of these objects (either on loading data or during processing. This feature has already proved useful in `dials.scale` and `dials.cosym`).

These identifiers (a uuid string by default) are stored in `experiment.identifier`, and the `reflection_table.experiment_identifiers()` map is used to record the numerical_id -> identifier mapping.
When a new experiment is created, a unique identifier is generated - this only happens in `dials.import` and `dials.index`. When a reflection table is created, the experiment_identifiers map is populated - this happens in spot-finding, indexing and integration. Other programs in the standard dials workflow add to the existing table, so the mapping is preserved.

So far I have only implemented and tested the uuid identifier generation for the sweeps case. For the stills case, I have added in function calls in the relevant locations in `stills_indexer` (which would currently generate a uuid); I invite @asmit3 and collaborators to add to this PR to modify this as you wish as I am unfamiliar with the ins and outs of the stills_process workflow.

People can probably ignore the changes to the scaling files if reviewing this. I shall continue to review the dials programs for the 'potential issue' (see below). However, the tests pass locally for me and wanted to get this PR out there for feedback.

**Detailed description on behaviour changes**
The behavioural changes are primarily to help programs which handle the input of multiple datasets in separate files - which will likely have duplicate numerical ids in the reflection tables.

1.  To implement safe handling of data on loading, regardless of order, there is a new function to perform the role of `flatten_experiments` and `flatten_refections`, which also reorders the reflection tables to match the experiments order using the experiment identifiers;
`refls, expts =  reflections_and_experiments_from_files(refl_file_objs, expt_file_objs)`
(note that the id columns in the tables are not renumbered at this point. This was something I introduced recently in `flatten_reflections` for #656 but agree that this functionality should occur elsewhere, see below).
So far I have only replaced the flatten functions in `dials.scale`, but this can be rolled out to other programs if people are happy about this. 

2. To ensure that multiple reflection tables can be joined together, one must ensure that the column id values do not clash. To do this, one can use the `renumber_table_id_columns(reflection_tables)` function in `dials.util.multi_dataset_handling`. There is also a `split_reflection_tables_on_ids(reflection_tables)` function for splitting multi-dataset tables on ids.

3.  Therefore for programs that handle reflection tables with multiple datasets, the following calls are the suggested way to load the data, to provide a list of experiments and reflections with different numerical ids:
```
# load data and make sure the order of refls and expts matches
refls, expts =  reflections_and_experiments_from_files(refl_file_objs, expt_file_objs)

# renumber id columns if necessary to avoid duplicate numerical ids across tables
refls = renumber_table_id_columns(refls)

# split multi-dataset tables if necessary to a list of single dataset tables
refls = split_reflection_tables_on_ids(refls)
```

**Potential issue**
One problematic aspect is that performing a selection on a multi-dataset reflection table based on the "id" column may no longer be safe, as the identifier map is not updated (which could be an issue if trying to recombine the tables). Therefore code like this, to select data from the 0th experiment;
```new_refl = refl.select(refl["id"] == 0)```
should be replaced with one of
```
new_refl = refl.select_on_id_values([0])
new_refl = refl.select_on_experiment_identifiers([experiments[0].identifier])
```
or should be modified to 
```
new_refl = refl.select(refl["id"] == 0)
new_refl.clean_experiment_identifiers_map()
```
I'm continuing to check the repository for places where this could be an issue.
