### PR TITLE
Fixes for #921 - split off dials.export format=best

### DIFF
--- a/command_line/export.py
+++ b/command_line/export.py
@@ -197,15 +197,9 @@ phil_scope = parse(
   }
 
   output {
-
     log = dials.export.log
       .type = path
       .help = "The log filename"
-
-    debug_log = dials.export.debug.log
-      .type = path
-      .help = "The debug log filename"
-
   }
 """
 )
@@ -569,7 +563,7 @@ if __name__ == "__main__":
     params, options = parser.parse_args(show_diff_phil=False)
 
     # Configure the logging
-    log.config(info=params.output.log, debug=params.output.debug_log)
+    log.config(info=params.output.log)
 
     # Print the version number
     logger.info(dials_version())

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -211,26 +211,6 @@ phil_scope = parse(
 )
 
 
-class BaseExporter(object):
-    """
-    A base class for export reflections - though do we need a class here
-    - could just have entry points registered?
-    """
-
-    def __init__(self, params, experiments, reflections):
-        self.params = params
-        self.experiments = experiments
-        self.reflections = reflections
-
-    def check(self):
-        """Check the input provided was sane."""
-        raise NotImplementedError("Function check() must be overloaded")
-
-    def export(self):
-        """Export the data in the desired format."""
-        raise NotImplementedError("Function export() must be overloaded")
-
-
 class MTZExporter(object):
     """
     A class to export reflections in MTZ format

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -563,7 +563,7 @@ if __name__ == "__main__":
     params, options = parser.parse_args(show_diff_phil=False)
 
     # Configure the logging
-    log.config(info=params.output.log)
+    log.config(logfile=params.output.log)
 
     # Print the version number
     logger.info(dials_version())

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-import os
 import sys
 
 from libtbx.phil import parse
