### PR TITLE
Cleanup file headers

### DIFF
--- a/algorithms/background/gmodel/modeller.py
+++ b/algorithms/background/gmodel/modeller.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# algorithm.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/algorithms/background/median/algorithm.py
+++ b/algorithms/background/median/algorithm.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# algorithm.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/algorithms/background/simple/algorithm.py
+++ b/algorithms/background/simple/algorithm.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# general.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/algorithms/background_lookup/background_and_gain.py
+++ b/algorithms/background_lookup/background_and_gain.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# gain.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from functools import reduce

--- a/algorithms/background_lookup/detector_noise.py
+++ b/algorithms/background_lookup/detector_noise.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# detector_noise.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/algorithms/centroid/simple/algorithm.py
+++ b/algorithms/centroid/simple/algorithm.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# algorithm.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/algorithms/clustering/observers.py
+++ b/algorithms/clustering/observers.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 from collections import OrderedDict

--- a/algorithms/clustering/plots.py
+++ b/algorithms/clustering/plots.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 from collections import OrderedDict

--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -1,14 +1,4 @@
-#!/usr/bin/env python
-# -*- mode: python; coding: utf-8; indent-tabs-mode: nil; python-indent: 2 -*-
-#
-# dials.algorithms.indexing.indexer.py
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: Richard Gildea
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 

--- a/algorithms/indexing/known_orientation.py
+++ b/algorithms/indexing/known_orientation.py
@@ -1,14 +1,4 @@
-#!/usr/bin/env python
-# -*- mode: python; coding: utf-8; indent-tabs-mode: nil; python-indent: 2 -*-
-#
-# dials.algorithms.indexing.known_orientation.py
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: Richard Gildea
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 

--- a/algorithms/indexing/nave_parameters.py
+++ b/algorithms/indexing/nave_parameters.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-# -*- mode: python; coding: utf-8; indent-tabs-mode: nil; python-indent: 2 -*-
-#
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 

--- a/algorithms/indexing/refinement.py
+++ b/algorithms/indexing/refinement.py
@@ -1,13 +1,4 @@
-#!/usr/bin/env python
-# -*- mode: python; coding: utf-8; indent-tabs-mode: nil; python-indent: 2 -*-
-# dials.algorithms.indexing.refinement.py
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: Richard Gildea
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 

--- a/algorithms/integration/filtering.py
+++ b/algorithms/integration/filtering.py
@@ -1,12 +1,3 @@
-#
-# filtering.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
 from iotbx.phil import parse

--- a/algorithms/integration/image_integrator.py
+++ b/algorithms/integration/image_integrator.py
@@ -1,14 +1,3 @@
-#
-# image_integrator.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/algorithms/integration/integrator_stills.py
+++ b/algorithms/integration/integrator_stills.py
@@ -1,13 +1,3 @@
-#
-# integrator_stills.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/algorithms/integration/parallel_integrator.py
+++ b/algorithms/integration/parallel_integrator.py
@@ -1,10 +1,3 @@
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -1,13 +1,3 @@
-#
-# processor.py
-#
-#  Copyright (C) 2015 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/algorithms/integration/report.py
+++ b/algorithms/integration/report.py
@@ -1,12 +1,3 @@
-#
-# report.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
 import collections

--- a/algorithms/integration/validation.py
+++ b/algorithms/integration/validation.py
@@ -1,13 +1,3 @@
-#
-# validation.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/algorithms/profile_model/factory.py
+++ b/algorithms/profile_model/factory.py
@@ -1,12 +1,3 @@
-#
-# factory.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
 

--- a/algorithms/profile_model/gaussian_rs/calculator.py
+++ b/algorithms/profile_model/gaussian_rs/calculator.py
@@ -1,10 +1,3 @@
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
 # FIXME Mosaicity seems to be overestimated
 # FIXME Don't know how XDS REFLECTING_RANGE is calculated
 # FIXME Don't know what XDS REFLECTION_RANGE is used for

