### PR TITLE
I thought imageset_id gone...

### DIFF
--- a/util/reciprocal_lattice/__init__.py
+++ b/util/reciprocal_lattice/__init__.py
@@ -93,10 +93,7 @@ class Render3d(object):
     def map_points_to_reciprocal_space(self):
         reflections = flex.reflection_table()
         for i, expt in enumerate(self.experiments):
-            if "imageset_id" in self.reflections_input:
-                sel = self.reflections_input["imageset_id"] == i
-            else:
-                sel = self.reflections_input["id"] == i
+            sel = self.reflections_input["id"] == i
             if isinstance(self.reflections_input["id"], flex.size_t):
                 self.reflections_input["id"] = self.reflections_input["id"].as_int()
 


### PR DESCRIPTION
Even if it is or is not - removing it appears to fix the issues listed in #905 - the `imageset_id` values from split_experiments all seem to be set to 0.