### PR TITLE
Exporting of multi-dataset and still experiments to XDS_ASCII

### DIFF
--- a/newsfragments/637.feature
+++ b/newsfragments/637.feature
@@ -1,0 +1,1 @@
+Support exporting multi-dataset and still experiments to XDS_ASCII

--- a/util/export_xds_ascii.py
+++ b/util/export_xds_ascii.py
@@ -2,11 +2,16 @@ from __future__ import absolute_import, division, print_function
 
 import copy
 import logging
+import os
 
+from cctbx.miller import map_to_asu
+from dials.array_family import flex
+from dials.util import Sorry
 from dials.util.filter_reflections import (
-    filter_reflection_table,
     FilteringReductionMethods,
+    filter_reflection_table,
 )
+from rstbx.cftbx.coordinate_frame_helpers import align_reference_frame
 from scitbx import matrix
 
 logger = logging.getLogger(__name__)
@@ -16,21 +21,43 @@ def export_xds_ascii(integrated_data, experiment_list, params, var_model=(1, 0))
     """Export data from integrated_data corresponding to experiment_list to
     an XDS_ASCII.HKL formatted text file."""
 
-    from dials.array_family import flex
+    if len(experiment_list) == 1:
+        experiment_data = integrated_data.select(integrated_data["id"] >= 0)
+        _export_experiment(
+            params.xds_ascii.hklout,
+            experiment_data,
+            experiment_list[0],
+            params,
+            var_model,
+        )
+    else:
+        for i, experiment in enumerate(experiment_list):
+            experiment_data = integrated_data.select(integrated_data["id"] == i)
+            name, ext = os.path.splitext(params.xds_ascii.hklout)
+            filename = name + "_{}".format(i) + ext
+            _export_experiment(filename, experiment_data, experiment, params, var_model)
 
-    # for the moment assume (and assert) that we will convert data from exactly
-    # one lattice...
 
-    assert len(experiment_list) == 1
-    # select reflections that are assigned to an experiment (i.e. non-negative id)
+def _export_experiment(filename, integrated_data, experiment, params, var_model=(1, 0)):
+    # type: (str, flex.reflection_table, dxtbx.model.Experiment, phil_scope, Tuple)
+    """Export a single experiment to an XDS_ASCII.HKL format file.
 
-    integrated_data = integrated_data.select(integrated_data["id"] >= 0)
-    assert max(integrated_data["id"]) == 0
-
+    Args:
+        filename: The file to write to
+        integrated_data: The reflection table, pre-selected to one experiment
+        experiment: The experiment list entry to export
+        params: The PHIL configuration object
+        var_model:
+    """
     # export for xds_ascii should only be for non-scaled reflections
     assert any(
         [i in integrated_data for i in ["intensity.sum.value", "intensity.prf.value"]]
     )
+    # Handle requesting profile intensities (default via auto) but no column
+    if "profile" in params.intensity and not "intensity.prf.value" in integrated_data:
+        raise Sorry(
+            "Requested profile intensity data but only summed present. Use intensity=sum."
+        )
 
     integrated_data = filter_reflection_table(
         integrated_data,
@@ -48,31 +75,29 @@ def export_xds_ascii(integrated_data, experiment_list, params, var_model=(1, 0))
         integrated_data
     )
 
-    experiment = experiment_list[0]
-
     # sort data before output
     nref = len(integrated_data["miller_index"])
     indices = flex.size_t_range(nref)
 
     unique = copy.deepcopy(integrated_data["miller_index"])
-    from cctbx.miller import map_to_asu
 
     map_to_asu(experiment.crystal.get_space_group().type(), False, unique)
 
     perm = sorted(indices, key=lambda k: unique[k])
     integrated_data = integrated_data.select(flex.size_t(perm))
 
-    from rstbx.cftbx.coordinate_frame_helpers import align_reference_frame
-
-    assert experiment.goniometer is not None
+    if experiment.goniometer is None:
+        print("Warning: No goniometer. Experimentally exporting with (1 0 0) axis")
 
     unit_cell = experiment.crystal.get_unit_cell()
 
