### PR TITLE
Calculate attenuation length per shoebox instead of per pixel

### DIFF
--- a/algorithms/profile_model/gaussian_rs/mask_calculator.h
+++ b/algorithms/profile_model/gaussian_rs/mask_calculator.h
@@ -41,9 +41,9 @@ namespace dials {
   using dxtbx::model::Goniometer;
   using dxtbx::model::Panel;
   using dxtbx::model::Scan;
+  using scitbx::af::int6;
   using scitbx::vec2;
   using scitbx::vec3;
-  using scitbx::af::int6;
 
   /**
    * Interface for bounding mask calculator.
@@ -361,11 +361,15 @@ namespace dials {
       // Mark those points within as Foreground and those without as
       // Background.
 
+      vec2<double> shoebox_centroid_px = panel.get_ray_intersection_px(s1);
+      double attenuation_length = panel.attenuation_length(shoebox_centroid_px);
+
       af::versa<double, af::c_grid<2> > dxy_array(af::c_grid<2>(ysize + 1, xsize + 1));
       for (int j = 0; j <= ysize; ++j) {
         for (int i = 0; i <= xsize; ++i) {
           vec2<double> gxy = cs.from_beam_vector(
-            panel.get_pixel_lab_coord(vec2<double>(x0 + i, y0 + j)).normalize()
+            panel.get_pixel_lab_coord(vec2<double>(x0 + i, y0 + j), attenuation_length)
+              .normalize()
             * s0_length);
           dxy_array(j, i) = (gxy[0] * gxy[0] + gxy[1] * gxy[1]) * delta_b_r2;
         }

--- a/algorithms/profile_model/gaussian_rs/transform/transform.h
+++ b/algorithms/profile_model/gaussian_rs/transform/transform.h
@@ -30,10 +30,10 @@ namespace dials {
       namespace gaussian_rs {
   namespace transform {
 
-    using dials::algorithms::polygon::simple_area;
     using dials::algorithms::polygon::clip::quad_with_convex_quad;
     using dials::algorithms::polygon::clip::vert4;
     using dials::algorithms::polygon::clip::vert8;
+    using dials::algorithms::polygon::simple_area;
     using dials::algorithms::polygon::spatial_interpolation::Match;
     using dials::algorithms::polygon::spatial_interpolation::quad_to_grid;
     using dials::algorithms::polygon::spatial_interpolation::
@@ -45,12 +45,12 @@ namespace dials {
     using dxtbx::model::Detector;
     using dxtbx::model::Goniometer;
     using dxtbx::model::Scan;
-    using scitbx::vec2;
-    using scitbx::vec3;
     using scitbx::af::double3;
     using scitbx::af::int2;
     using scitbx::af::int3;
     using scitbx::af::int6;
+    using scitbx::vec2;
+    using scitbx::vec3;
 
     template <typename T>
     T min4(T a, T b, T c, T d) {
@@ -383,6 +383,14 @@ namespace dials {
           }
         }
 
+        af::versa<vec2<double>, af::c_grid<2> > gc_array(
+          af::c_grid<2>(shoebox_size_[1] + 1, shoebox_size_[2] + 1));
+        for (int j = 0; j <= shoebox_size_[1]; ++j) {
+          for (int i = 0; i <= shoebox_size_[2]; ++i) {
+            gc_array(j, i) = gc(panel, j, i);
+          }
+        }
+
         // Loop through all the points in the shoebox. Calculate the polygon
         // formed by the pixel in the local coordinate system. Find the points
         // on the grid which intersect with the polygon and the fraction of the
@@ -392,10 +400,10 @@ namespace dials {
         af::c_grid<2> grid_size2(grid_size_[1], grid_size_[2]);
         for (std::size_t j = 0; j < shoebox_size_[1]; ++j) {
           for (std::size_t i = 0; i < shoebox_size_[2]; ++i) {
-            vert4 input(gc(panel, j, i),
-                        gc(panel, j, i + 1),
-                        gc(panel, j + 1, i + 1),
-                        gc(panel, j + 1, i));
+            vert4 input(gc_array(j, i),
+                        gc_array(j, i + 1),
+                        gc_array(j + 1, i + 1),
+                        gc_array(j + 1, i));
             af::shared<Match> matches = quad_to_grid(input, grid_size2, 0);
             for (int m = 0; m < matches.size(); ++m) {
               FloatType fraction = matches[m].fraction;

--- a/algorithms/profile_model/gaussian_rs/transform/transform.h
+++ b/algorithms/profile_model/gaussian_rs/transform/transform.h
@@ -383,11 +383,14 @@ namespace dials {
           }
         }
 
+        vec2<double> shoebox_centroid_px = panel.get_ray_intersection_px(s1_);
+        double attenuation_length = panel.attenuation_length(shoebox_centroid_px);
+
         af::versa<vec2<double>, af::c_grid<2> > gc_array(
           af::c_grid<2>(shoebox_size_[1] + 1, shoebox_size_[2] + 1));
         for (int j = 0; j <= shoebox_size_[1]; ++j) {
           for (int i = 0; i <= shoebox_size_[2]; ++i) {
-            gc_array(j, i) = gc(panel, j, i);
+            gc_array(j, i) = gc(panel, j, i, attenuation_length);
           }
         }
 
@@ -434,6 +437,17 @@ namespace dials {
        */
       vec2<double> gc(const Panel &panel, std::size_t j, std::size_t i) const {
         vec3<double> sp = panel.get_pixel_lab_coord(vec2<double>(x0_ + i, y0_ + j));
+        vec3<double> ds = sp.normalize() * s1_.length() - s1_;
+        return vec2<double>(grid_cent_[2] + (e1_ * ds) / step_size_[2],
+                            grid_cent_[1] + (e2_ * ds) / step_size_[1]);
+      }
+
+      vec2<double> gc(const Panel &panel,
+                      std::size_t j,
+                      std::size_t i,
+                      double attenuation_length) const {
+        vec3<double> sp =
+          panel.get_pixel_lab_coord(vec2<double>(x0_ + i, y0_ + j), attenuation_length);
         vec3<double> ds = sp.normalize() * s1_.length() - s1_;
         return vec2<double>(grid_cent_[2] + (e1_ * ds) / step_size_[2],
                             grid_cent_[1] + (e2_ * ds) / step_size_[1]);


### PR DESCRIPTION
Corresponding changes in DIALS for https://github.com/cctbx/dxtbx/pull/94