### PR TITLE
For #994 - split experiments

### DIFF
--- a/command_line/index.py
+++ b/command_line/index.py
@@ -81,8 +81,6 @@ include scope dials.algorithms.refinement.refiner.phil_scope
 output {
   experiments = indexed.expt
     .type = path
-  split_experiments = False
-    .type = bool
   reflections = indexed.refl
     .type = path
   unindexed_reflections = None
@@ -263,11 +261,6 @@ def run(phil=working_phil, args=None):
         sys.exit(str(e))
 
     # Save experiments
-    if params.output.split_experiments:
-        logger.info("Splitting experiments before output")
-        indexed_experiments = ExperimentList(
-            [copy.deepcopy(re) for re in indexed_experiments]
-        )
     logger.info("Saving refined experiments to %s" % params.output.experiments)
     assert indexed_experiments.is_consistent()
     indexed_experiments.as_file(params.output.experiments)

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -385,11 +385,18 @@ def run(args=None, phil=working_phil):
         )
 
     if params.refinement.parameterisation.scan_varying is not False:
-        # duplicate crystal if necessary for scan varying
-        if len(experiments) > len(experiments.crystals()):
-            logger.info("Splitting crystal models before refinement")
-            for e in experiments:
-                e.crystal = copy.deepcopy(e.crystal)
+        # duplicate crystal if necessary for scan varying - will need
+        # to compare the scans with crystals - if not 1:1 will need to
+        # split the crystals
+
+        crystal_has_scan = {}
+        for j, e in enumerate(experiments):
+            if e.crystal in crystal_has_scan:
+                if e.scan is not crystal_has_scan[e.crystal]:
+                    logger.info("Separating crystal model for experiment %d" % j)
+                    e.crystal = copy.deepcopy(e.crystal)
+            else:
+                crystal_has_scan[e.crystal] = e.scan
 
     # Run refinement
     experiments, reflections, refiner, history = run_dials_refine(

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -370,15 +370,6 @@ def run(args=None, phil=working_phil):
 
     logger.info(dials_version())
 
-    if params.refinement.parameterisation.scan_varying is not False:
-        # duplicate crystal if exactly one and > 1 scan
-        if len(experiments) > 1 and len(experiments.crystals()) == 1:
-            logger.info("Splitting crystal models before refinement")
-            c = experiments.crystals()[0]
-            crystals = [copy.deepcopy(c) for e in experiments]
-            for j, e in enumerate(experiments):
-                e.crystal = crystals[j]
-
     # Log the diff phil
     diff_phil = parser.diff_phil.as_str()
     if diff_phil:
@@ -392,6 +383,15 @@ def run(args=None, phil=working_phil):
             "circumstances. It is not recommended for typical data processing "
             "tasks.\n"
         )
