### PR TITLE
Symmetry on limited range

### DIFF
--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -32,11 +32,13 @@ from dials.algorithms.symmetry.absences.run_absences_checks import (
 from dials.algorithms.symmetry.absences.laue_groups_info import (
     laue_groups as laue_groups_for_absence_analysis,
 )
+from dials.util.exclude_images import exclude_image_ranges_for_scaling
 
 logger = logging.getLogger("dials.command_line.symmetry")
 
 phil_scope = iotbx.phil.parse(
     """\
+include scope dials.util.exclude_images.phil_scope
 d_min = Auto
   .type = float(value_min=0)
 
@@ -45,10 +47,6 @@ min_i_mean_over_sigma_mean = 4
 
 min_cc_half = 0.6
   .type = float(value_min=0, value_max=1)
-
-batch = None
-  .type = ints(value_min=0, size=2)
-  .help = "Limit batch range for analysis: manually apply results afterwards"
 
 normalisation = kernel quasi ml_iso *ml_aniso
   .type = choice
@@ -153,6 +151,22 @@ def symmetry(experiments, reflection_tables, params=None):
     result = None
     if params is None:
         params = phil_scope.extract()
+    refls_for_sym = []
+
+    def get_refl_for_sym(params, experiments, reflection_tables):
+        """Optionally apply exclude images"""
+        refls_for_sym = []
+        if params.exclude_images:
+            reflection_tables, experiments = exclude_image_ranges_for_scaling(
+                reflection_tables, experiments, params.exclude_images
+            )
+            for refl in reflection_tables:
+                refls_for_sym.append(
+                    refl.select(~refl.get_flags(refl.flags.user_excluded_in_scaling))
+                )
+        else:
+            refls_for_sym = reflection_tables
+        return refls_for_sym
 
     if params.laue_group is Auto:
         logger.info("=" * 80)
@@ -167,9 +181,11 @@ def symmetry(experiments, reflection_tables, params=None):
             experiments, reflection_tables, params.lattice_symmetry_max_delta
         )
 
+        refls_for_sym = get_refl_for_sym(params, experiments, reflection_tables)
+
         datasets = filtered_arrays_from_experiments_reflections(
             experiments,
-            reflection_tables,
+            refls_for_sym,
             outlier_rejection_after_filter=True,
             partiality_threshold=params.partiality_threshold,
         )
@@ -240,11 +256,14 @@ def symmetry(experiments, reflection_tables, params=None):
         if laue_group not in laue_groups_for_absence_analysis:
             logger.info("No absences to check for this laue group\n")
         else:
+            if not refls_for_sym:
+                refls_for_sym = get_refl_for_sym(params, experiments, reflection_tables)
+
             if (params.d_min is Auto) and (result is not None):
                 d_min = result.intensities.resolution_range()[1]
             elif params.d_min is Auto:
                 d_min = resolution_filter_from_reflections_experiments(
-                    reflection_tables,
+                    refls_for_sym,
                     experiments,
                     params.min_i_mean_over_sigma_mean,
                     params.min_cc_half,
@@ -256,10 +275,10 @@ def symmetry(experiments, reflection_tables, params=None):
             # multiple input files.
             if len(reflection_tables) > 1:
                 joint_reflections = flex.reflection_table()
-                for table in reflection_tables:
+                for table in refls_for_sym:
                     joint_reflections.extend(table)
             else:
-                joint_reflections = reflection_tables[0]
+                joint_reflections = refls_for_sym[0]
 
             merged_reflections = prepare_merged_reflection_table(
                 experiments, joint_reflections, d_min
@@ -375,17 +394,6 @@ def run(args=None):
     reflections = flatten_reflections(params.input.reflections)
 
     reflections = parse_multiple_datasets(reflections)
-
-    # Cut down reflection lists according to input batch range if set
-    if params.batch is not None:
-        z0, z1 = map(float, params.batch)
-        logger.info("Cutting reflection lists to batch range %d to %d" % (z0, z1))
-        trimmed_reflections = []
-        for refl in reflections:
-            z = refl["xyzcal.px"].parts()[2]
-            keep = (z >= z0) & (z <= z1)
-            trimmed_reflections.append(refl.select(keep))
-        reflections = trimmed_reflections
 
     if len(experiments) != len(reflections):
         sys.exit(

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -32,7 +32,10 @@ from dials.algorithms.symmetry.absences.run_absences_checks import (
 from dials.algorithms.symmetry.absences.laue_groups_info import (
     laue_groups as laue_groups_for_absence_analysis,
 )
-from dials.util.exclude_images import exclude_image_ranges_for_scaling
+from dials.util.exclude_images import (
+    exclude_image_ranges_from_scans,
+    get_selection_for_valid_image_ranges,
+)
 
 logger = logging.getLogger("dials.command_line.symmetry")
 
@@ -157,13 +160,12 @@ def symmetry(experiments, reflection_tables, params=None):
         """Optionally apply exclude images"""
         refls_for_sym = []
         if params.exclude_images:
-            reflection_tables, experiments = exclude_image_ranges_for_scaling(
-                reflection_tables, experiments, params.exclude_images
+            experiments = exclude_image_ranges_from_scans(
+                experiments, params.exclude_images
             )
-            for refl in reflection_tables:
-                refls_for_sym.append(
-                    refl.select(~refl.get_flags(refl.flags.user_excluded_in_scaling))
-                )
+            for refl, exp in zip(reflection_tables, experiments):
+                sel = get_selection_for_valid_image_ranges(refl, exp)
+                refls_for_sym.append(refl.select(sel))
         else:
             refls_for_sym = reflection_tables
         return refls_for_sym

--- a/test/command_line/test_symmetry.py
+++ b/test/command_line/test_symmetry.py
@@ -85,19 +85,21 @@ def test_symmetry_basis_changes_for_C2(tmpdir):
         )
 
 
-def test_symmetry_with_absences(dials_data, tmpdir):
+@pytest.mark.parametrize("option", ["", "exclude_images=0:1500:1800"])
+def test_symmetry_with_absences(dials_data, tmpdir, option):
     """Simple test to check that dials.symmetry, with absences, completes"""
 
-    result = procrunner.run(
-        [
-            "dials.symmetry",
-            dials_data("l_cysteine_dials_output") / "20_integrated_experiments.json",
-            dials_data("l_cysteine_dials_output") / "20_integrated.pickle",
-            dials_data("l_cysteine_dials_output") / "25_integrated_experiments.json",
-            dials_data("l_cysteine_dials_output") / "25_integrated.pickle",
-        ],
-        working_directory=tmpdir,
-    )
+    cmd = [
+        "dials.symmetry",
+        dials_data("l_cysteine_dials_output") / "20_integrated_experiments.json",
+        dials_data("l_cysteine_dials_output") / "20_integrated.pickle",
+        dials_data("l_cysteine_dials_output") / "25_integrated_experiments.json",
+        dials_data("l_cysteine_dials_output") / "25_integrated.pickle",
+    ]
+    if option:
+        cmd.append(option)
+
+    result = procrunner.run(cmd, working_directory=tmpdir)
     assert not result.returncode and not result.stderr
     assert tmpdir.join("symmetrized.refl").check()
     assert tmpdir.join("symmetrized.expt").check()


### PR DESCRIPTION
@graeme-winter 's full rotation dataset, with this branch (on ws357)

```
time dials.symmetry  ''/dls/tmp/gw56/rerun-prot-k/work/DEFAULT/SAD/SWEEP1/integrate/13_integrated.expt'' ''/dls/tmp/gw56/rerun-prot-k/work/DEFAULT/SAD/SWEEP1/integrate/13_integrated.refl'' 'output.experiments='15_symmetrized.expt'' 'output.reflections='15_symmetrized.refl'' 'relative_length_tolerance=0.05' 'absolute_angle_tolerance=2' 'output.json='15_dials_symmetry.json'' exclude_images="0:7200:28800"

...

Recommended space group: P 41 21 2
Space group with equivalent score (enantiomorphic pair): P 43 21 2
Saving reindexed experiments to 15_symmetrized.expt in space group P 41 21 2
Saving 9017966 reindexed reflections to 15_symmetrized.refl

real	3m51.139s
user	1m33.316s
sys	0m40.116s
```