### PR TITLE
Simplify usage of flex.reflection_table methods.

### DIFF
--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -395,9 +395,7 @@ class StillsIndexer(Indexer):
             ):
                 # Experimental geometry may have changed - re-map centroids to
                 # reciprocal space
-                self.reflections = self.map_centroids_to_reciprocal_space(
-                    self.experiments, self.reflections
-                )
+                self.reflections.map_centroids_to_reciprocal_space(self.experiments)
 
             # update for next cycle
             experiments = refined_experiments

--- a/algorithms/indexing/test_assign_indices.py
+++ b/algorithms/indexing/test_assign_indices.py
@@ -119,7 +119,7 @@ def test_assign_indices(space_group_symbol, experiment, crystal_factory):
     predicted_reflections["xyzobs.mm.value"] = predicted_reflections["xyzcal.mm"]
     predicted_reflections["id"] = flex.int(len(predicted_reflections), 0)
     predicted_reflections.map_centroids_to_reciprocal_space(
-        experiment.detector, experiment.beam, experiment.goniometer
+        ExperimentList([experiment])
     )
 
     # check that local and global indexing worked equally well in absence of errors
@@ -234,12 +234,8 @@ def test_index_reflections(dials_regression):
             dials_regression, "indexing_test_data", "i04_weak_data", "full.pickle"
         )
     )
-    reflections.centroid_px_to_mm(experiments[0].detector, scan=experiments[0].scan)
-    reflections.map_centroids_to_reciprocal_space(
-        experiments[0].detector,
-        experiments[0].beam,
-        goniometer=experiments[0].goniometer,
-    )
+    reflections.centroid_px_to_mm(experiments)
+    reflections.map_centroids_to_reciprocal_space(experiments)
     reflections["imageset_id"] = flex.int(len(reflections), 0)
     reflections["id"] = flex.int(len(reflections), -1)
     with pytest.deprecated_call():

--- a/algorithms/indexing/test_model_evaluation.py
+++ b/algorithms/indexing/test_model_evaluation.py
@@ -207,14 +207,8 @@ def test_ModelEvaluation(dials_regression, tmpdir):
     input_reflections = input_reflections.select(
         input_reflections["xyzobs.px.value"].parts()[2] < 100
     )
-    input_reflections.centroid_px_to_mm(
-        input_experiments[0].detector, scan=input_experiments[0].scan
-    )
-    input_reflections.map_centroids_to_reciprocal_space(
-        input_experiments[0].detector,
-        input_experiments[0].beam,
-        goniometer=input_experiments[0].goniometer,
-    )
+    input_reflections.centroid_px_to_mm(input_experiments)
+    input_reflections.map_centroids_to_reciprocal_space(input_experiments)
     input_reflections["imageset_id"] = flex.size_t(input_reflections.size(), 0)
     input_reflections["id"] = flex.int(input_reflections.size(), -1)
 

--- a/command_line/augment_spots.py
+++ b/command_line/augment_spots.py
@@ -50,22 +50,12 @@ def add_resolution_to_reflections(reflections, experiments):
     # will assume everything from the first detector at the moment - clearly this
     # could be incorrect, will have to do something a little smarter, later
 
-    imageset = experiments.imagesets()[0]
-
     if "imageset_id" not in reflections:
         reflections["imageset_id"] = reflections["id"]
 
-    reflections.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
-
-    reflections.map_centroids_to_reciprocal_space(
-        detector=imageset.get_detector(),
-        beam=imageset.get_beam(),
-        goniometer=imageset.get_goniometer(),
-    )
-
-    d_spacings = 1 / reflections["rlp"].norms()
-
-    reflections["d"] = d_spacings
+    reflections.centroid_px_to_mm(experiments)
+    reflections.map_centroids_to_reciprocal_space(experiments)
+    reflections["d"] = 1 / reflections["rlp"].norms()
 
 
 def augment_reflections(reflections, params, experiments=None):

--- a/command_line/filter_reflections.py
+++ b/command_line/filter_reflections.py
@@ -13,7 +13,6 @@ from dials.util.filter_reflections import SumAndPrfIntensityReducer, SumIntensit
 from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
 from dials.array_family import flex
 from dials.algorithms.integration import filtering
-from dials.algorithms.spot_finding.per_image_analysis import map_to_reciprocal_space
 from libtbx.phil import parse
 from libtbx.table_utils import simple_table
 
