### PR TITLE
Fix change of basis operation in dials.symmetry

### DIFF
--- a/algorithms/symmetry/cosym/_generate_test_data.py
+++ b/algorithms/symmetry/cosym/_generate_test_data.py
@@ -20,6 +20,7 @@ def generate_experiments_reflections(
     sample_size=100,
     map_to_p1=False,
     twin_fractions=None,
+    map_to_minimum=True,
 ):
     datasets, reindexing_ops = generate_test_data(
         space_group,
@@ -32,6 +33,7 @@ def generate_experiments_reflections(
         sample_size=sample_size,
         map_to_p1=map_to_p1,
         twin_fractions=twin_fractions,
+        map_to_minimum=map_to_minimum,
     )
 
     expts = ExperimentList()
@@ -67,6 +69,7 @@ def generate_test_data(
     sample_size=100,
     map_to_p1=False,
     twin_fractions=None,
+    map_to_minimum=True,
 ):
 
     import random
@@ -90,7 +93,8 @@ def generate_test_data(
     else:
         cs = sgi.any_compatible_crystal_symmetry(volume=unit_cell_volume)
 
-    cs = cs.minimum_cell()
+    if map_to_minimum:
+        cs = cs.minimum_cell()
     intensities = generate_intensities(cs, d_min=d_min)
     intensities.show_summary()
 

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -107,19 +107,19 @@ input data and filtering settings e.g partiality_threshold"""
 
         reindexed_experiments = copy.deepcopy(experiments)
         reindexed_reflections = flex.reflection_table()
-        cb_op_inp_best = (
-            result.best_solution.subgroup["cb_op_inp_best"] * result.cb_op_inp_min
-        )
+        # Change of basis operator from input unit cell to best unit cell
+        cb_op_inp_best = result.best_solution.subgroup["cb_op_inp_best"]
+        # Get the best space group.
         best_subsym = result.best_solution.subgroup["best_subsym"]
+        best_space_group = best_subsym.space_group().build_derived_acentric_group()
         for i, expt in enumerate(reindexed_experiments):
-            expt.crystal = expt.crystal.change_basis(result.cb_op_inp_min)
+            # Set the space group to the best symmetry and change basis accordingly.
+            # Setting the basis to one incompatible with the initial space group is
+            # forbidden, so we must first change the space group to P1 to be safe`.
             expt.crystal.set_space_group(sgtbx.space_group("P 1"))
-            expt.crystal = expt.crystal.change_basis(
-                result.best_solution.subgroup["cb_op_inp_best"]
-            )
-            expt.crystal.set_space_group(
-                best_subsym.space_group().build_derived_acentric_group()
-            )
+            expt.crystal = expt.crystal.change_basis(cb_op_inp_best)
+            expt.crystal.set_space_group(best_space_group)
+
             S = parameter_reduction.symmetrize_reduce_enlarge(
                 expt.crystal.get_space_group()
             )

--- a/test/command_line/test_symmetry.py
+++ b/test/command_line/test_symmetry.py
@@ -3,6 +3,10 @@ from __future__ import absolute_import, division, print_function
 import os
 
 import procrunner
+import pytest
+from cctbx import sgtbx
+
+from dials.array_family import flex
 
 
 def test_symmetry(dials_regression, tmpdir):
@@ -21,3 +25,44 @@ def test_symmetry(dials_regression, tmpdir):
     assert not result.returncode and not result.stderr
     assert tmpdir.join("symmetrized.refl").check()
     assert tmpdir.join("symmetrized.expt").check()
+
+
+from dials.algorithms.symmetry.cosym._generate_test_data import (
+    generate_experiments_reflections,
+)
+
+
+def test_symmetry_R3m_I2m(tmpdir):
+    os.chdir(tmpdir.strpath)
+    space_group = "C 2"
+    unit_cell = (53.173, 61.245, 69.292, 90.0, 93.04675, 90.0)
+    space_group = sgtbx.space_group_info(space_group).group()
+    experiments, reflections, _ = generate_experiments_reflections(
+        space_group=space_group,
+        unit_cell=unit_cell,
+        sample_size=1,
+        map_to_minimum=False,
+    )
+    experiments.as_json("tmp.expt")
+    expt_file = tmpdir.join("tmp.expt").strpath
+    joint_table = flex.reflection_table()
+    for r in reflections:
+        joint_table.extend(r)
+    joint_table.as_pickle("tmp.refl")
+    refl_file = tmpdir.join("tmp.refl").strpath
+
+    # okay so generated in C 1 m 1, but lattice looks like R-3m, s*o reindex
+    # to this first
+
+    command = ["dials.symmetry", expt_file, refl_file]
+    result = procrunner.run(command, working_directory=tmpdir.strpath)
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("symmetrized.refl").check(file=1)
+    assert tmpdir.join("symmetrized.expt").check(file=1)
+    from dxtbx.serialize import load
+
+    expts = load.experiment_list(
+        tmpdir.join("symmetrized.expt").strpath, check_format=False
+    )
+    for v, expected in zip(expts[0].crystal.get_unit_cell().parameters(), unit_cell):
+        assert v == pytest.approx(expected)


### PR DESCRIPTION
After correctly determining the best space group and unit cell parameters, `dials.symmetry` sometimes then writes incorrect ones to the output experiment list file.

I think that for historical reasons, the change-of-basis operation from the input unit cell to the best solution unit cell was previously of the form
(minimum ↦ best) ∘ (input ↦ minimum)
(where minimum ≡ primitive perhaps?), though (minimum ↦ best) was misleadingly labeled `cb_op_inp_best`, more suggestive of the form (input ↦ best).

Now that `cb_op_inp_best` really is (input ↦ best), the change-of-basis operation is incorrect and needs tidying up.  In its current form, it results in an incompatibility between the final space group and an erroneous unit cell for some combinations of input and best symmetries.  This goes undetected because, before saving to the experiment list file, the unit cell is always automatically 'corrected' to an average of the set of unit cells generated by application of each of the symmetry operations in the space group to the specified (potentially erroneous) unit cell.  Equivalently, the unit cell is forced to abide by the symmetry of a space group that is correct except that has a different basis to the cell.

The symptom of this is that the correctly reported unit cell in the `dials.symmetry` log file may be at odds with an incorrect-symmetry-averaged unit cell stored in the experiment list file.  For example, a monoclinic cell with space group P2/m (which, in the conventional setting P 1 2/m 1, would have β ≠ 90°) is assigned the correct space group in the conventional setting (P 1 2/m 1) but a unit cell consistent with the unconventional setting (P 1 1 2/m, with γ ≠ 90°), due to the incorrect change-of-basis operation.  Before saving to the experiment list, the unit cell is then forcibly made consistent by applying the correct space group symmetry to the incorrect unit cell and taking an average.  This results in a unit cell that is consistent with the space group symmetry (γ becomes 90° and b & c are altered accordingly), but is clearly not correct.

This slipped through the net because the `dials.symmetry` tests are very basic and the only tested system happens to be one in which (input ↦ minimum) = 𝟙, so the problem does not manifest.  Also, this problem took a long time to debug because the sparseness of docstrings and comments in `sgtbx` (which we cannot help) is matched here in this corner of DIALS.

In addition to patching the dodgy change-of-basis operator in `dials.command_line.symmetry`, I propose that @jbeilstenedmands, @rjgildea and I
  - add some proper tests and
  - add some decent inline developer documentation to make sense, for newcomers and oldcomers alike, of what the code is trying to represent.

Being something of a bumbling idiot in this area, I could do with a little guidance as to what's needed in terms of tests and what the code is actually trying to do.