@@ -72,7 +71,7 @@ Examples::
 phil_scope = parse(
     """
 
-  format = *mtz sadabs nxs mmcif mosflm xds best xds_ascii json
+  format = *mtz sadabs nxs mmcif mosflm xds xds_ascii json
     .type = choice
     .help = "The output file format"
 
@@ -183,23 +182,6 @@ phil_scope = parse(
     directory = xds
       .type = path
       .help = "The output directory for xds output"
-
-  }
-
-  best {
-
-    prefix = best
-      .type = str
-      .help = "The prefix for the output file names for best"
-              "(.hkl, .dat and .par files)"
-
-    n_bins = 100
-      .type = int(value_min=1)
-      .help = "Number of resolution bins for background estimation"
-
-    min_partiality = 0.1
-      .type = float(value_min=0, value_max=1)
-      .help = "Minimum partiality of reflections to export"
 
   }
 
@@ -526,64 +508,6 @@ class XDSExporter(object):
         dump(self.experiments, self.reflections, self.params.xds.directory)
 
 
-class BestExporter(object):
-    """
-    A class to export stuff in BEST format
-    """
-
-    def __init__(self, params, experiments, reflections):
-        """
-        Initialise the exporter
-
-        :param params: The phil parameters
-        :param experiments: The experiment list
-        :param reflections: The reflection tables
-        """
-
-        # Check the input
-        if not experiments:
-            raise Sorry("BEST exporter requires an experiment list")
-        if not reflections:
-            raise Sorry("BEST exporter require a reflection table")
-
-        # Save the stuff
-        self.params = params
-        self.experiments = experiments
-        self.reflections = reflections
-
-    def export(self):
-        """
-        Export the files
-        """
-        from dials.util import best
-
-        experiment = self.experiments[0]
-        reflections = self.reflections[0]
-        partiality = reflections["partiality"]
-        sel = partiality >= self.params.best.min_partiality
-        logger.info(
-            "Selecting %s/%s reflections with partiality >= %s",
-            sel.count(True),
-            sel.size(),
-            self.params.best.min_partiality,
-        )
-        if sel.count(True) == 0:
-            raise Sorry(
-                "No reflections remaining after filtering for minimum partiality (min_partiality=%f)"
-                % (self.params.best.min_partiality)
-            )
-        reflections = reflections.select(sel)
-
-        imageset = experiment.imageset
-        prefix = self.params.best.prefix
-
-        best.write_background_file(
-            "%s.dat" % prefix, imageset, n_bins=self.params.best.n_bins
-        )
-        best.write_integrated_hkl(prefix, reflections)
-        best.write_par_file("%s.par" % prefix, experiment)
-
-
 class JsonExporter(object):
     """
     A class to export reflections in json format
@@ -652,23 +576,14 @@ if __name__ == "__main__":
     usage = "dials.export models.expt reflections.pickle [options]"
 
     # Create the option parser
-    if os.getenv("DIALS_EXPORT_DO_NOT_CHECK_FORMAT"):
-        parser = OptionParser(
-            usage=usage,
-            read_experiments=True,
-            read_reflections=True,
-            check_format=False,
-            phil=phil_scope,
-            epilog=help_message,
-        )
-    else:
-        parser = OptionParser(
-            usage=usage,
-            read_experiments=True,
-            read_reflections=True,
-            phil=phil_scope,
-            epilog=help_message,
-        )
+    parser = OptionParser(
+        usage=usage,
+        read_experiments=True,
+        read_reflections=True,
+        check_format=False,
+        phil=phil_scope,
+        epilog=help_message,
+    )
 
     # Get the parameters
     params, options = parser.parse_args(show_diff_phil=False)
@@ -678,8 +593,6 @@ if __name__ == "__main__":
 
     # Print the version number
     logger.info(dials_version())
-    if os.getenv("DIALS_EXPORT_DO_NOT_CHECK_FORMAT"):
-        logger.info("(format checks disabled due to environment variable)")
 
     # Log the diff phil
     diff_phil = parser.diff_phil.as_str()
@@ -723,8 +636,6 @@ if __name__ == "__main__":
         exporter = MosflmExporter(params, experiments, reflections)
     elif params.format == "xds":
         exporter = XDSExporter(params, experiments, reflections)
-    elif params.format == "best":
-        exporter = BestExporter(params, experiments, reflections)
     elif params.format == "json":
         exporter = JsonExporter(params, reflections, experiments=experiments)
     else:

--- a/command_line/export_best.py
+++ b/command_line/export_best.py
@@ -1,0 +1,173 @@
+from __future__ import absolute_import, division, print_function
+
+import logging
+import sys
+
+from libtbx.phil import parse
+from libtbx import Auto
+
+logger = logging.getLogger("dials.command_line.export_best")
+
+help_message = """
+This program is used to export the results of dials processing for the strategy
+program BEST.
+
+"""
+
+phil_scope = parse(
+    """
+
+  intensity = *auto profile sum scale
+    .type = choice(multi=True)
+    .help = "Choice of which intensities to export. Allowed combinations:
+            scale, profile, sum, profile+sum, sum+profile+scale. Auto will
+            default to scale or profile+sum depending on if the data are scaled."
+
+  debug = False
+    .type = bool
+    .help = "Output additional debugging information"
+
+  best {
+
+    prefix = best
+      .type = str
+      .help = "The prefix for the output file names for best"
+              "(.hkl, .dat and .par files)"
+
+    n_bins = 100
+      .type = int(value_min=1)
+      .help = "Number of resolution bins for background estimation"
+
+    min_partiality = 0.1
+      .type = float(value_min=0, value_max=1)
+      .help = "Minimum partiality of reflections to export"
+
+  }
+
+  output {
+
+    log = dials.export_best.log
+      .type = path
+      .help = "The log filename"
+
+    debug_log = dials.export_best.debug.log
+      .type = path
+      .help = "The debug log filename"
+
+  }
+"""
+)
+
+
+class BestExporter(object):
+    def __init__(self, params, experiments, reflections):
+        """
+        Initialise the exporter
+
+        :param params: The phil parameters
+        :param experiments: The experiment list
+        :param reflections: The reflection tables
+        """
+
+        # Check the input
+        if not experiments:
+            raise Sorry("BEST exporter requires an experiment list")
+        if not reflections:
+            raise Sorry("BEST exporter require a reflection table")
+
+        # Save the stuff
+        self.params = params
+        self.experiments = experiments
+        self.reflections = reflections
+
+    def export(self):
+        """
+        Export the files
+        """
+        from dials.util import best
+
+        experiment = self.experiments[0]
+        reflections = self.reflections[0]
+        partiality = reflections["partiality"]
+        sel = partiality >= self.params.best.min_partiality
+        logger.info(
+            "Selecting %s/%s reflections with partiality >= %s",
+            sel.count(True),
+            sel.size(),
+            self.params.best.min_partiality,
+        )
+        if sel.count(True) == 0:
+            raise Sorry(
+                "No reflections remaining after filtering for minimum partiality (min_partiality=%f)"
+                % (self.params.best.min_partiality)
+            )
+        reflections = reflections.select(sel)
+
+        imageset = experiment.imageset
+        prefix = self.params.best.prefix
+
+        best.write_background_file(
+            "%s.dat" % prefix, imageset, n_bins=self.params.best.n_bins
+        )
+        best.write_integrated_hkl(prefix, reflections)
+        best.write_par_file("%s.par" % prefix, experiment)
+
+
+if __name__ == "__main__":
+    from dials.util.options import (
+        OptionParser,
+        flatten_experiments,
+        flatten_reflections,
+    )
+    from dials.util.version import dials_version
+    from dials.util import log
+    from dials.util import Sorry
+
+    usage = "dials.export models.expt reflections.pickle [options]"
+
+    parser = OptionParser(
+        usage=usage,
+        read_experiments=True,
+        read_reflections=True,
+        phil=phil_scope,
+        epilog=help_message,
+    )
+
+    # Get the parameters
+    params, options = parser.parse_args(show_diff_phil=False)
+
+    # Configure the logging
+    log.config(info=params.output.log, debug=params.output.debug_log)
+
+    # Print the version number
+    logger.info(dials_version())
+
+    # Log the diff phil
+    diff_phil = parser.diff_phil.as_str()
+    if diff_phil != "":
+        logger.info("The following parameters have been modified:\n")
+        logger.info(diff_phil)
+
+    if not params.input.experiments and not params.input.reflections:
+        parser.print_help()
+        sys.exit()
+
+    # Get the experiments and reflections
+    experiments = flatten_experiments(params.input.experiments)
+    reflections = flatten_reflections(params.input.reflections)
+
+    # do auto intepreting of intensity choice:
+    # note that this may still fail certain checks further down the processing,
+    # but these are the defaults to try
+    if params.intensity in ([None], [Auto], ["auto"]) and reflections:
+        if ("intensity.scale.value" in reflections[0]) and (
+            "intensity.scale.variance" in reflections[0]
+        ):
+            params.intensity = ["scale"]
+            logger.info("Data appears to be scaled, setting intensity = scale")
+        else:
+            params.intensity = ["profile", "sum"]
+            logger.info("Data appears to be unscaled, setting intensity = profile+sum")
+
+    exporter = BestExporter(params, experiments, reflections)
+    exporter.export()

--- a/command_line/export_best.py
+++ b/command_line/export_best.py
@@ -27,32 +27,24 @@ phil_scope = parse(
     .type = bool
     .help = "Output additional debugging information"
 
-  best {
+  prefix = best
+    .type = str
+    .help = "The prefix for the output file names for best"
+            "(.hkl, .dat and .par files)"
 
-    prefix = best
-      .type = str
-      .help = "The prefix for the output file names for best"
-              "(.hkl, .dat and .par files)"
+  n_bins = 100
+    .type = int(value_min=1)
+    .help = "Number of resolution bins for background estimation"
 
-    n_bins = 100
-      .type = int(value_min=1)
-      .help = "Number of resolution bins for background estimation"
-
-    min_partiality = 0.1
-      .type = float(value_min=0, value_max=1)
-      .help = "Minimum partiality of reflections to export"
-
-  }
+  min_partiality = 0.1
+    .type = float(value_min=0, value_max=1)
+    .help = "Minimum partiality of reflections to export"
 
   output {
 
     log = dials.export_best.log
       .type = path
       .help = "The log filename"
-
-    debug_log = dials.export_best.debug.log
-      .type = path
-      .help = "The debug log filename"
 
   }
 """
@@ -89,25 +81,25 @@ class BestExporter(object):
         experiment = self.experiments[0]
         reflections = self.reflections[0]
         partiality = reflections["partiality"]
-        sel = partiality >= self.params.best.min_partiality
+        sel = partiality >= self.params.min_partiality
         logger.info(
             "Selecting %s/%s reflections with partiality >= %s",
             sel.count(True),
             sel.size(),
-            self.params.best.min_partiality,
+            self.params.min_partiality,
         )
         if sel.count(True) == 0:
             raise Sorry(
                 "No reflections remaining after filtering for minimum partiality (min_partiality=%f)"
-                % (self.params.best.min_partiality)
+                % (self.params.min_partiality)
             )
         reflections = reflections.select(sel)
 
         imageset = experiment.imageset
-        prefix = self.params.best.prefix
+        prefix = self.params.prefix
 
         best.write_background_file(
-            "%s.dat" % prefix, imageset, n_bins=self.params.best.n_bins
+            "%s.dat" % prefix, imageset, n_bins=self.params.n_bins
         )
         best.write_integrated_hkl(prefix, reflections)
         best.write_par_file("%s.par" % prefix, experiment)
@@ -137,7 +129,7 @@ if __name__ == "__main__":
     params, options = parser.parse_args(show_diff_phil=False)
 
     # Configure the logging
-    log.config(info=params.output.log, debug=params.output.debug_log)
+    log.config(info=params.output.log)
 
     # Print the version number
     logger.info(dials_version())

--- a/command_line/export_best.py
+++ b/command_line/export_best.py
@@ -4,28 +4,16 @@ import logging
 import sys
 
 from libtbx.phil import parse
-from libtbx import Auto
 
 logger = logging.getLogger("dials.command_line.export_best")
 
 help_message = """
 This program is used to export the results of dials processing for the strategy
 program BEST.
-
 """
 
 phil_scope = parse(
     """
-
-  intensity = *auto profile sum scale
-    .type = choice(multi=True)
-    .help = "Choice of which intensities to export. Allowed combinations:
-            scale, profile, sum, profile+sum, sum+profile+scale. Auto will
-            default to scale or profile+sum depending on if the data are scaled."
-
-  debug = False
-    .type = bool
-    .help = "Output additional debugging information"
 
   n_bins = 100
     .type = int(value_min=1)
@@ -147,19 +135,6 @@ if __name__ == "__main__":
     # Get the experiments and reflections
     experiments = flatten_experiments(params.input.experiments)
     reflections = flatten_reflections(params.input.reflections)
-
-    # do auto intepreting of intensity choice:
-    # note that this may still fail certain checks further down the processing,
-    # but these are the defaults to try
-    if params.intensity in ([None], [Auto], ["auto"]) and reflections:
-        if ("intensity.scale.value" in reflections[0]) and (
-            "intensity.scale.variance" in reflections[0]
-        ):
-            params.intensity = ["scale"]
-            logger.info("Data appears to be scaled, setting intensity = scale")
-        else:
-            params.intensity = ["profile", "sum"]
-            logger.info("Data appears to be unscaled, setting intensity = profile+sum")
 
     exporter = BestExporter(params, experiments, reflections)
     exporter.export()

--- a/command_line/export_best.py
+++ b/command_line/export_best.py
@@ -27,11 +27,6 @@ phil_scope = parse(
     .type = bool
     .help = "Output additional debugging information"
 
-  prefix = best
-    .type = str
-    .help = "The prefix for the output file names for best"
-            "(.hkl, .dat and .par files)"
-
   n_bins = 100
     .type = int(value_min=1)
     .help = "Number of resolution bins for background estimation"
@@ -45,6 +40,11 @@ phil_scope = parse(
     log = dials.export_best.log
       .type = path
       .help = "The log filename"
+
+    prefix = best
+      .type = str
+      .help = "The prefix for the output file names for best"
+              "(.hkl, .dat and .par files)"
 
   }
 """
@@ -96,7 +96,7 @@ class BestExporter(object):
         reflections = reflections.select(sel)
 
         imageset = experiment.imageset
-        prefix = self.params.prefix
+        prefix = self.params.output.prefix
 
         best.write_background_file(
             "%s.dat" % prefix, imageset, n_bins=self.params.n_bins

--- a/command_line/export_best.py
+++ b/command_line/export_best.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     params, options = parser.parse_args(show_diff_phil=False)
 
     # Configure the logging
-    log.config(info=params.output.log)
+    log.config(logfile=params.output.log)
 
     # Print the version number
     logger.info(dials_version())

--- a/newsfragments/921.feature
+++ b/newsfragments/921.feature
@@ -1,0 +1,3 @@
+Moved `dials.export format=best` to `dials.export_best` as that one needed 
+access to the format object, the rest do not, and having `dials.export` work
+in the general case seems like a better idea...

--- a/test/command_line/test_export_best.py
+++ b/test/command_line/test_export_best.py
@@ -34,7 +34,7 @@ def test_export_best(dials_data, tmpdir):
     )
     assert not result.returncode and not result.stderr
     result = procrunner.run(
-        ["dials.export", "integrated.expt", "integrated.refl", "format=best"],
+        ["dials.export_best", "integrated.expt", "integrated.refl"],
         working_directory=tmpdir.strpath,
     )
     assert not result.returncode and not result.stderr


### PR DESCRIPTION
Made a second program `dials.export_best` and removed option for `dials.export` so that it does not need access to the format object (so `check_format=False` and can run without images)