@@ -316,9 +315,7 @@ def run_filtering(params, experiments, reflections):
             d_spacings = reflections["d"]
         else:
             if "rlp" not in reflections:
-                imageset = experiments.imagesets()[0]
-                assert imageset is not None
-                reflections = map_to_reciprocal_space(reflections, imageset)
+                reflections.map_centroids_to_reciprocal_space(experiments)
             d_star_sq = flex.pow2(reflections["rlp"].norms())
             d_spacings = uctbx.d_star_sq_as_d(d_star_sq)
 

--- a/command_line/reindex.py
+++ b/command_line/reindex.py
@@ -258,26 +258,15 @@ experiments file must also be specified with the option: reference= """
             assert len(reflections) == 1
 
             # always re-map reflections to reciprocal space
-            refl_copy = flex.reflection_table()
-            for i, imageset in enumerate(experiments.imagesets()):
-                if "imageset_id" in reflections[0]:
-                    sel = reflections[0]["imageset_id"] == i
-                else:
-                    sel = reflections[0]["id"] == i
-                refl = reflections[0].select(sel)
-                refl.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
-                refl.map_centroids_to_reciprocal_space(
-                    imageset.get_detector(),
-                    imageset.get_beam(),
-                    imageset.get_goniometer(),
-                )
-                refl_copy.extend(refl)
+            refl = reflections.deep_copy()
+            refl.centroid_px_to_mm(experiments)
+            refl.map_centroids_to_reciprocal_space(experiments)
 
             # index the reflection list using the input experiments list
-            refl_copy["id"] = flex.int(len(refl_copy), -1)
+            refl["id"] = flex.int(len(refl), -1)
             index = AssignIndicesGlobal(tolerance=0.2)
-            index(refl_copy, experiments)
-            hkl_expt = refl_copy["miller_index"]
+            index(refl, experiments)
+            hkl_expt = refl["miller_index"]
             hkl_input = reflections[0]["miller_index"]
 
             change_of_basis_op = derive_change_of_basis_op(hkl_input, hkl_expt)

--- a/command_line/rl_png.py
+++ b/command_line/rl_png.py
@@ -162,14 +162,11 @@ def run():
 
     reflections = reflections[0]
 
-    imagesets = experiments.imagesets()
-
     f = ReciprocalLatticePng(settings=params)
     f.load_models(experiments, reflections)
 
-    imageset = imagesets[0]
-    rotation_axis = matrix.col(imageset.get_goniometer().get_rotation_axis())
-    s0 = matrix.col(imageset.get_beam().get_s0())
+    rotation_axis = matrix.col(experiments[0].goniometer.get_rotation_axis())
+    s0 = matrix.col(experiments[0].beam.get_s0())
 
     e1 = rotation_axis.normalize()
     e2 = s0.normalize()
@@ -207,13 +204,9 @@ def run():
         if "imageset_id" not in reflections:
             reflections["imageset_id"] = reflections["id"]
 
-        reflections.centroid_px_to_mm(imageset.get_detector(), scan=imageset.get_scan())
+        reflections.centroid_px_to_mm(experiments)
 
-        reflections.map_centroids_to_reciprocal_space(
-            detector=imageset.get_detector(),
-            beam=imageset.get_beam(),
-            goniometer=imageset.get_goniometer(),
-        )
+        reflections.map_centroids_to_reciprocal_space(experiments)
 
         if params.d_min is not None:
             d_spacings = 1 / reflections["rlp"].norms()
@@ -228,7 +221,9 @@ def run():
             reflections, max_cell_multiplier=1.3, step_size=45
         ).max_cell
 
-        result = run_dps((imageset, reflections, max_cell, hardcoded_phil))
+        result = run_dps(
+            (experiments[0].imageset, reflections, max_cell, hardcoded_phil)
+        )
         solutions = [matrix.col(v) for v in result["solutions"]]
         for i in range(min(n_solutions, len(solutions))):
             v = solutions[i]

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -20,6 +20,7 @@ import iotbx.phil
 from rstbx.indexing_api import dps_extended
 from rstbx.indexing_api.lattice import DPS_primitive_lattice
 from rstbx.dps_core import Direction, Directional_FFT
+from dxtbx.model import Experiment, ExperimentList
 
 from dials.algorithms.indexing.indexer import find_max_cell
 from dials.util import log
@@ -288,7 +289,15 @@ class better_experimental_model_discovery(object):
         gonio = copy.deepcopy(imageset.get_goniometer())
         gonio.set_fixed_rotation((1, 0, 0, 0, 1, 0, 0, 0, 1))
         spots_mm.map_centroids_to_reciprocal_space(
-            trial_detector, imageset.get_beam(), gonio
+            ExperimentList(
+                [
+                    Experiment(
+                        beam=imageset.get_beam(),
+                        detector=trial_detector,
+                        goniometer=gonio,
+                    )
+                ]
+            )
         )
 
         return self.sum_score_detail(spots_mm["rlp"], solutions, amax=amax)
@@ -409,17 +418,20 @@ def discover_better_experimental_model(
         raise Sorry("input beam does not intersect detector")
 
     for imageset, spots in zip(imagesets, spot_lists):
-        if "imageset_id" not in spots:
-            spots["imageset_id"] = spots["id"]
-
         spots_mm = copy.deepcopy(spots)
-        spots_mm.centroid_px_to_mm(imageset.get_detector(), scan=imageset.get_scan())
-
-        spots_mm.map_centroids_to_reciprocal_space(
-            detector=imageset.get_detector(),
-            beam=imageset.get_beam(),
-            goniometer=imageset.get_goniometer(),
+        spots_mm["imageset_id"] = flex.int(len(spots), 0)
+        expts = ExperimentList(
+            [
+                Experiment(
+                    detector=imageset.get_detector(),
+                    beam=imageset.get_beam(),
+                    goniometer=imageset.get_goniometer(),
+                    scan=imageset.get_scan(),
+                )
+            ]
         )
+        spots_mm.centroid_px_to_mm(expts)
+        spots_mm.map_centroids_to_reciprocal_space(expts)
 
         if dps_params.d_min is not None:
             d_spacings = 1 / spots_mm["rlp"].norms()

--- a/command_line/spot_resolution_shells.py
+++ b/command_line/spot_resolution_shells.py
@@ -23,24 +23,11 @@ def settings():
     return phil_scope.fetch().extract()
 
 
-def spot_resolution_shells(imagesets, reflections, params):
+def spot_resolution_shells(experiments, reflections, params):
     from dials.array_family import flex
 
-    mapped_reflections = flex.reflection_table()
-    for i, imageset in enumerate(imagesets):
-        if "imageset_id" in reflections:
-            sel = reflections["imageset_id"] == i
-        else:
-            sel = reflections["id"] == i
-        if isinstance(reflections["id"], flex.size_t):
-            reflections["id"] = reflections["id"].as_int()
-        refl = reflections.select(sel)
-        refl.centroid_px_to_mm(imageset.get_detector(), imageset.get_scan())
-        refl.map_centroids_to_reciprocal_space(
-            imageset.get_detector(), imageset.get_beam(), imageset.get_goniometer()
-        )
-        mapped_reflections.extend(refl)
-    reflections = mapped_reflections
+    reflections.centroid_px_to_mm(experiments)
+    reflections.map_centroids_to_reciprocal_space(experiments)
     two_theta_array = reflections["rlp"].norms()
     h0 = flex.weighted_histogram(two_theta_array ** 2, n_slots=params.shells)
     n = h0.slots()
@@ -76,9 +63,7 @@ def run(args):
 
     reflections = reflections[0]
 
-    imagesets = experiments.imagesets()
-
-    spot_resolution_shells(imagesets, reflections, params)
+    spot_resolution_shells(experiments, reflections, params)
 
 
 if __name__ == "__main__":

--- a/test/array_family/test_reflection_table.py
+++ b/test/array_family/test_reflection_table.py
@@ -1355,20 +1355,15 @@ def test_as_miller_array():
 def test_map_centroids_to_reciprocal_space(dials_regression):
     data_dir = os.path.join(dials_regression, "indexing_test_data", "i04_weak_data")
     pickle_path = os.path.join(data_dir, "full.pickle")
-    sweep_path = os.path.join(data_dir, "datablock_orig.json")
+    expts_path = os.path.join(data_dir, "experiments_import.json")
 
     refl = flex.reflection_table.from_file(pickle_path)
-    datablock = load.datablock(sweep_path, check_format=False)[0]
-    imageset = datablock.extract_imagesets()[0]
-    detector = imageset.get_detector()
-    scan = imageset.get_scan()
-    beam = imageset.get_beam()
-    goniometer = imageset.get_goniometer()
+    expts = load.experiment_list(expts_path, check_format=False)
 
     # check mm values not in
     assert "xyzobs.mm.value" not in refl
 
-    refl.centroid_px_to_mm(detector, scan=scan)
+    refl.centroid_px_to_mm(expts)
 
     for k in ("xyzobs.mm.value", "xyzobs.mm.variance"):
         assert k in refl
@@ -1380,7 +1375,7 @@ def test_map_centroids_to_reciprocal_space(dials_regression):
         (0.0035346345381526106, 0.0029881028112449803, 5.711576621000785e-07)
     )
 
-    refl.map_centroids_to_reciprocal_space(detector, beam, goniometer=goniometer)
+    refl.map_centroids_to_reciprocal_space(expts)
 
     for k in ("s1", "rlp"):
         assert k in refl
@@ -1398,8 +1393,10 @@ def test_map_centroids_to_reciprocal_space(dials_regression):
     del refl1["xyzobs.mm.value"], refl1["xyzobs.mm.variance"], refl1["s1"], refl1["rlp"]
 
     # pretend this is a still and hence no scan or goniometer
-    refl1.centroid_px_to_mm(detector, scan=None)
-    refl1.map_centroids_to_reciprocal_space(detector, beam, goniometer=None)
+    expts[0].goniometer = None
+    expts[0].scan = None
+    refl1.centroid_px_to_mm(expts)
+    refl1.map_centroids_to_reciprocal_space(expts)
 
     assert refl1["s1"][0] == pytest.approx(
         (-0.035321308540942425, 0.6030297672949761, -0.8272574664632307)
@@ -1419,14 +1416,9 @@ def test_calculate_entering_flags(dials_regression):
 
     refl = flex.reflection_table.from_pickle(pickle_path)
     experiments = load.experiment_list(experiments_path, check_format=False)
-    experiment = experiments[0]
-    detector = experiment.detector
-    scan = experiment.scan
-    beam = experiment.beam
-    goniometer = experiment.goniometer
 
-    refl.centroid_px_to_mm(detector, scan=scan)
-    refl.map_centroids_to_reciprocal_space(detector, beam, goniometer=goniometer)
+    refl.centroid_px_to_mm(experiments)
+    refl.map_centroids_to_reciprocal_space(experiments)
     refl.calculate_entering_flags(experiments)
     assert "entering" in refl
     flags = refl["entering"]

--- a/util/export_json.py
+++ b/util/export_json.py
@@ -2,15 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 import json
 
-from dials.algorithms.indexing.indexer import Indexer
-
 
 class ReciprocalLatticeJson(object):
     def __init__(self, experiments, reflections):
         self.experiments = experiments
-        self.reflections = Indexer.map_centroids_to_reciprocal_space(
-            experiments, reflections
-        )
+        self.reflections = reflections
+        self.reflections.centroid_px_to_mm(experiments)
+        self.reflections.map_centroids_to_reciprocal_space(experiments)
 
     def as_dict(self, n_digits=None):
         rlp = self.reflections["rlp"]

--- a/util/reciprocal_lattice/test_render_3d.py
+++ b/util/reciprocal_lattice/test_render_3d.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import random
 
-import pytest
 import six
 from dials.array_family import flex
 from dials.util.reciprocal_lattice import Render3d
@@ -64,12 +63,7 @@ def test_Render3d(mocker, multi_sweep_data):
     render.settings.reverse_phi = True
     mocker.spy(flex.reflection_table, "map_centroids_to_reciprocal_space")
     render.load_models(experiments, reflections)
-    assert flex.reflection_table.map_centroids_to_reciprocal_space.call_count == len(
-        experiments
-    )
-    assert flex.reflection_table.map_centroids_to_reciprocal_space.call_args[0][
-        3
-    ].get_rotation_axis() == pytest.approx((-1.0, 0.0, 0.0))
+    assert flex.reflection_table.map_centroids_to_reciprocal_space.call_count == 1
 
 
 def test_Render3d_integrated(mocker, centroid_test_data):


### PR DESCRIPTION
`flex.reflection_table.centroid_px_to_mm()` and `flex.reflection_table.map_centroids_to_reciprocal_space()` now take an `ExperimentList` as input instead of individual dxtbx models, which simplifies usage, removing the need to iterate over experiments/imagesets everywhere the methods are used.