+
+    if params.refinement.parameterisation.scan_varying is not False:
+        # duplicate crystal if exactly one and > 1 scan for scan_varying
+        if len(experiments) > 1 and len(experiments.crystals()) == 1:
+            logger.info("Splitting crystal models before refinement")
+            c = experiments.crystals()[0]
+            crystals = [copy.deepcopy(c) for e in experiments]
+            for j, e in enumerate(experiments):
+                e.crystal = crystals[j]
 
     # Run refinement
     experiments, reflections, refiner, history = run_dials_refine(

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -15,6 +15,7 @@ Examples::
 """
 
 from __future__ import absolute_import, division, print_function
+import copy
 import sys
 import logging
 from time import time
@@ -22,6 +23,7 @@ import dials.util
 import libtbx.phil
 from libtbx import Auto
 from dials.array_family import flex
+from dxtbx.model.experiment_list import ExperimentList
 from dials.algorithms.refinement import RefinerFactory
 from dials.algorithms.refinement import DialsRefineConfigError, DialsRefineRuntimeError
 from dials.algorithms.refinement.corrgram import create_correlation_plots
@@ -368,6 +370,12 @@ def run(args=None, phil=working_phil):
     from dials.util.version import dials_version
 
     logger.info(dials_version())
+
+    # duplicate crystal if exactly one and > 1 scan - should probably check
+    # if scan_varying is not False here too.
+    if len(experiments) > 1 and len(experiments.crystals()) == 1:
+        logger.info("Splitting experiments refinement")
+        experiments = ExperimentList([copy.deepcopy(e) for e in experiments])
 
     # Log the diff phil
     diff_phil = parser.diff_phil.as_str()

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -393,7 +393,10 @@ def run(args=None, phil=working_phil):
         for j, e in enumerate(experiments):
             if e.crystal in crystal_has_scan:
                 if e.scan is not crystal_has_scan[e.crystal]:
-                    logger.info("Separating crystal model for experiment %d" % j)
+                    logger.info(
+                        "Duplicating crystal model for scan-varying refinement of experiment %d"
+                        % j
+                    )
                     e.crystal = copy.deepcopy(e.crystal)
             else:
                 crystal_has_scan[e.crystal] = e.scan

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -23,7 +23,6 @@ import dials.util
 import libtbx.phil
 from libtbx import Auto
 from dials.array_family import flex
-from dxtbx.model.experiment_list import ExperimentList
 from dials.algorithms.refinement import RefinerFactory
 from dials.algorithms.refinement import DialsRefineConfigError, DialsRefineRuntimeError
 from dials.algorithms.refinement.corrgram import create_correlation_plots
@@ -371,11 +370,14 @@ def run(args=None, phil=working_phil):
 
     logger.info(dials_version())
 
-    # duplicate crystal if exactly one and > 1 scan - should probably check
-    # if scan_varying is not False here too.
-    if len(experiments) > 1 and len(experiments.crystals()) == 1:
-        logger.info("Splitting experiments refinement")
-        experiments = ExperimentList([copy.deepcopy(e) for e in experiments])
+    if params.refinement.parameterisation.scan_varying is not False:
+        # duplicate crystal if exactly one and > 1 scan
+        if len(experiments) > 1 and len(experiments.crystals()) == 1:
+            logger.info("Splitting crystal models before refinement")
+            c = experiments.crystals()[0]
+            crystals = [copy.deepcopy(c) for e in experiments]
+            for j, e in enumerate(experiments):
+                e.crystal = crystals[j]
 
     # Log the diff phil
     diff_phil = parser.diff_phil.as_str()

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -385,13 +385,11 @@ def run(args=None, phil=working_phil):
         )
 
     if params.refinement.parameterisation.scan_varying is not False:
-        # duplicate crystal if exactly one and > 1 scan for scan_varying
-        if len(experiments) > 1 and len(experiments.crystals()) == 1:
+        # duplicate crystal if necessary for scan varying
+        if len(experiments) > len(experiments.crystals()):
             logger.info("Splitting crystal models before refinement")
-            c = experiments.crystals()[0]
-            crystals = [copy.deepcopy(c) for e in experiments]
-            for j, e in enumerate(experiments):
-                e.crystal = crystals[j]
+            for e in experiments:
+                e.crystal = copy.deepcopy(e.crystal)
 
     # Run refinement
     experiments, reflections, refiner, history = run_dials_refine(

--- a/doc/sphinx/documentation/tutorials/small_molecule_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/small_molecule_tutorial.rst
@@ -57,7 +57,7 @@ Indexing here will depend on the model for the experiment being reasonably accur
 
 .. code-block:: bash
 
-   dials.index datablock.expt strong.refl split_experiments=True
+   dials.index datablock.expt strong.refl
 
 Without any additional input, the indexing will determine the most approproiate primitive lattice parameters and orientation which desctibe the observed reciprocal lattice positions.
 
@@ -77,7 +77,7 @@ Inspect the results, conclude that the oP lattice is appropriate then assign thi
 
 .. code-block:: bash
 
-   dials.index datablock.expt strong.refl split_experiments=True space_group=P222
+   dials.index datablock.expt strong.refl space_group=P222
 
 This will once again consistently index the data, this time enforcing the lattice constraints.
 


### PR DESCRIPTION
If len(crystals) == 1 but len(experiments) > 1 split experiments to allow scan varying refinement.

Draft PR to allow discussion of how best to solve this - this change duplicates each model which is probably not 100% what we want but does work. Means detectors are _not_ constrained to be the same (likewise beam) - 

```
Silver-Surfer split :) $ dials.show refined.expt |grep _axis
  fast_axis: {0.00299689,0.86451,0.502607}
  slow_axis: {0.999995,-0.00210866,-0.00233566}
  fast_axis: {0.00223049,0.864408,0.502786}
  slow_axis: {0.999991,-0.000121619,-0.00422713}
  fast_axis: {-0.00445467,0.864301,0.502955}
  slow_axis: {0.999989,0.0044793,0.00115946}
  fast_axis: {0.000307802,0.999999,0.00151444}
  slow_axis: {0.999995,-0.000312514,0.00311193}
```

First three should probably be identical... 