--- a/algorithms/profile_model/gaussian_rs/model.py
+++ b/algorithms/profile_model/gaussian_rs/model.py
@@ -1,13 +1,3 @@
-#
-# profile_model.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/algorithms/refinement/analysis/centroid_analysis.py
+++ b/algorithms/refinement/analysis/centroid_analysis.py
@@ -1,10 +1,3 @@
-#  Copyright (C) (2016) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
 """Analysis of centroid residuals for determining suitable refinement and
 outlier rejection parameters automatically"""
 

--- a/algorithms/refinement/constraints.py
+++ b/algorithms/refinement/constraints.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-#  constraints.py
-#
-#  Copyright (C) 2017 Diamond Light Source and STFC Rutherford Appleton
-#                     Laboratory, UK.
-#
-#  Author: David Waterman
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/algorithms/refinement/engine.py
+++ b/algorithms/refinement/engine.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 """Contains classes for refinement engines. Refinery is the shared interface,
 LevenbergMarquardtIterations, GaussNewtonIterations, SimpleLBFGS and LBFGScurvs
 are the current concrete implementations"""

--- a/algorithms/refinement/outlier_detection/mcd.py
+++ b/algorithms/refinement/outlier_detection/mcd.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-#  mcd.py
-#
-#  Copyright (C) 2015 Diamond Light Source and STFC Rutherford Appleton
-#                     Laboratory, UK.
-#
-#  Author: David Waterman
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from dials.algorithms.refinement.outlier_detection import CentroidOutlier

--- a/algorithms/refinement/outlier_detection/tukey.py
+++ b/algorithms/refinement/outlier_detection/tukey.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-#  tukey.py
-#
-#  Copyright (C) 2015 Diamond Light Source and STFC Rutherford Appleton
-#                     Laboratory, UK.
-#
-#  Author: David Waterman
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from dials.algorithms.refinement.outlier_detection import CentroidOutlier

--- a/algorithms/refinement/parameterisation/beam_parameters.py
+++ b/algorithms/refinement/parameterisation/beam_parameters.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env cctbx.python
-
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 from dials.algorithms.refinement.parameterisation.model_parameters import (
     Parameter,

--- a/algorithms/refinement/parameterisation/crystal_parameters.py
+++ b/algorithms/refinement/parameterisation/crystal_parameters.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env cctbx.python
-
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 import logging
 

--- a/algorithms/refinement/parameterisation/goniometer_parameters.py
+++ b/algorithms/refinement/parameterisation/goniometer_parameters.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env cctbx.python
-
-#
-#  Copyright (C) (2017) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 from dials.algorithms.refinement.parameterisation.model_parameters import (
     Parameter,

--- a/algorithms/refinement/parameterisation/model_parameters.py
+++ b/algorithms/refinement/parameterisation/model_parameters.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 from scitbx.array_family import flex

--- a/algorithms/refinement/parameterisation/prediction_parameters.py
+++ b/algorithms/refinement/parameterisation/prediction_parameters.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2014) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 from dials.array_family import flex

