### PR TITLE
Multiscan

### DIFF
--- a/algorithms/refinement/parameterisation/configure.py
+++ b/algorithms/refinement/parameterisation/configure.py
@@ -107,6 +107,12 @@ phil_str = (
               "of the serialized model small. At the moment, this only has"
               "an effect for crystal unit cell (B matrix) errors."
 
+    allow_multiple_scans_per_crystal = False
+      .type = bool
+      .help = "If scan-varying refinement is done, allow multiple scans"
+              "per crystal.                                             "
+      .expert_level = 2
+
     debug_centroid_analysis = False
       .help = "Set True to write out a file containing the reflections used"
               "for centroid analysis for automatic setting of the  scan-varying"
@@ -488,7 +494,10 @@ def _parameterise_crystals(options, experiments, analysis):
                 )
             # If a crystal is scan-varying, then it must always be found alongside
             # the same Scan and Goniometer in any Experiments in which it appears
-            if not all(g is goniometer and s is scan for (g, s) in assoc_models):
+            if (
+                not all(g is goniometer and s is scan for (g, s) in assoc_models)
+                and not options.allow_multiple_scans_per_crystal
+            ):
                 raise DialsRefineConfigError(
                     "A single scan-varying crystal model cannot be refined "
                     "when associated with more than one scan or goniometer"

--- a/algorithms/refinement/parameterisation/configure.py
+++ b/algorithms/refinement/parameterisation/configure.py
@@ -494,9 +494,8 @@ def _parameterise_crystals(options, experiments, analysis):
                 )
             # If a crystal is scan-varying, then it must always be found alongside
             # the same Scan and Goniometer in any Experiments in which it appears
-            if (
-                not all(g is goniometer and s is scan for (g, s) in assoc_models)
-                and not options.allow_multiple_scans_per_crystal
+            if not options.allow_multiple_scans_per_crystal and not all(
+                g is goniometer and s is scan for (g, s) in assoc_models
             ):
                 raise DialsRefineConfigError(
                     "A single scan-varying crystal model cannot be refined "


### PR DESCRIPTION
I've added a new phil parameter to bypass one of the configuration sanity checks in dials.refine. The new parameter is called **allow_multiple_scans_per_crystal**. It is **boolean**, defaults to **False**, and has **expert_level = 2**. If True, dials.refine will allow a single scan-varying crystal and goniometer to be associated with multiple scans. 

The use case for this parameter is rotation series of still images wherein multiple images were acquired per angle. 