### PR TITLE
Retire *.debug.log (fixes #832)

### DIFF
--- a/command_line/check_indexing_symmetry.py
+++ b/command_line/check_indexing_symmetry.py
@@ -78,8 +78,6 @@ reference = None
 output {
   log = dials.check_indexing_symmetry.log
     .type = str
-  debug_log = dials.check_indexing_symmetry.debug.log
-    .type = str
 }
 """,
     process_includes=True,
@@ -323,7 +321,7 @@ def run(args):
     params, options = parser.parse_args(show_diff_phil=True)
 
     # Configure the logging
-    log.config(info=params.output.log, debug=params.output.debug_log)
+    log.config(logfile=params.output.log)
     logger.info(dials_version())
 
     reflections = flatten_reflections(params.input.reflections)

--- a/command_line/complete_full_sphere.py
+++ b/command_line/complete_full_sphere.py
@@ -53,10 +53,7 @@ class Script(object):
         params, options = self.parser.parse_args(show_diff_phil=True)
         from dials.util import log
 
-        log.config(
-            info="dials.complete_full_sphere.log",
-            debug="dials.complete_full_sphere.debug.log",
-        )
+        log.config(logfile="dials.complete_full_sphere.log")
 
         import math
         from scitbx import matrix

--- a/command_line/compute_delta_cchalf.py
+++ b/command_line/compute_delta_cchalf.py
@@ -75,14 +75,9 @@ phil_scope = parse(
     .help = "Datasets with a delta cc half below (mean - stdcutoff*std) are removed"
 
   output {
-
     log = 'dials.compute_delta_cchalf.log'
       .type = str
       .help = "The log filename"
-
-    debug_log = 'dials.compute_delta_cchalf.debug.log'
-      .type = str
-      .help = "The debug log filename"
   }
 """
 )
@@ -535,7 +530,7 @@ def run(args=None, phil=phil_scope):
 
     params, _ = parser.parse_args(args=args, show_diff_phil=False)
 
-    dials.util.log.config(info=params.output.log, debug=params.output.debug_log)
+    dials.util.log.config(logfile=params.output.log)
 
     experiments = flatten_experiments(params.input.experiments)
     reflections = flatten_reflections(params.input.reflections)

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -49,8 +49,6 @@ output {
     .type = str
   log = dials.cosym.log
     .type = str
-  debug_log = dials.cosym.debug.log
-    .type = str
   experiments = "symmetrized.expt"
     .type = path
   reflections = "symmetrized.refl"
@@ -317,9 +315,7 @@ def run(args):
     )
 
     # Configure the logging
-    log.config(
-        verbosity=options.verbose, info=params.output.log, debug=params.output.debug_log
-    )
+    log.config(verbosity=options.verbose, logfile=params.output.log)
 
     from dials.util.version import dials_version
 

--- a/command_line/detect_blanks.py
+++ b/command_line/detect_blanks.py
@@ -220,7 +220,7 @@ def run(args):
         exit(0)
 
     # Configure the logging