--- a/algorithms/refinement/parameterisation/prediction_parameters_stills.py
+++ b/algorithms/refinement/parameterisation/prediction_parameters_stills.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2014) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 from dials.array_family import flex
 from dials.algorithms.refinement.parameterisation.prediction_parameters import (

--- a/algorithms/refinement/parameterisation/scan_varying_beam_parameters.py
+++ b/algorithms/refinement/parameterisation/scan_varying_beam_parameters.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2016) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 from scitbx import matrix
 from dials.algorithms.refinement.parameterisation.scan_varying_model_parameters import (

--- a/algorithms/refinement/parameterisation/scan_varying_crystal_parameters.py
+++ b/algorithms/refinement/parameterisation/scan_varying_crystal_parameters.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 from scitbx import matrix
 from dials.algorithms.refinement.parameterisation.scan_varying_model_parameters import (

--- a/algorithms/refinement/parameterisation/scan_varying_detector_parameters.py
+++ b/algorithms/refinement/parameterisation/scan_varying_detector_parameters.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2016) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 from collections import namedtuple
 from scitbx import matrix

--- a/algorithms/refinement/parameterisation/scan_varying_goniometer_parameters.py
+++ b/algorithms/refinement/parameterisation/scan_varying_goniometer_parameters.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2017) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 from scitbx import matrix
 from dials.algorithms.refinement.parameterisation.scan_varying_model_parameters import (

--- a/algorithms/refinement/parameterisation/scan_varying_model_parameters.py
+++ b/algorithms/refinement/parameterisation/scan_varying_model_parameters.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 from dials.algorithms.refinement.parameterisation.model_parameters import (
     Parameter,

--- a/algorithms/refinement/prediction/managed_predictors.py
+++ b/algorithms/refinement/prediction/managed_predictors.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 """Managed reflection prediction for refinement.
 
 * ScansRayPredictor adapts DIALS prediction for use in refinement, by keeping

--- a/algorithms/refinement/refiner.py
+++ b/algorithms/refinement/refiner.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.algorithms.refinement.refiner.py
-#
-#  Copyright (C) 2013 Diamond Light Source and STFC Rutherford Appleton
-#                     Laboratory, UK.
-#
-#  Authors: James Parkhurst, David Waterman
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 """Refiner is the refinement module public interface. RefinerFactory is
 what should usually be used to construct a Refiner."""
 

--- a/algorithms/refinement/restraints/restraints.py
+++ b/algorithms/refinement/restraints/restraints.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-#  restraints.py
-#
-#  Copyright (C) 2015 Diamond Light Source and STFC Rutherford Appleton
-#                     Laboratory, UK.
-#
-#  Author: David Waterman
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 from scitbx.array_family import flex
 from scitbx import sparse

--- a/algorithms/refinement/rotation_decomposition.py
+++ b/algorithms/refinement/rotation_decomposition.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-#
-#  Copyright (C) (2014) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 import math
 from scitbx import matrix

--- a/algorithms/refinement/target.py
+++ b/algorithms/refinement/target.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2014) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 """Contains classes used to construct a target function for refinement,
 principally Target and ReflectionManager."""
 

--- a/algorithms/refinement/target_stills.py
+++ b/algorithms/refinement/target_stills.py
@@ -1,13 +1,3 @@
-#
-#  Copyright (C) (2014) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
-# python and cctbx imports
 from __future__ import absolute_import, division, print_function
 from math import pi, sqrt
 from cctbx.array_family import flex

--- a/algorithms/refinement/two_theta_refiner.py
+++ b/algorithms/refinement/two_theta_refiner.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env cctbx.python
-
-#
-#  Copyright (C) (2016) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
 """Versions of refinement classes for two theta refinement of the unit cell"""
 
 from __future__ import absolute_import, division, print_function

--- a/algorithms/refinement/weighting_strategies.py
+++ b/algorithms/refinement/weighting_strategies.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2014) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 """Contains classes used to provide weighting schemes as strategies for
 ReflectionManagers."""
 from __future__ import absolute_import, division, print_function

--- a/algorithms/scaling/plots.py
+++ b/algorithms/scaling/plots.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 """
 Make plotly plots for html output by dials.scale, dials.report or xia2.report.
 """

--- a/algorithms/scaling/scale_and_filter.py
+++ b/algorithms/scaling/scale_and_filter.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 """Definitions of functions and classes for scaling and filtering algorithm."""
 from __future__ import absolute_import, division, print_function
 

--- a/algorithms/shoebox/masker.py
+++ b/algorithms/shoebox/masker.py
@@ -1,13 +1,3 @@
-#
-# masker.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/algorithms/simulation/reciprocal_space.py
+++ b/algorithms/simulation/reciprocal_space.py
@@ -1,12 +1,3 @@
-#!/usr/bin/env python
-#
-# reciprocal_space.py
-#
-#  Copyright (C) 2014 Diamond Light Source, James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -1,13 +1,3 @@
-#
-# finder.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/algorithms/spot_finding/threshold.py
+++ b/algorithms/spot_finding/threshold.py
@@ -1,13 +1,3 @@
-#
-# threshold.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/algorithms/spot_prediction/reflection_predictor.py
+++ b/algorithms/spot_prediction/reflection_predictor.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# reflection_predictor.py
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 import logging
 

--- a/algorithms/statistics/delta_cchalf.py
+++ b/algorithms/statistics/delta_cchalf.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-# delta_cchalf.py
-#
-#  Copyright (C) 2018 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/algorithms/symmetry/cosym/plots.py
+++ b/algorithms/symmetry/cosym/plots.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 from __future__ import absolute_import, division, print_function
 
 from scitbx.array_family import flex

--- a/algorithms/symmetry/origin.py
+++ b/algorithms/symmetry/origin.py
@@ -1,16 +1,7 @@
-#!/usr/bin/env dials.python
-#
-# dials.algorithms.symmetry.origin
-#
-#  Copyright (C) 2016 Diamond Light Source
-#
-#  Author: Graeme Winter
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-# Analysis of the origin of the diffraction pattern based on indexed and
-# measured intensities.
+"""
+Analysis of the origin of the diffraction pattern based on indexed and
+measured intensities.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/command_line/analyse_output.py
+++ b/command_line/analyse_output.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# analyse_output.py
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import copy

--- a/command_line/assign_experiment_identifiers.py
+++ b/command_line/assign_experiment_identifiers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 from __future__ import absolute_import, division, print_function
 

--- a/command_line/check_indexing_symmetry.py
+++ b/command_line/check_indexing_symmetry.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.command_line.check_indexing_symmetry.py
-#
-#  Copyright (C) 2015 Diamond Light Source
-#
-#  Author: Graeme Winter
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import math

--- a/command_line/cluster_exec.py
+++ b/command_line/cluster_exec.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# cluster.dials.exec
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
 # LIBTBX_SET_DISPATCHER_NAME cluster.dials.exec
 
 from __future__ import absolute_import, division, print_function

--- a/command_line/combine_experiments.py
+++ b/command_line/combine_experiments.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env dials.python
 from __future__ import absolute_import, division, print_function
 
 import os

--- a/command_line/complete_full_sphere.py
+++ b/command_line/complete_full_sphere.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # LIBTBX_SET_DISPATCHER_NAME dials.complete_full_sphere
 
 from __future__ import absolute_import, division, print_function

--- a/command_line/compute_delta_cchalf.py
+++ b/command_line/compute_delta_cchalf.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.compute_delta_cchalf
-#
-#  Copyright (C) 2018 Diamond Light Source
-#
-#  Authors: James Parkhurst, James Beilsten-Edmands
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
 from __future__ import absolute_import, division, print_function
 import collections
 import logging

--- a/command_line/convert_to_cbf.py
+++ b/command_line/convert_to_cbf.py
@@ -1,12 +1,3 @@
-#!/usr/bin/env python
-# convert_to_cbf.py
-#
-#   Copyright (C) 2018 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 import iotbx.phil

--- a/command_line/create_profile_model.py
+++ b/command_line/create_profile_model.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.create_profile_model.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/command_line/find_shared_models.py
+++ b/command_line/find_shared_models.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.find_shared_models.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/command_line/find_spots.py
+++ b/command_line/find_spots.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.find_spots.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
 # DIALS_ENABLE_COMMAND_LINE_COMPLETION
 
 from __future__ import absolute_import, division, print_function

--- a/command_line/frame_orientations.py
+++ b/command_line/frame_orientations.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 Print a table of the orientation for every image of a dataset. The
 orientation is expressed as a zone axis (a direction referenced to the direct

--- a/command_line/generate_mask.py
+++ b/command_line/generate_mask.py
@@ -1,14 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# generate_mask.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
+# coding: utf-8
 
 """
 Mask images to remove unwanted pixels.

--- a/command_line/geometry_viewer.py
+++ b/command_line/geometry_viewer.py
@@ -1,5 +1,4 @@
 # LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
-
 # DIALS_ENABLE_COMMAND_LINE_COMPLETION
 from __future__ import absolute_import, division, print_function
 

--- a/command_line/import_stream.py
+++ b/command_line/import_stream.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-# import_stream.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is` distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/command_line/import_xds.py
+++ b/command_line/import_xds.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import absolute_import, division, print_function
 
 import os

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.integrate.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 """
 Command line script to allow merging and truncating of a dials dataset.

--- a/command_line/merge_cbf.py
+++ b/command_line/merge_cbf.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import absolute_import, division, print_function
 
 import binascii

--- a/command_line/merge_reflection_lists.py
+++ b/command_line/merge_reflection_lists.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# merge_reflection_lists.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 # LIBTBX_SET_DISPATCHER_NAME dev.dials.merge_reflection_lists
 
 from __future__ import absolute_import, division, print_function

--- a/command_line/model_background.py
+++ b/command_line/model_background.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.model_background.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/command_line/plot_Fo_vs_Fc.py
+++ b/command_line/plot_Fo_vs_Fc.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # LIBTBX_SET_DISPATCHER_NAME dials.plot_Fo_vs_Fc
 
 """

--- a/command_line/predict.py
+++ b/command_line/predict.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.predict.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from dials.util import show_mail_on_error

--- a/command_line/reciprocal_lattice_viewer.py
+++ b/command_line/reciprocal_lattice_viewer.py
@@ -1,5 +1,4 @@
 # LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
-
 # DIALS_ENABLE_COMMAND_LINE_COMPLETION
 from __future__ import absolute_import, division, print_function
 

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.refine.py
-#
-#  Copyright (C) 2013 Diamond Light Source and STFC Rutherford Appleton
-#  Laboratory, UK.
-#
-#  Author: James Parkhurst and David Waterman
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 # DIALS_ENABLE_COMMAND_LINE_COMPLETION
 
 """

--- a/command_line/reindex.py
+++ b/command_line/reindex.py
@@ -1,14 +1,4 @@
-#!/usr/bin/env python
-# -*- mode: python; coding: utf-8; indent-tabs-mode: nil; python-indent: 2 -*-
-#
-# dials.command_line.reindex.py
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: Richard Gildea
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -1,11 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-#  Copyright (C) 2015 Diamond Light Source
-#
-#  Author: James Parkhurst, Richard Gildea
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 

--- a/command_line/rl_png.py
+++ b/command_line/rl_png.py
@@ -1,5 +1,4 @@
 # LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
-
 # DIALS_ENABLE_COMMAND_LINE_COMPLETION
 from __future__ import absolute_import, division, print_function
 

--- a/command_line/rs_mapper.py
+++ b/command_line/rs_mapper.py
@@ -1,12 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.rs_mapper.py
-#
-#  Copyright (C) 2014 Takanori Nakane
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import math

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 from __future__ import absolute_import, division, print_function
 import time

--- a/command_line/slice_sweep.py
+++ b/command_line/slice_sweep.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.slice_sweep.py
-#
-#  Copyright (C) 2014 Diamond Light Source and STFC Rutherford Appleton
-#  Laboratory, UK.
-#
-#  Author: David Waterman
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from os.path import basename, splitext

--- a/command_line/space_group.py
+++ b/command_line/space_group.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 """
 Command line script to assess the space group symmetry (for MX datasets)

--- a/command_line/split_experiments.py
+++ b/command_line/split_experiments.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env dials.python
 from __future__ import absolute_import, division, print_function
 
 import functools

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import absolute_import, division, print_function
 
 import copy

--- a/command_line/stills_process_mpi.py
+++ b/command_line/stills_process_mpi.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # LIBTBX_SET_DISPATCHER_NAME dials.stills_process_mpi
 
 from __future__ import absolute_import, division, print_function

--- a/command_line/two_theta_offset.py
+++ b/command_line/two_theta_offset.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.two_theta_offset.py
-#
-#  Copyright (C) 2016 Diamond Light Source
-#
-#  Author: Graeme Winter
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from dials.util import show_mail_on_error

--- a/command_line/two_theta_refine.py
+++ b/command_line/two_theta_refine.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-#  two_theta_refine.py
-#
-#  Copyright (C) 2016 Diamond Light Source and STFC Rutherford Appleton
-#  Laboratory, UK.
-#
-#  Author: David Waterman
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import datetime

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@
 # write and run pytest tests, and an overview of the available features.
 #
 
+
 from __future__ import absolute_import, division, print_function
 
 import os

--- a/data/lookup.py
+++ b/data/lookup.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-# lookup.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 from libtbx.phil import parse
 

--- a/data/multiprocessing.py
+++ b/data/multiprocessing.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-# multiprocessing.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 from libtbx.phil import parse
 

--- a/doc/examples/read_experiment_and_data/experiment_data.py
+++ b/doc/examples/read_experiment_and_data/experiment_data.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
-#
+# coding: utf-8
 # Example code for how to load experiments and reflections in the DIALS
-# framework
 
 from __future__ import absolute_import, division, print_function
 

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 from __future__ import absolute_import, division, print_function
 
 # DIALS documentation build configuration file, created by

--- a/doc/sphinx/conf_bootstrap.py
+++ b/doc/sphinx/conf_bootstrap.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 from __future__ import absolute_import, division, print_function
 
 ### build documentation with: phenix.python `which sphinx-build` -b html source build/html

--- a/extensions/gaussian_rs_profile_model_ext.py
+++ b/extensions/gaussian_rs_profile_model_ext.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-# gaussian_rs_profile_model_ext.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
 

--- a/extensions/simple_background_ext.py
+++ b/extensions/simple_background_ext.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-# simple_background_ext.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
 

--- a/model/experiment/profile.py
+++ b/model/experiment/profile.py
@@ -1,13 +1,3 @@
-#
-# profile.py
-#
-#  Copyright (C) 2015 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/report/plots.py
+++ b/report/plots.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 """
 This module defines a number of general plots, which may be relevant to
 for reports of several programs.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# coding: utf-8
 
 import sys
 from setuptools import setup, find_packages

--- a/test/algorithms/refinement/setup_minimiser.py
+++ b/test/algorithms/refinement/setup_minimiser.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env cctbx.python
-
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 """Setup experimental geometry for refinement test cases"""
 
 # Python and cctbx imports

--- a/test/algorithms/refinement/test_constraints.py
+++ b/test/algorithms/refinement/test_constraints.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2017) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 """
 Tests for the constraints system used in refinement
 

--- a/test/algorithms/refinement/test_crystal_parameters.py
+++ b/test/algorithms/refinement/test_crystal_parameters.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.model import Crystal

--- a/test/algorithms/refinement/test_cspad_refinement.py
+++ b/test/algorithms/refinement/test_cspad_refinement.py
@@ -1,5 +1,3 @@
-# Test multiple stills refinement.
-
 from __future__ import absolute_import, division, print_function
 
 import os

--- a/test/algorithms/refinement/test_finite_diffs.py
+++ b/test/algorithms/refinement/test_finite_diffs.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env cctbx.python
-
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 """Test analytical calculation of gradients of the target function versus finite
 difference calculations"""
 

--- a/test/algorithms/refinement/test_hierarchical_detector_refinement.py
+++ b/test/algorithms/refinement/test_hierarchical_detector_refinement.py
@@ -1,5 +1,3 @@
-# Test hierarchical detector refinement.
-
 from __future__ import absolute_import, division, print_function
 
 import copy

--- a/test/algorithms/refinement/test_refine_multi_stills.py
+++ b/test/algorithms/refinement/test_refine_multi_stills.py
@@ -1,5 +1,3 @@
-# Test multiple stills refinement.
-
 from __future__ import absolute_import, division, print_function
 
 import os

--- a/test/algorithms/refinement/test_rotation_decomposition.py
+++ b/test/algorithms/refinement/test_rotation_decomposition.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env cctbx.python
-
-#
-#  Copyright (C) (2015) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 """Test decomposition of rotation matrices around arbitrary axes"""
 
 from __future__ import absolute_import, division, print_function

--- a/test/algorithms/refinement/test_two_theta_refinement.py
+++ b/test/algorithms/refinement/test_two_theta_refinement.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2016) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 """
 Test refinement of a crystal unit cell using a two theta target.
 

--- a/test/algorithms/spot_prediction/test_reeke.py
+++ b/test/algorithms/spot_prediction/test_reeke.py
@@ -1,12 +1,3 @@
-#
-#  Copyright (C) (2013) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 # A class for producing efficient looping limits for reflection

--- a/util/command_line.py
+++ b/util/command_line.py
@@ -1,13 +1,3 @@
-#
-# command_line.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import time

--- a/util/export_json.py
+++ b/util/export_json.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-# export_json.py
-#
-#  Copyright (C) 2016 Diamond Light Source
-#
-#  Author: Richard Gildea
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
 import json

--- a/util/image.py
+++ b/util/image.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# dials.util.image.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/util/image_viewer/slip_viewer/calibration_frame.py
+++ b/util/image_viewer/slip_viewer/calibration_frame.py
@@ -1,6 +1,4 @@
-# -*- mode: python; coding: utf-8; indent-tabs-mode: nil; python-indent: 2 -*-
-#
-# $Id$
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 from six.moves import range

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -1,9 +1,8 @@
-# -*- mode: python; coding: utf-8; indent-tabs-mode: nil; python-indent: 2 -*-
+# coding: utf-8
 #
 # Known issues: Recentering on resize and when switching between
 # different image types.  Ring centre on image switch.
-#
-# $Id$
+
 
 from __future__ import absolute_import, division, print_function
 from six.moves import range

--- a/util/image_viewer/slip_viewer/pyslip.py
+++ b/util/image_viewer/slip_viewer/pyslip.py
@@ -1,4 +1,4 @@
-# -*- mode: python; coding: utf-8; indent-tabs-mode: nil -*-
+# coding: utf-8
 
 """
 A 'slippy map' widget for wxPython.

--- a/util/image_viewer/slip_viewer/score_frame.py
+++ b/util/image_viewer/slip_viewer/score_frame.py
@@ -1,6 +1,4 @@
-# -*- mode: python; coding: utf-8; indent-tabs-mode: nil; python-indent: 2 -*-
-#
-# $Id$
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 from six.moves import range

--- a/util/image_viewer/slip_viewer/slip_display.py
+++ b/util/image_viewer/slip_viewer/slip_display.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding= utf-8 -*-
-
 """pySlip demonstration program."""
 from __future__ import absolute_import, division, print_function
 

--- a/util/intensity_explorer.py
+++ b/util/intensity_explorer.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding:utf-8 -*-
+# coding: utf-8
 
 from __future__ import absolute_import, division, print_function
 

--- a/util/masking/__init__.py
+++ b/util/masking/__init__.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# masking.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import logging

--- a/util/nexus_old.py
+++ b/util/nexus_old.py
@@ -1,15 +1,3 @@
-#!/usr/bin/env python
-#
-# nexus.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/util/phil.py
+++ b/util/phil.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-# phil.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
 import libtbx.phil

--- a/util/report.py
+++ b/util/report.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# report.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 

--- a/viewer/bitmap_from_array.py
+++ b/viewer/bitmap_from_array.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-#  bitmap_from_array.py
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: Luis Fuentes-Montero (Luiso)
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 import wx
 import numpy as np

--- a/viewer/slice_viewer.py
+++ b/viewer/slice_viewer.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-#  slice_viewer.py
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: Luis Fuentes-Montero (Luiso)
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 import wx
 from dials.viewer.viewer_low_level_util import (

--- a/viewer/viewer_interface.py
+++ b/viewer/viewer_interface.py
@@ -1,14 +1,3 @@
-#
-#  DIALS viewer_interface
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: Luis Fuentes-Montero (Luiso)
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package."
-#
-#
 from __future__ import absolute_import, division, print_function
 
 from dials.array_family import flex

--- a/viewer/viewer_low_level_util.py
+++ b/viewer/viewer_low_level_util.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-#  viewer_low_level_util.py
-#
-#  Copyright (C) 2014 Diamond Light Source
-#
-#  Author: Luis Fuentes-Montero (Luiso)
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 from dials.array_family import flex
 from dials.viewer.from_flex_to_wxbitmap import wxbitmap_convert


### PR DESCRIPTION
For further discussion from #913. This cleans up the file headers, using [this script](https://gist.github.com/ndevenish/cb9ed83742d3c5102cc1aef9de1fb24a). Precisely:

- Removes all header lines except when possibly relevant (ignores e.g. `FIXME`, libtbx dispatcher instructions, pytest comment in conftest and a couple of hand-tuned files)
- Removes all shebang unless in `command_line/`, `setup.py` or `util/show_version.py`
- Makes all coding instruction `# coding: utf-8`
- Removes editor commands otherwise
