### PR TITLE
Putative fix for dials.generate_mask trusted_range bug (#978)

### DIFF
--- a/newsfragments/978.bugfix
+++ b/newsfragments/978.bugfix
@@ -1,0 +1,2 @@
+Ensure that generated masks do not include pixels that are overloaded on a few
+images, but only pixels that are always outside the trusted range.

--- a/test/command_line/test_generate_mask.py
+++ b/test/command_line/test_generate_mask.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 import six.moves.cPickle as pickle
-import procrunner
 import pytest
 
-from dials.command_line.generate_mask import generate_mask, phil_scope
+from dials.command_line.generate_mask import generate_mask, run, phil_scope
+from dials.command_line.dials_import import Script as ImportScript
+from dials.command_line.dials_import import phil_scope as import_phil_scope
 from dxtbx.serialize import load
 
 
@@ -26,29 +27,27 @@ def input_experiment_list(request, dials_data):
 
 
 def test_generate_mask(dials_data, tmpdir):
-    result = procrunner.run(
-        [
-            "dials.generate_mask",
-            dials_data("centroid_test_data").join("experiments.json"),
-        ],
-        working_directory=tmpdir,
-    )
-    assert not result.returncode and not result.stderr
+    with tmpdir.as_cwd():
+        run(
+            phil_scope,
+            [dials_data("centroid_test_data").join("experiments.json").strpath],
+        )
+
     assert tmpdir.join("pixels.mask").check()
 
 
 def test_generate_mask_with_untrusted_rectangle(dials_data, tmpdir):
-    result = procrunner.run(
-        [
-            "dials.generate_mask",
-            dials_data("centroid_test_data").join("experiments.json"),
-            "output.mask=pixels2.mask",
-            "output.experiments=masked.expt",
-            "untrusted.rectangle=100,200,100,200",
-        ],
-        working_directory=tmpdir,
-    )
-    assert not result.returncode and not result.stderr
+    with tmpdir.as_cwd():
+        run(
+            phil_scope,
+            [
+                dials_data("centroid_test_data").join("experiments.json").strpath,
+                "output.mask=pixels2.mask",
+                "output.experiments=masked.expt",
+                "untrusted.rectangle=100,200,100,200",
+            ],
+        )
+
     assert tmpdir.join("pixels2.mask").check()
     assert tmpdir.join("masked.expt").check()
 
@@ -58,75 +57,75 @@ def test_generate_mask_with_untrusted_rectangle(dials_data, tmpdir):
 
 
 def test_generate_mask_with_untrusted_circle(dials_data, tmpdir):
-    result = procrunner.run(
-        [
-            "dials.generate_mask",
-            dials_data("centroid_test_data").join("experiments.json"),
-            "output.mask=pixels3.mask",
-            "untrusted.circle=100,100,10",
-        ],
-        working_directory=tmpdir,
-    )
-    assert not result.returncode and not result.stderr
+    with tmpdir.as_cwd():
+        run(
+            phil_scope,
+            [
+                dials_data("centroid_test_data").join("experiments.json").strpath,
+                "output.mask=pixels3.mask",
+                "untrusted.circle=100,100,10",
+            ],
+        )
+
     assert tmpdir.join("pixels3.mask").check()
 
 
 def test_generate_mask_with_resolution_range(dials_data, tmpdir):
-    result = procrunner.run(
-        [
-            "dials.generate_mask",
-            dials_data("centroid_test_data").join("experiments.json"),
-            "output.mask=pixels4.mask",
-            "resolution_range=2,3",
-        ],
-        working_directory=tmpdir,
-    )
-    assert not result.returncode and not result.stderr
+    with tmpdir.as_cwd():
+        run(
+            phil_scope,
+            [
+                dials_data("centroid_test_data").join("experiments.json").strpath,
+                "output.mask=pixels4.mask",
+                "resolution_range=2,3",
+            ],
+        )
+
     assert tmpdir.join("pixels4.mask").check()
 
 
 def test_generate_mask_with_d_min_d_max(dials_data, tmpdir):
-    result = procrunner.run(
-        [
-            "dials.generate_mask",
-            dials_data("centroid_test_data").join("experiments.json"),
-            "output.mask=pixels5.mask",
-            "d_min=3",
-            "d_max=2",
-        ],
-        working_directory=tmpdir,
-    )
-    assert not result.returncode and not result.stderr
+    with tmpdir.as_cwd():
+        run(
+            phil_scope,
+            [
+                dials_data("centroid_test_data").join("experiments.json").strpath,
+                "output.mask=pixels5.mask",
+                "d_min=3",
+                "d_max=2",
+            ],
+        )
+
     assert tmpdir.join("pixels5.mask").check()
 
 
 def test_generate_mask_with_ice_rings(dials_data, tmpdir):
-    result = procrunner.run(
-        [
-            "dials.generate_mask",
-            dials_data("centroid_test_data").join("experiments.json"),
-            "output.mask=pixels6.mask",
-            "ice_rings{filter=True;d_min=2}",
-        ],
-        working_directory=tmpdir,
-    )
-    assert not result.returncode and not result.stderr
+    with tmpdir.as_cwd():
+        run(
+            phil_scope,
+            [
+                dials_data("centroid_test_data").join("experiments.json").strpath,
+                "output.mask=pixels6.mask",
+                "ice_rings{filter=True;d_min=2}",
+            ],
+        )
+
     assert tmpdir.join("pixels6.mask").check()
 
 
 def test_generate_mask_with_untrusted_polygon_and_pixels(dials_data, tmpdir):
-    result = procrunner.run(
-        [
-            "dials.generate_mask",
-            dials_data("centroid_test_data").join("experiments.json"),
-            "output.mask=pixels3.mask",
-            "untrusted.polygon=100,100,100,200,200,200,200,100",
-            "untrusted.pixel=0,0",
-            "untrusted.pixel=1,1",
-        ],
-        working_directory=tmpdir,
-    )
-    assert not result.returncode and not result.stderr
+    with tmpdir.as_cwd():
+        run(
+            phil_scope,
+            [
+                dials_data("centroid_test_data").join("experiments.json").strpath,
+                "output.mask=pixels3.mask",
+                "untrusted.polygon=100,100,100,200,200,200,200,100",
+                "untrusted.pixel=0,0",
+                "untrusted.pixel=1,1",
+            ],
+        )
+
     assert tmpdir.join("pixels3.mask").check()
     with tmpdir.join("pixels3.mask").open("rb") as fh:
         mask = pickle.load(fh)
@@ -157,39 +156,36 @@ def test_generate_mask_function_with_untrusted_rectangle(input_experiment_list, 
 
 def test_generate_mask_trusted_range(dials_data, tmpdir):
     # https://github.com/dials/dials/issues/978
-    image_files = dials_data("x4wide").listdir("*.cbf", sort=True)
 
-    # Import as usual
-    procrunner.run(
-        ["dials.import", "trusted_range=-1,100", "output.experiments=no-overloads.expt"]
-        + [f.strpath for f in image_files],
-        working_directory=tmpdir,
-    )
-    procrunner.run(
-        [
-            "dials.generate_mask",
-            "no-overloads.expt",
-            "output.mask=pixels1.mask",
-            "untrusted.rectangle=100,200,100,200",
-        ],
-        working_directory=tmpdir,
-    )
+    image_files = [f.strpath for f in dials_data("x4wide").listdir("*.cbf", sort=True)]
+    with tmpdir.as_cwd():
+        # Import as usual
+        import_script = ImportScript(import_phil_scope)
+        import_script.run(["output.experiments=no-overloads.expt"] + image_files)
 
-    # Import with narrow trusted range to produce overloads
-    procrunner.run(
-        ["dials.import", "trusted_range=-1,100", "output.experiments=overloads.expt"]
-        + [f.strpath for f in image_files],
-        working_directory=tmpdir,
-    )
-    procrunner.run(
-        [
-            "dials.generate_mask",
-            "overloads.expt",
-            "output.mask=pixels2.mask",
-            "untrusted.rectangle=100,200,100,200",
-        ],
-        working_directory=tmpdir,
-    )
+        run(
+            phil_scope,
+            [
+                "no-overloads.expt",
+                "output.mask=pixels1.mask",
+                "untrusted.rectangle=100,200,100,200",
+            ],
+        )
+
+        # Import with narrow trusted range to produce overloads
+        import_script = ImportScript(import_phil_scope)
+        import_script.run(
+            ["trusted_range=-1,100", "output.experiments=overloads.expt"] + image_files
+        )
+
+        run(
+            phil_scope,
+            [
+                "overloads.expt",
+                "output.mask=pixels2.mask",
+                "untrusted.rectangle=100,200,100,200",
+            ],
+        )
 
     with tmpdir.join("pixels1.mask").open("rb") as fh:
         mask1 = pickle.load(fh)

--- a/util/masking.py
+++ b/util/masking.py
@@ -161,6 +161,9 @@ class MaskGenerator(object):
                     else:
                         trusted_mask = trusted_mask | frame_mask
 
+                    if trusted_mask.count(False) == 0:
+                        break
+
                 mask = trusted_mask
             else:
                 mask = flex.bool(flex.grid(im.all()), True)

--- a/util/masking.py
+++ b/util/masking.py
@@ -149,6 +149,9 @@ class MaskGenerator(object):
         masks = []
         for index, (im, panel) in enumerate(zip(image, detector)):
 
+            # Build a trusted mask by looking for pixels that are always outside
+            # the trusted range. This identifies bad pixels, but does not include
+            # pixels that are overloaded on some images.
             if self.params.use_trusted_range:
                 trusted_mask = None
                 low, high = panel.get_trusted_range()

--- a/util/masking.py
+++ b/util/masking.py
@@ -152,7 +152,6 @@ class MaskGenerator(object):
             if self.params.use_trusted_range:
                 trusted_mask = None
                 low, high = panel.get_trusted_range()
-                trusted_mask = None
                 for image_index in imageset.indices():
                     image_data = imageset.get_raw_data(image_index)[index].as_double()
                     frame_mask = (image_data > low) & (image_data < high)

--- a/util/masking.py
+++ b/util/masking.py
@@ -149,11 +149,19 @@ class MaskGenerator(object):
         masks = []
         for index, (im, panel) in enumerate(zip(image, detector)):
 
-            # Create the basic mask from the trusted range
             if self.params.use_trusted_range:
+                trusted_mask = None
                 low, high = panel.get_trusted_range()
-                imd = im.as_double()
-                mask = (imd > low) & (imd < high)
+                trusted_mask = None
+                for image_index in imageset.indices():
+                    image_data = imageset.get_raw_data(image_index)[index].as_double()
+                    frame_mask = (image_data > low) & (image_data < high)
+                    if trusted_mask is None:
+                        trusted_mask = frame_mask
+                    else:
+                        trusted_mask = trusted_mask | frame_mask
+
+                mask = trusted_mask
             else:
                 mask = flex.bool(flex.grid(im.all()), True)
 

--- a/util/options.py
+++ b/util/options.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import copy
 import sys
 import os
 import itertools
@@ -390,7 +391,7 @@ class PhilCommandParser(object):
         if phil is None:
             self._system_phil = parse("")
         else:
-            self._system_phil = phil
+            self._system_phil = copy.deepcopy(phil)
 
         # Set the flags
         self._read_experiments = read_experiments


### PR DESCRIPTION
Loop is efficient for single-panel detectors and resolves the issue as published. Will be expensive for large image sets but that is the expected behaviour I would expect. Could do with refactoring for multi-panel detectors as the loop is inside out.

Draft PR to allow discussion as to best solution. 