-    log.config(info="dials.detect_blanks.log")
+    log.config(logfile="dials.detect_blanks.log")
 
     # Log the diff phil
     diff_phil = parser.diff_phil.as_str()

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -84,10 +84,6 @@ phil_scope = parse(
       .type = str
       .help = "The log filename"
 
-    debug_log = 'dials.import.debug.log'
-      .type = str
-      .help = "The debug log filename"
-
     compact = False
       .type = bool
       .help = "For JSON output use compact representation"

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -215,15 +215,9 @@ phil_scope = parse(
   }
 
   output {
-
     log = dials.export.log
       .type = path
       .help = "The log filename"
-
-    debug_log = dials.export.debug.log
-      .type = path
-      .help = "The debug log filename"
-
   }
 """
 )
@@ -654,7 +648,7 @@ if __name__ == "__main__":
     params, options = parser.parse_args(show_diff_phil=False)
 
     # Configure the logging
-    log.config(info=params.output.log, debug=params.output.debug_log)
+    log.config(logfile=params.output.log)
 
     # Print the version number
     logger.info(dials_version())

--- a/command_line/find_hot_pixels.py
+++ b/command_line/find_hot_pixels.py
@@ -58,11 +58,7 @@ def run(args):
     params, options = parser.parse_args(show_diff_phil=False)
 
     # Configure the log
-    log.config(
-        verbosity=options.verbose,
-        info="dials.find_hot_pixels.log",
-        debug="dials.find_hot_pixels.debug.log",
-    )
+    log.config(verbosity=options.verbose, logfile="dials.find_hot_pixels.log")
 
     # Log the diff phil
     diff_phil = parser.diff_phil.as_str()

--- a/command_line/find_shared_models.py
+++ b/command_line/find_shared_models.py
@@ -26,10 +26,6 @@ phil_scope = parse(
     log = 'dials.find_shared_models.log'
       .type = str
       .help = "The log filename"
-
-    debug_log = 'dials.find_shared_models.debug.log'
-      .type = str
-      .help = "The debug log filename"
   }
 """,
     process_includes=True,
@@ -69,11 +65,7 @@ class Script(object):
         params, options = self.parser.parse_args(show_diff_phil=False)
 
         # Configure the logging
-        log.config(
-            verbosity=options.verbose,
-            info=params.output.log,
-            debug=params.output.debug_log,
-        )
+        log.config(verbosity=options.verbose, logfile=params.output.log)
 
         from dials.util.version import dials_version
 

--- a/command_line/find_spots.py
+++ b/command_line/find_spots.py
@@ -58,10 +58,6 @@ phil_scope = parse(
     log = 'dials.find_spots.log'
       .type = str
       .help = "The log filename"
-
-    debug_log = 'dials.find_spots.debug.log'
-      .type = str
-      .help = "The debug log filename"
   }
 
   per_image_statistics = False
@@ -111,11 +107,7 @@ class Script(object):
 
         if __name__ == "__main__":
             # Configure the logging
-            log.config(
-                verbosity=options.verbose,
-                info=params.output.log,
-                debug=params.output.debug_log,
-            )
+            log.config(verbosity=options.verbose, logfile=params.output.log)
 
         from dials.util.version import dials_version
 

--- a/command_line/generate_mask.py
+++ b/command_line/generate_mask.py
@@ -160,7 +160,7 @@ def run(phil=phil_scope, args=None):
     experiments = flatten_experiments(params.input.experiments)
 
     # Configure logging
-    dials.util.log.config(options.verbose, info=params.output.log)
+    dials.util.log.config(verbosity=options.verbose, logfile=params.output.log)
 
     # Check number of args
     if len(experiments) == 0:

--- a/command_line/import_stream.py
+++ b/command_line/import_stream.py
@@ -26,10 +26,6 @@ phil_scope = parse(
       .type = str
       .help = "The log filename"
 
-    debug_log = 'dials.import_stream.debug.log'
-      .type = str
-      .help = "The debug log filename"
-
     compact = False
       .type = bool
       .help = "For JSON output use compact representation"
@@ -87,11 +83,7 @@ class Script(object):
         params, options = self.parser.parse_args(show_diff_phil=False, quick_parse=True)
 
         # Configure logging
-        log.config(
-            verbosity=options.verbose,
-            info=params.output.log,
-            debug=params.output.debug_log,
-        )
+        log.config(verbosity=options.verbose, logfile=params.output.log)
         from dials.util.version import dials_version
 
         logger.info(dials_version())

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -52,10 +52,6 @@ phil_scope = parse(
       .type = str
       .help = "The log filename"
 
-    debug_log = 'dials.integrate.debug.log'
-      .type = str
-      .help = "The debug log filename"
-
     report = None
       .type = str
       .help = "The integration report filename (*.xml or *.json)"
@@ -172,11 +168,7 @@ class Script(object):
 
         if __name__ == "__main__":
             # Configure logging
-            log.config(
-                verbosity=options.verbose,
-                info=params.output.log,
-                debug=params.output.debug_log,
-            )
+            log.config(verbosity=options.verbose, logfile=params.output.log)
 
         from dials.util.version import dials_version
 

--- a/command_line/model_background.py
+++ b/command_line/model_background.py
@@ -24,10 +24,6 @@ phil_scope = parse(
       .type = str
       .help = "The log filename"
 
-    debug_log = 'dials.model_background.debug.log'
-      .type = str
-      .help = "The debug log filename"
-
     mean_image_prefix = 'mean'
       .type = str
       .help = "The mean background image"
@@ -311,11 +307,7 @@ class Script(object):
         params, options = self.parser.parse_args(show_diff_phil=False)
 
         # Configure the logging
-        log.config(
-            verbosity=options.verbose,
-            info=params.output.log,
-            debug=params.output.debug_log,
-        )
+        log.config(verbosity=options.verbose, logfile=params.output.log)
 
         from dials.util.version import dials_version
 

--- a/command_line/rl_png.py
+++ b/command_line/rl_png.py
@@ -152,7 +152,7 @@ def run():
         exit(0)
 
     # Configure the logging
-    log.config(info="dials.rl_png.log")
+    log.config(logfile="dials.rl_png.log")
 
     # Log the diff phil
     diff_phil = parser.diff_phil.as_str()

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -79,8 +79,6 @@ output {
     .type = path
   log = "dials.search_beam_position.log"
     .type = str
-  debug_log = "dials.search_beam_position.debug.log"
-    .type = str
 }
 """
 )
@@ -534,7 +532,7 @@ def run(args):
         exit(0)
 
     # Configure the logging
-    log.config(info=params.output.log, debug=params.output.debug_log)
+    log.config(logfile=params.output.log)
 
     # Log the diff phil
     diff_phil = parser.diff_phil.as_str()

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -10,6 +10,7 @@ import six.moves.cPickle as pickle
 from six.moves import StringIO
 
 import dials.util
+from dials.util import log
 from dials.array_family import flex
 from dxtbx.model.experiment_list import ExperimentListFactory
 from dxtbx.model.experiment_list import ExperimentList
@@ -294,7 +295,6 @@ class Script(object):
 
     def run(self):
         """Execute the script."""
-        from dials.util import log
         from libtbx import easy_mp
 
         # Parse the command line
@@ -324,11 +324,7 @@ class Script(object):
         st = time.time()
 
         # Configure logging
-        log.config(
-            verbosity=options.verbose,
-            info="dials.process.log",
-            debug="dials.process.debug.log",
-        )
+        log.config(verbosity=options.verbose, logfile="dials.process.log")
 
         bad_phils = [f for f in all_paths if os.path.splitext(f)[1] == ".phil"]
         if len(bad_phils) > 0:
@@ -518,8 +514,7 @@ class Script(object):
 
             # Configure the logging
             if params.output.logging_dir is None:
-                info_path = ""
-                debug_path = ""
+                logfile = None
             else:
                 log_path = os.path.join(
                     params.output.logging_dir, "log_rank%04d.out" % rank
@@ -533,16 +528,11 @@ class Script(object):
                 sys.stderr = open(error_path, "a", buffering=0)
                 print("Should be redirected now")
 
-                info_path = os.path.join(
+                logfile = os.path.join(
                     params.output.logging_dir, "info_rank%04d.out" % rank
                 )
-                debug_path = os.path.join(
-                    params.output.logging_dir, "debug_rank%04d.out" % rank
-                )
 
-            from dials.util import log
-
-            log.config(verbosity=options.verbose, info=info_path, debug=debug_path)
+            log.config(verbosity=options.verbose, logfile=logfile)
 
             if size <= 2:  # client/server only makes sense for n>2
                 subset = [

--- a/command_line/stills_process_mpi.py
+++ b/command_line/stills_process_mpi.py
@@ -80,7 +80,7 @@ class Script(base_script):
         all_paths = transmitted_info["a"]
 
         # Configure logging
-        log.config(verbosity=self.options.verbose, info=None, debug=None)
+        log.config(verbosity=self.options.verbose)
 
         for abs_params in self.params.integration.absorption_correction:
             if abs_params.apply:

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -55,8 +55,6 @@ partiality_threshold = 0.99
 output {
   log = dials.symmetry.log
     .type = str
-  debug_log = dials.symmetry.debug.log
-    .type = str
   experiments = "symmetrized.expt"
     .type = path
   reflections = "symmetrized.refl"
@@ -178,9 +176,7 @@ def run(args):
     )
 
     # Configure the logging
-    log.config(
-        verbosity=options.verbose, info=params.output.log, debug=params.output.debug_log
-    )
+    log.config(verbosity=options.verbose, logfile=params.output.log)
 
     from dials.util.version import dials_version
 

--- a/command_line/two_theta_refine.py
+++ b/command_line/two_theta_refine.py
@@ -46,9 +46,6 @@ phil_scope = parse(
     log = dials.two_theta_refine.log
       .type = str
 
-    debug_log = dials.two_theta_refine.debug.log
-      .type = str
-
     cif = None
       .type = str
       .help = "Write unit cell error information to a Crystallographic"
@@ -472,7 +469,7 @@ class Script(object):
         self.check_input(reflections)
 
         # Configure the logging
-        log.config(info=params.output.log, debug=params.output.debug_log)
+        log.config(logfile=params.output.log)
         logger.info(dials_version())
 
         # Log the diff phil

--- a/newsfragments/923.feature
+++ b/newsfragments/923.feature
@@ -1,0 +1,2 @@
+Unified logging output for dials programs - logs are no longer split into .log
+and .debug.log. Use -v to get debug output.


### PR DESCRIPTION
- remove debug= parameter passed to dials.util.log.config()
- info parameter is superseded by logfile