### PR TITLE
DIALS 2.0.1

### DIFF
--- a/algorithms/symmetry/__init__.py
+++ b/algorithms/symmetry/__init__.py
@@ -128,11 +128,15 @@ class symmetry_base(object):
                 relative_length_tolerance is not None
                 and absolute_angle_tolerance is not None
             ):
-                assert d.unit_cell().is_similar_to(
+                if not d.unit_cell().is_similar_to(
                     self.median_unit_cell,
                     relative_length_tolerance,
                     absolute_angle_tolerance,
-                ), (str(d.unit_cell()), str(self.median_unit_cell))
+                ):
+                    raise ValueError(
+                        "Incompatible unit cell: %s\n" % d.unit_cell()
+                        + "      median unit cell: %s" % self.median_unit_cell
+                    )
 
     def _normalise(self, method):
         if method is None:

--- a/algorithms/symmetry/absences/screw_axes.py
+++ b/algorithms/symmetry/absences/screw_axes.py
@@ -147,6 +147,14 @@ class ScrewAxis(Subject):
             # results appear inconsistent - significant i_over_sigma_abs, but this
             # is still low compared to i_over_sigma_expected
             # try removing the highest absent reflection in case its an outlier
+            outlier_msg = (
+                """Screw axis %s could only be assigned after removing a suspected outlier
+from the expected 'absent' reflections."""
+                % self.name
+            )
+            if expected_abs.size() <= 1:
+                logger.info(outlier_msg)
+                return P_present
             sel = flex.sort_permutation(expected_abs)
             sorted_exp_abs = expected_abs.select(sel)
             mean_i_sigma_abs = flex.mean(sorted_exp_abs[:-1])
