### PR TITLE
Remove unused variables from GModelBackgroundCreator

### DIFF
--- a/algorithms/background/gmodel/algorithm.py
+++ b/algorithms/background/gmodel/algorithm.py
@@ -82,9 +82,7 @@ class GModelBackgroundCalculatorFactory(object):
     """ Class to do background subtraction. """
 
     @staticmethod
-    def create(
-        experiments, model=None, robust=False, tuning_constant=1.345, min_pixels=10
-    ):
+    def create(experiments, model=None, robust=False, min_pixels=10):
         """
         Initialise the algorithm.
 
@@ -102,9 +100,5 @@ class GModelBackgroundCalculatorFactory(object):
 
         # Create the background creator
         return GModelBackgroundCalculator(
-            model=model,
-            robust=robust,
-            tuning_constant=tuning_constant,
-            max_iter=100,
-            min_pixels=min_pixels,
+            model=model, robust=robust, min_pixels=min_pixels
         )

--- a/algorithms/background/gmodel/algorithm.py
+++ b/algorithms/background/gmodel/algorithm.py
@@ -58,13 +58,7 @@ class BackgroundAlgorithm(object):
         model = global_model_cache.get(model)
 
         # Create the background creator
-        self._create = Creator(
-            model=model,
-            robust=robust,
-            tuning_constant=tuning_constant,
-            max_iter=100,
-            min_pixels=min_pixels,
-        )
+        self._create = Creator(model=model, robust=robust, min_pixels=min_pixels)
 
     def compute_background(self, reflections, image_volume=None):
         """

--- a/algorithms/background/gmodel/boost_python/ext.cc
+++ b/algorithms/background/gmodel/boost_python/ext.cc
@@ -65,12 +65,8 @@ namespace dials { namespace algorithms { namespace background { namespace boost_
     creator
       .def(init<boost::shared_ptr<BackgroundModel>,
                 bool,
-                double,
-                std::size_t,
                 std::size_t>((arg("model"),
                               arg("robust"),
-                              arg("tuning_constant"),
-                              arg("max_iter"),
                               arg("min_pixels") = 10)))
       .def("__call__", &GModelBackgroundCreator::shoebox)
       .def("__call__", &GModelBackgroundCreator::volume);

--- a/algorithms/background/gmodel/creator.h
+++ b/algorithms/background/gmodel/creator.h
@@ -34,22 +34,14 @@ namespace dials { namespace algorithms {
   public:
     /**
      * Initialise the creator
-     * @param tuning_constant The robust tuning constant
-     * @param max_iter The maximum number of iterations
      * @param min_pixels The minimum number of pixels needed
      */
     GModelBackgroundCreator(boost::shared_ptr<BackgroundModel> model,
                             bool robust,
-                            double tuning_constant,
-                            std::size_t max_iter,
                             std::size_t min_pixels)
         : model_(model),
           robust_(robust),
-          tuning_constant_(tuning_constant),
-          max_iter_(max_iter),
           min_pixels_(min_pixels) {
-      DIALS_ASSERT(tuning_constant > 0);
-      DIALS_ASSERT(max_iter > 0);
       DIALS_ASSERT(min_pixels > 0);
     }
 
@@ -293,8 +285,6 @@ namespace dials { namespace algorithms {
 
     boost::shared_ptr<BackgroundModel> model_;
     bool robust_;
-    double tuning_constant_;
-    std::size_t max_iter_;
     std::size_t min_pixels_;
   };
 

--- a/algorithms/integration/algorithms.h
+++ b/algorithms/integration/algorithms.h
@@ -200,14 +200,10 @@ namespace dials { namespace algorithms {
      * Init the algorithms
      * @param model The model to use
      * @param robust Do robust estimation
-     * @param tuning_constant The robust tuning constant
-     * @param max_iter The maximum number of iterations
      * @param min_pixels The minimum number of pixels
      */
     GModelBackgroundCalculator(boost::shared_ptr<BackgroundModel> model,
                                bool robust,
-                               double tuning_constant,
-                               std::size_t max_iter,
                                std::size_t min_pixels)
         : creator_(model, robust, min_pixels) {}
 

--- a/algorithms/integration/algorithms.h
+++ b/algorithms/integration/algorithms.h
@@ -209,7 +209,7 @@ namespace dials { namespace algorithms {
                                double tuning_constant,
                                std::size_t max_iter,
                                std::size_t min_pixels)
-        : creator_(model, robust, tuning_constant, max_iter, min_pixels) {}
+        : creator_(model, robust, min_pixels) {}
 
     ~GModelBackgroundCalculator() {}
 

--- a/algorithms/integration/boost_python/parallel_integrator_ext.cc
+++ b/algorithms/integration/boost_python/parallel_integrator_ext.cc
@@ -302,12 +302,8 @@ namespace dials { namespace algorithms { namespace boost_python {
       "GModelBackgroundCalculator", no_init)
       .def(init<boost::shared_ptr<BackgroundModel>,
                 bool,
-                double,
-                std::size_t,
                 std::size_t>((arg("model"),
                               arg("robust"),
-                              arg("tuning_constant"),
-                              arg("max_iter"),
                               arg("min_pixels"))));
 
     // Export the reference data structure

--- a/algorithms/integration/parallel_integrator.py
+++ b/algorithms/integration/parallel_integrator.py
@@ -177,7 +177,6 @@ class BackgroundCalculatorFactory(object):
                 experiments,
                 model=params.model,
                 robust=params.robust.algorithm,
-                tuning_constant=params.robust.tuning_constant,
                 min_pixels=params.min_pixels,
             )
 

--- a/algorithms/refinement/refiner.py
+++ b/algorithms/refinement/refiner.py
@@ -211,7 +211,7 @@ class RefinerFactory(object):
             elif exp.scan.get_num_images() == 1:
                 if single_as_still:
                     exps_are_stills.append(True)
-                elif exp.scan.get_oscillation()[1] == 0.0:
+                elif exp.scan.is_still():
                     exps_are_stills.append(True)
                 else:
                     exps_are_stills.append(False)


### PR DESCRIPTION
Remove `tuning_constant` and `max_iter` from `GModelBackgroundCreator`. Then remove the same from `GModelBackgroundCalculatorFactory`.