-    from scitbx.array_family import flex
-
-    assert experiment.scan is not None
-    image_range = experiment.scan.get_image_range()
-    phi_start, phi_range = experiment.scan.get_image_oscillation(image_range[0])
+    if experiment.scan is None:
+        print("Warning: No Scan. Experimentally exporting no-oscillation values")
+        image_range = (1, 1)
+        phi_start, phi_range = 0.0, 0.0
+    else:
+        image_range = experiment.scan.get_image_range()
+        phi_start, phi_range = experiment.scan.get_image_oscillation(image_range[0])
 
     # gather the required information for the reflection file
 
@@ -105,7 +130,7 @@ def export_xds_ascii(integrated_data, experiment_list, params, var_model=(1, 0))
         V = var_model[0] * (V + var_model[1] * I * I)
         sigI = flex.sqrt(V)
 
-    fout = open(params.xds_ascii.hklout, "w")
+    fout = open(filename, "w")
 
     # first write the header - in the "standard" coordinate frame...
 
@@ -133,7 +158,11 @@ def export_xds_ascii(integrated_data, experiment_list, params, var_model=(1, 0))
     UB = Rd * matrix.sqr(experiment.crystal.get_A())
     real_space_ABC = UB.inverse().elems
 
-    axis = Rd * experiment.goniometer.get_rotation_axis()
+    if experiment.goniometer is not None:
+        axis = Rd * experiment.goniometer.get_rotation_axis()
+    else:
+        axis = Rd * (1, 0, 0)
+
     beam = Rd * experiment.beam.get_s0()
     cell_fmt = "%9.3f %9.3f %9.3f %7.3f %7.3f %7.3f"
     axis_fmt = "%9.3f %9.3f %9.3f"
@@ -230,4 +259,4 @@ def export_xds_ascii(integrated_data, experiment_list, params, var_model=(1, 0))
 
     fout.write("!END_OF_DATA\n")
     fout.close()
-    logger.info("Output %d reflections to %s" % (nref, params.xds_ascii.hklout))
+    logger.info("Output %d reflections to %s" % (nref, filename))

--- a/util/export_xds_ascii.py
+++ b/util/export_xds_ascii.py
@@ -4,15 +4,23 @@ import copy
 import logging
 import os
 
+import libtbx.phil
 from cctbx.miller import map_to_asu
+from rstbx.cftbx.coordinate_frame_helpers import align_reference_frame
+from scitbx import matrix
+
+import dxtbx.model
 from dials.array_family import flex
 from dials.util import Sorry
 from dials.util.filter_reflections import (
     FilteringReductionMethods,
     filter_reflection_table,
 )
-from rstbx.cftbx.coordinate_frame_helpers import align_reference_frame
-from scitbx import matrix
+
+try:
+    from typing import Tuple
+except ImportError:
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +47,7 @@ def export_xds_ascii(integrated_data, experiment_list, params, var_model=(1, 0))
 
 
 def _export_experiment(filename, integrated_data, experiment, params, var_model=(1, 0)):
-    # type: (str, flex.reflection_table, dxtbx.model.Experiment, phil_scope, Tuple)
+    # type: (str, flex.reflection_table, dxtbx.model.Experiment, libtbx.phil.scope_extract, Tuple)
     """Export a single experiment to an XDS_ASCII.HKL format file.
 
     Args:
@@ -54,7 +62,7 @@ def _export_experiment(filename, integrated_data, experiment, params, var_model=
         [i in integrated_data for i in ["intensity.sum.value", "intensity.prf.value"]]
     )
     # Handle requesting profile intensities (default via auto) but no column
-    if "profile" in params.intensity and not "intensity.prf.value" in integrated_data:
+    if "profile" in params.intensity and "intensity.prf.value" not in integrated_data:
         raise Sorry(
             "Requested profile intensity data but only summed present. Use intensity=sum."
         )


### PR DESCRIPTION
Was asked to help export some still data to XDS_ASCII this, and lots of things fell over, so this fixes the immediate problems.

- Stills have been handled by writing a neutral (1,0,0) rotation axis and zero oscillation values. Not knowing the use cases for this, I don't know if this violates assumptions.
- If multiple experiments, an index will be inserted into the filename before the extension and written to a separate file.
- Also, a more useful error if the profile column doesn't exist

This issue was raised in #637, which this fixes.

Suggestions on testing/validating this output are welcome, I don't know any still/multilattice datasets in dials-data yet.