@@ -166,11 +174,7 @@ There may be a set of weak reflections due to pseudosymmetry.""",
                 self.intensities.select(~expected_sel).select(sel)[:-1]
             )
             if z_score_present > cutoff:
-                logger.info(
-                    """Screw axis %s could only be assigned after removing a suspected outlier
-from the expected 'absent' reflections.""",
-                    self.name,
-                )
+                logger.info(outlier_msg)
                 return P_present
             # else in the uncertain case
         elif z_score_present > cutoff:  # evidence with confidence

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -104,7 +104,7 @@ class cosym(Subject):
             self._experiments, self._reflections
         )
 
-        self._experiments, self._reflections = map_to_minimum_cell(
+        self._experiments, self._reflections, _ = map_to_minimum_cell(
             self._experiments, self._reflections, params.lattice_symmetry_max_delta
         )
 

--- a/command_line/filter_reflections.py
+++ b/command_line/filter_reflections.py
@@ -315,6 +315,8 @@ def run_filtering(params, experiments, reflections):
             d_spacings = reflections["d"]
         else:
             if "rlp" not in reflections:
+                if "xyzobs.mm.value" not in reflections:
+                    reflections.centroid_px_to_mm(experiments)
                 reflections.map_centroids_to_reciprocal_space(experiments)
             d_star_sq = flex.pow2(reflections["rlp"].norms())
             d_spacings = uctbx.d_star_sq_as_d(d_star_sq)

--- a/command_line/filter_reflections.py
+++ b/command_line/filter_reflections.py
@@ -199,9 +199,10 @@ def run_filtering(params, experiments, reflections):
     if params.d_min is not None and params.d_max is not None:
         if params.d_min > params.d_max:
             raise Sorry("d_min must be less than d_max")
-    if params.d_min is not None or params.d_max is not None:
+    if params.d_min is not None or params.d_max is not None or params.ice_rings.filter:
         if "d" not in reflections:
-            if experiments:
+            if experiments and any(experiments.crystals()):
+                # Calculate d-spacings from the miller indices
                 print(
                     "Reflection table does not have resolution information. "
                     "Attempting to calculate this from the experiment list"
@@ -215,6 +216,14 @@ def run_filtering(params, experiments, reflections):
                     )
                 reflections = reflections.select(sel)
                 reflections.compute_d(experiments)
+            elif experiments:
+                # Calculate d-spacings from the observed reflection centroids
+                if "rlp" not in reflections:
+                    if "xyzobs.mm.value" not in reflections:
+                        reflections.centroid_px_to_mm(experiments)
+                    reflections.map_centroids_to_reciprocal_space(experiments)
+                d_star_sq = flex.pow2(reflections["rlp"].norms())
+                reflections["d"] = uctbx.d_star_sq_as_d(d_star_sq)
             else:
                 raise Sorry(
                     "reflection table has no resolution information "
@@ -311,21 +320,11 @@ def run_filtering(params, experiments, reflections):
 
     # Filter powder rings
     if params.ice_rings.filter:
-        if "d" in reflections:
-            d_spacings = reflections["d"]
-        else:
-            if "rlp" not in reflections:
-                if "xyzobs.mm.value" not in reflections:
-                    reflections.centroid_px_to_mm(experiments)
-                reflections.map_centroids_to_reciprocal_space(experiments)
-            d_star_sq = flex.pow2(reflections["rlp"].norms())
-            d_spacings = uctbx.d_star_sq_as_d(d_star_sq)
-
         d_min = params.ice_rings.d_min
         width = params.ice_rings.width
 
         if d_min is None:
-            d_min = flex.min(d_spacings)
+            d_min = flex.min(reflections["d"])
 
         ice_filter = filtering.PowderRingFilter(
             params.ice_rings.unit_cell,
@@ -334,7 +333,7 @@ def run_filtering(params, experiments, reflections):
             width,
         )
 
-        ice_sel = ice_filter(d_spacings)
+        ice_sel = ice_filter(reflections["d"])
 
         print("Rejecting %i reflections at ice ring resolution" % ice_sel.count(True))
         reflections = reflections.select(~ice_sel)

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -81,8 +81,6 @@ include scope dials.algorithms.refinement.refiner.phil_scope
 output {
   experiments = indexed.expt
     .type = path
-  split_experiments = False
-    .type = bool
   reflections = indexed.refl
     .type = path
   unindexed_reflections = None
@@ -263,11 +261,6 @@ def run(phil=working_phil, args=None):
         sys.exit(str(e))
 
     # Save experiments
-    if params.output.split_experiments:
-        logger.info("Splitting experiments before output")
-        indexed_experiments = ExperimentList(
-            [copy.deepcopy(re) for re in indexed_experiments]
-        )
     logger.info("Saving refined experiments to %s" % params.output.experiments)
     assert indexed_experiments.is_consistent()
     indexed_experiments.as_file(params.output.experiments)

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -206,7 +206,7 @@ def run_macrocycle(params, reflections, experiments):
     # just copy over the columns of interest or columns that may have been
     # updated, leaving behind things added by e.g. scan-varying refinement
     # such as 'block', the U, B and UB matrices and gradients.
-    for key in preds.rows():
+    for key in preds:
         if key in reflections.keys() or key in [
             "s1",
             "xyzcal.mm",

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -15,6 +15,7 @@ Examples::
 """
 
 from __future__ import absolute_import, division, print_function
+import copy
 import sys
 import logging
 from time import time
@@ -382,6 +383,23 @@ def run(args=None, phil=working_phil):
             "circumstances. It is not recommended for typical data processing "
             "tasks.\n"
         )
+
+    if params.refinement.parameterisation.scan_varying is not False:
+        # duplicate crystal if necessary for scan varying - will need
+        # to compare the scans with crystals - if not 1:1 will need to
+        # split the crystals
+
+        crystal_has_scan = {}
+        for j, e in enumerate(experiments):
+            if e.crystal in crystal_has_scan:
+                if e.scan is not crystal_has_scan[e.crystal]:
+                    logger.info(
+                        "Duplicating crystal model for scan-varying refinement of experiment %d"
+                        % j
+                    )
+                    e.crystal = copy.deepcopy(e.crystal)
+            else:
+                crystal_has_scan[e.crystal] = e.scan
 
     # Run refinement
     experiments, reflections, refiner, history = run_dials_refine(

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -11,7 +11,7 @@ import iotbx.phil
 from rstbx.symmetry.constraints import parameter_reduction
 
 from dials.array_family import flex
-from dials.util import log, Sorry, show_mail_on_error
+from dials.util import log, show_mail_on_error
 from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
 from dials.util.version import dials_version
 from dials.util.multi_dataset_handling import (
@@ -310,7 +310,7 @@ def run(args=None):
 
     reflections = parse_multiple_datasets(reflections)
     if len(experiments) != len(reflections):
-        raise Sorry(
+        raise sys.exit(
             "Mismatched number of experiments and reflection tables found: %s & %s."
             % (len(experiments), len(reflections))
         )
@@ -318,7 +318,7 @@ def run(args=None):
         experiments, reflections = assign_unique_identifiers(experiments, reflections)
         symmetry(experiments, reflections, params=params)
     except ValueError as e:
-        raise Sorry(e)
+        raise sys.exit(e)
 
 
 if __name__ == "__main__":

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import copy
+import json
 import logging
 import random
 import sys
@@ -118,6 +119,7 @@ def map_to_minimum_cell(experiments, reflections, max_delta):
 
     Returns: The experiments and reflections mapped to the minimum cell
     """
+    cb_ops = []
     for expt, refl in zip(experiments, reflections):
         groups = metric_subgroups(
             expt.crystal.get_crystal_symmetry(),
@@ -130,7 +132,8 @@ def map_to_minimum_cell(experiments, reflections, max_delta):
         refl["miller_index"] = cb_op_inp_min.apply(refl["miller_index"])
         expt.crystal = expt.crystal.change_basis(cb_op_inp_min)
         expt.crystal.set_space_group(sgtbx.space_group())
-    return experiments, reflections
+        cb_ops.append(cb_op_inp_min)
+    return experiments, reflections, cb_ops
 
 
 def symmetry(experiments, reflection_tables, params=None):
@@ -155,7 +158,7 @@ def symmetry(experiments, reflection_tables, params=None):
         # transform models into miller arrays
         n_datasets = len(experiments)
 
-        experiments, reflection_tables = map_to_minimum_cell(
+        experiments, reflection_tables, cb_ops = map_to_minimum_cell(
             experiments, reflection_tables, params.lattice_symmetry_max_delta
         )
 
@@ -184,7 +187,14 @@ def symmetry(experiments, reflection_tables, params=None):
         logger.info(result)
 
         if params.output.json is not None:
-            result.as_json(filename=params.output.json)
+            d = result.as_dict()
+            d["cb_op_inp_min"] = [str(cb_op) for cb_op in cb_ops]
+            # This is not the input symmetry as we have already mapped it to minimum
+            # cell, so delete from the output dictionary to avoid confusion
+            del d["input_symmetry"]
+            json_str = json.dumps(d, indent=2)
+            with open(params.output.json, "w") as f:
+                f.write(json_str)
 
         # Change of basis operator from input unit cell to best unit cell
         cb_op_inp_best = result.best_solution.subgroup["cb_op_inp_best"]

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -344,7 +344,7 @@ def run(args=None):
 
     reflections = parse_multiple_datasets(reflections)
     if len(experiments) != len(reflections):
-        raise sys.exit(
+        sys.exit(
             "Mismatched number of experiments and reflection tables found: %s & %s."
             % (len(experiments), len(reflections))
         )
@@ -352,7 +352,7 @@ def run(args=None):
         experiments, reflections = assign_unique_identifiers(experiments, reflections)
         symmetry(experiments, reflections, params=params)
     except ValueError as e:
-        raise sys.exit(e)
+        sys.exit(e)
 
 
 if __name__ == "__main__":

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -6,6 +6,7 @@ import random
 import sys
 
 from cctbx import sgtbx
+from cctbx.sgtbx.lattice_symmetry import metric_subgroups
 from libtbx import Auto
 import iotbx.phil
 from rstbx.symmetry.constraints import parameter_reduction
@@ -104,6 +105,34 @@ output {
 )
 
 
+def map_to_minimum_cell(experiments, reflections, max_delta):
+    """
+    Map experiments and reflections to the minimum cell
+
+    Map to the minimum cell via the best cell, which appears to guarantee that the
+    resulting minimum cells are consistent.
+
+    Args:
+        experiments (ExperimentList): a list of experiments.
+        reflections (list): a list of reflection tables
+
+    Returns: The experiments and reflections mapped to the minimum cell
+    """
+    for expt, refl in zip(experiments, reflections):
+        groups = metric_subgroups(
+            expt.crystal.get_crystal_symmetry(),
+            max_delta,
+            enforce_max_delta_for_generated_two_folds=True,
+        )
+        group = groups.result_groups[0]
+        cb_op_best_to_min = group["best_subsym"].change_of_basis_op_to_minimum_cell()
+        cb_op_inp_min = cb_op_best_to_min * group["cb_op_inp_best"]
+        refl["miller_index"] = cb_op_inp_min.apply(refl["miller_index"])
+        expt.crystal = expt.crystal.change_basis(cb_op_inp_min)
+        expt.crystal.set_space_group(sgtbx.space_group())
+    return experiments, reflections
+
+
 def symmetry(experiments, reflection_tables, params=None):
     """
     Run symmetry analysis
@@ -125,6 +154,11 @@ def symmetry(experiments, reflection_tables, params=None):
 
         # transform models into miller arrays
         n_datasets = len(experiments)
+
+        experiments, reflection_tables = map_to_minimum_cell(
+            experiments, reflection_tables, params.lattice_symmetry_max_delta
+        )
+
         datasets = filtered_arrays_from_experiments_reflections(
             experiments,
             reflection_tables,

--- a/conftest.py
+++ b/conftest.py
@@ -42,7 +42,7 @@ def dials_regression():
     try:
         import socket
 
-        reference_copy = "/dls/science/groups/scisoft/DIALS/repositories/git-reference/dials_regression"
+        reference_copy = "/dls/science/groups/scisoft/DIALS/repositories/git-reference/dials_regression_1939"
         if (
             os.name == "posix"
             and socket.gethostname().endswith(".diamond.ac.uk")

--- a/doc/sphinx/documentation/tutorials/small_molecule_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/small_molecule_tutorial.rst
@@ -57,7 +57,7 @@ Indexing here will depend on the model for the experiment being reasonably accur
 
 .. code-block:: bash
 
-   dials.index datablock.expt strong.refl split_experiments=True
+   dials.index datablock.expt strong.refl
 
 Without any additional input, the indexing will determine the most approproiate primitive lattice parameters and orientation which desctibe the observed reciprocal lattice positions.
 
@@ -77,7 +77,7 @@ Inspect the results, conclude that the oP lattice is appropriate then assign thi
 
 .. code-block:: bash
 
-   dials.index datablock.expt strong.refl split_experiments=True space_group=P222
+   dials.index datablock.expt strong.refl space_group=P222
 
 This will once again consistently index the data, this time enforcing the lattice constraints.
 

--- a/libtbx_config
+++ b/libtbx_config
@@ -6,6 +6,7 @@
     "python_required": [
         "dials-data>=2.0.38",
         "Jinja2",
+        "pyparsing<2.4.3",
         "pytest-mock",
         "mock>=2.0",
         "msgpack",

--- a/newsfragments/991.bugfix
+++ b/newsfragments/991.bugfix
@@ -1,0 +1,4 @@
+Fix output of predictions in dials.refine.
+A recently-introduced bug meant that the updated predictions weren't
+being copied to the output reflections file.
+

--- a/test/command_line/test_cosym.py
+++ b/test/command_line/test_cosym.py
@@ -7,7 +7,7 @@ import procrunner
 from cctbx import sgtbx, uctbx
 import scitbx.matrix
 from dxtbx.serialize import load
-from dxtbx.model import Crystal, Experiment, ExperimentList
+from dxtbx.model import Crystal, Experiment
 from dials.array_family import flex
 from dials.algorithms.symmetry.cosym._generate_test_data import (
     generate_experiments_reflections,
@@ -195,70 +195,3 @@ def test_eliminate_sys_absent():
         (-25, -3, -3),
         (-42, -8, -2),
     ]
-
-
-def test_map_to_minimum_cell():
-    # Input and expected output
-    input_ucs = [
-        (39.7413, 183.767, 140.649, 90, 90, 90),
-        (40.16, 142.899, 92.4167, 90, 102.48, 90),
-        (180.613, 40.1558, 142.737, 90, 90.0174, 90),
-    ]
-    input_sgs = ["C 2 2 21", "P 1 2 1", "C 1 2 1"]
-    input_hkl = [
-        [(1, -75, -71), (1, -73, -70), (1, -71, -69)],
-        [(14, -37, -36), (-2, -35, -46), (-3, -34, -47)],
-        [(-31, -5, -3), (-25, -3, -3), (-42, -8, -2)],
-    ]
-    expected_ucs = [
-        (39.7413, 94.00755450320204, 140.649, 90.0, 90.0, 77.79717980856927),
-        (40.16, 92.46399390642911, 142.899, 90.0, 90.0, 77.3882749092846),
-        (
-            40.1558,
-            92.51154528306184,
-            142.73699999999997,
-            89.9830147351441,
-            90.0,
-            77.46527404307477,
-        ),
-    ]
-    expected_output_hkl = [
-        [(-1, 37, -71), (-1, 36, -70), (-1, 35, -69)],
-        [(-14, 22, 37), (2, 48, 35), (3, 50, 34)],
-        [(-5, 13, -3), (-3, 11, -3), (-8, 17, -2)],
-    ]
-
-    # Setup the input experiments and reflection tables
-    expts = ExperimentList()
-    reflections = []
-    for uc, sg, hkl in zip(input_ucs, input_sgs, input_hkl):
-        uc = uctbx.unit_cell(uc)
-        sg = sgtbx.space_group_info(sg).group()
-        B = scitbx.matrix.sqr(uc.fractionalization_matrix()).transpose()
-        expts.append(Experiment(crystal=Crystal(B, space_group=sg, reciprocal=True)))
-        refl = flex.reflection_table()
-        refl["miller_index"] = flex.miller_index(hkl)
-        reflections.append(refl)
-
-    # Actually run the method we are testing
-    expts_min, reflections_min = cosym._map_to_minimum_cell(
-        expts, reflections, max_delta=5
-    )
-
-    # Verify that the unit cells have been transformed as expected
-    for expt, uc in zip(expts, expected_ucs):
-        assert expt.crystal.get_unit_cell().parameters() == pytest.approx(uc, abs=4e-2)
-
-    # Space group should be set to P1
-    assert [expt.crystal.get_space_group().type().number() for expt in expts_min] == [
-        1,
-        1,
-        1,
-    ]
-
-    # Verify that the reflections have been reindexed as expected
-    # Because the exact choice of minimum cell can be platform-dependent,
-    # compare the magnitude, but not the sign of the output hkl values
-    for refl, expected_hkl in zip(reflections, expected_output_hkl):
-        for hkl, e_hkl in zip(refl["miller_index"], expected_hkl):
-            assert [abs(h) for h in hkl] == [abs(eh) for eh in e_hkl]

--- a/test/command_line/test_cosym.py
+++ b/test/command_line/test_cosym.py
@@ -247,7 +247,7 @@ def test_map_to_minimum_cell():
 
     # Verify that the unit cells have been transformed as expected
     for expt, uc in zip(expts, expected_ucs):
-        assert expt.crystal.get_unit_cell().parameters() == pytest.approx(uc)
+        assert expt.crystal.get_unit_cell().parameters() == pytest.approx(uc, abs=4e-2)
 
     # Space group should be set to P1
     assert [expt.crystal.get_space_group().type().number() for expt in expts_min] == [
@@ -257,5 +257,8 @@ def test_map_to_minimum_cell():
     ]
 
     # Verify that the reflections have been reindexed as expected
-    for refl, hkl in zip(reflections, expected_output_hkl):
-        assert list(refl["miller_index"]) == hkl
+    # Because the exact choice of minimum cell can be platform-dependent,
+    # compare the magnitude, but not the sign of the output hkl values
+    for refl, expected_hkl in zip(reflections, expected_output_hkl):
+        for hkl, e_hkl in zip(refl["miller_index"], expected_hkl):
+            assert [abs(h) for h in hkl] == [abs(eh) for eh in e_hkl]

--- a/test/command_line/test_filter_reflections.py
+++ b/test/command_line/test_filter_reflections.py
@@ -78,3 +78,23 @@ def test_filter_reflections_printing_analysis(reflections, tmpdir):
         ["dials.filter_reflections", reflections], working_directory=tmpdir
     )
     assert not result.returncode and not result.stderr
+
+
+def test_filter_ice_rings(dials_data, tmpdir):
+    directory = dials_data("centroid_test_data")
+    expt_filename = directory.join("imported_experiments.json").strpath
+    refl_filename = directory.join("strong.pickle").strpath
+    result = procrunner.run(
+        [
+            "dials.filter_reflections",
+            "ice_rings.filter=True",
+            expt_filename,
+            refl_filename,
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    input_refl = flex.reflection_table.from_file(refl_filename)
+    filtered_refl = flex.reflection_table.from_file(tmpdir.join("filtered.refl"))
+    assert len(filtered_refl) < len(input_refl)
+    assert len(filtered_refl) == 615

--- a/test/command_line/test_symmetry.py
+++ b/test/command_line/test_symmetry.py
@@ -4,13 +4,16 @@ import os
 
 import procrunner
 import pytest
-from cctbx import sgtbx
+from cctbx import sgtbx, uctbx
+import scitbx.matrix
 from dxtbx.serialize import load
+from dxtbx.model import Crystal, Experiment, ExperimentList
 
 from dials.array_family import flex
 from dials.algorithms.symmetry.cosym._generate_test_data import (
     generate_experiments_reflections,
 )
+from dials.command_line.symmetry import map_to_minimum_cell
 
 
 def test_symmetry_laue_only(dials_regression, tmpdir):
@@ -146,3 +149,68 @@ def test_symmetry_absences_only(dials_data, tmpdir):
         tmpdir.join("symmetrized.expt").strpath, check_format=False
     )
     assert str(exps[0].crystal.get_space_group().info()) == "P 41"
+
+
+def test_map_to_minimum_cell():
+    # Input and expected output
+    input_ucs = [
+        (39.7413, 183.767, 140.649, 90, 90, 90),
+        (40.16, 142.899, 92.4167, 90, 102.48, 90),
+        (180.613, 40.1558, 142.737, 90, 90.0174, 90),
+    ]
+    input_sgs = ["C 2 2 21", "P 1 2 1", "C 1 2 1"]
+    input_hkl = [
+        [(1, -75, -71), (1, -73, -70), (1, -71, -69)],
+        [(14, -37, -36), (-2, -35, -46), (-3, -34, -47)],
+        [(-31, -5, -3), (-25, -3, -3), (-42, -8, -2)],
+    ]
+    expected_ucs = [
+        (39.7413, 94.00755450320204, 140.649, 90.0, 90.0, 77.79717980856927),
+        (40.16, 92.46399390642911, 142.899, 90.0, 90.0, 77.3882749092846),
+        (
+            40.1558,
+            92.51154528306184,
+            142.73699999999997,
+            89.9830147351441,
+            90.0,
+            77.46527404307477,
+        ),
+    ]
+    expected_output_hkl = [
+        [(-1, 37, -71), (-1, 36, -70), (-1, 35, -69)],
+        [(-14, 22, 37), (2, 48, 35), (3, 50, 34)],
+        [(-5, 13, -3), (-3, 11, -3), (-8, 17, -2)],
+    ]
+
+    # Setup the input experiments and reflection tables
+    expts = ExperimentList()
+    reflections = []
+    for uc, sg, hkl in zip(input_ucs, input_sgs, input_hkl):
+        uc = uctbx.unit_cell(uc)
+        sg = sgtbx.space_group_info(sg).group()
+        B = scitbx.matrix.sqr(uc.fractionalization_matrix()).transpose()
+        expts.append(Experiment(crystal=Crystal(B, space_group=sg, reciprocal=True)))
+        refl = flex.reflection_table()
+        refl["miller_index"] = flex.miller_index(hkl)
+        reflections.append(refl)
+
+    # Actually run the method we are testing
+    expts_min, reflections_min = map_to_minimum_cell(expts, reflections, max_delta=5)
+
+    # Verify that the unit cells have been transformed as expected
+    for expt, uc in zip(expts, expected_ucs):
+        assert expt.crystal.get_unit_cell().parameters() == pytest.approx(uc, abs=4e-2)
+
+    # Space group should be set to P1
+    assert [expt.crystal.get_space_group().type().number() for expt in expts_min] == [
+        1,
+        1,
+        1,
+    ]
+
+    # Verify that the reflections have been reindexed as expected
+    # Because the exact choice of minimum cell can be platform-dependent,
+    # compare the magnitude, but not the sign of the output hkl values
+    for refl, expected_hkl in zip(reflections, expected_output_hkl):
+        for hkl, e_hkl in zip(refl["miller_index"], expected_hkl):
+            assert [abs(h) for h in hkl] == [abs(eh) for eh in e_hkl]

--- a/util/version.py
+++ b/util/version.py
@@ -16,11 +16,15 @@ def get_git_version(dials_path, treat_merges_as_single_commit=False):
     version = None
     with open(os.devnull, "w") as devnull:
         # Obtain name of the current branch. If this fails then the other commands will probably also fail
-        branch = subprocess.check_output(
-            ["git", "describe", "--contains", "--all", "HEAD"],
-            cwd=dials_path,
-            stderr=devnull,
-        ).rstrip()
+        branch = (
+            subprocess.check_output(
+                ["git", "describe", "--contains", "--all", "HEAD"],
+                cwd=dials_path,
+                stderr=devnull,
+            )
+            .rstrip()
+            .decode("latin-1")
+        )
         releasebranch = "dials-2" in branch
 
         # Always treat merges as single commit on release branches
@@ -40,9 +44,13 @@ def get_git_version(dials_path, treat_merges_as_single_commit=False):
                 pass  # This is not supported on older git versions < 1.8.4.
         if version is None:
             # Find the most recent tag
-            version = subprocess.check_output(
-                ["git", "describe", "--long"], cwd=dials_path, stderr=devnull
-            ).rstrip()
+            version = (
+                subprocess.check_output(
+                    ["git", "describe", "--long"], cwd=dials_path, stderr=devnull
+                )
+                .rstrip()
+                .decode("latin-1")
+            )
             if treat_merges_as_single_commit:
                 tag = version[: version.rindex("-", 0, version.rindex("-"))]
                 commit = version[version.rindex("-") + 1 :]  # 'gxxxxxxx'

--- a/util/version.py
+++ b/util/version.py
@@ -73,7 +73,7 @@ def get_git_version(dials_path, treat_merges_as_single_commit=False):
         # If we are on a release branch, then append a '-release'-tag
         if releasebranch:
             version = version + "-release"
-    return version
+    return str(version)
 
 
 # When run from a development installation the version information is extracted


### PR DESCRIPTION
* `dials.refine`: Fix bug where unrefined predictions are returned (#991)
* `dials.refine`: Duplicate crystals for scan-varying refinement of multi-scan data (#994)
* `dials.symmetry`: Fix crash with different but compatible unit cells (#992)
* `cosym`: ???