### PR TITLE
Masks for non-pilatus-like detectors

### DIFF
--- a/newsfragments/536.bugfix
+++ b/newsfragments/536.bugfix
@@ -1,0 +1,2 @@
+Don't use -2 to indicate masked pixels, except for DECTRIS detectors where this
+is to be expected.

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -17,11 +17,13 @@ from ..rstbx_frame import EVT_EXTERNAL_UPDATE
 from ..rstbx_frame import XrayFrame as XFBaseClass
 from rstbx.viewer import settings as rv_settings, image as rv_image
 from wxtbx import bitmaps
+from boost.python import c_sizeof
 
 pyslip._Tiles = tile_generation._Tiles
 
-# Use minimum value for 4 byte int to indicate a masked pixel
-MASK_VAL = -(2 ** 31)
+# Use minimum value for an int to indicate a masked pixel
+int_bits = c_sizeof("int") * 8
+MASK_VAL = -(2 ** (int_bits - 1))
 
 
 class chooser_wrapper(object):

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -20,6 +20,9 @@ from wxtbx import bitmaps
 
 pyslip._Tiles = tile_generation._Tiles
 
+# Use minimum value for 4 byte int to indicate a masked pixel
+MASK_VAL = -(2 ** 31)
+
 
 class chooser_wrapper(object):
     def __init__(self, image_set, index):
@@ -228,10 +231,13 @@ class XrayFrame(XFBaseClass):
                 if possible_intensity is not None:
                     if possible_intensity == 0:
                         format_str = " I=%6.4f"
+                        posn_str += format_str % possible_intensity
+                    elif possible_intensity == MASK_VAL:
+                        posn_str += " I=mask"
                     else:
                         yaya = int(math.ceil(math.log10(abs(possible_intensity))))
                         format_str = " I=%%6.%df" % (max(0, 5 - yaya))
-                    posn_str += format_str % possible_intensity
+                        posn_str += format_str % possible_intensity
 
                 if (
                     len(coords) > 2 and readout >= 0

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -639,9 +639,8 @@ class SpotFrame(XrayFrame):
         # FIXME Currently assuming that all panels are in same plane
         p_id = detector.get_panel_intersection(beam.get_s0())
         if p_id == -1:
-            p_id = (
-                0
-            )  # XXX beam doesn't intersect with any panels - is there a better solution?
+            # XXX beam doesn't intersect with any panels - is there a better solution?
+            p_id = 0
         pan = detector[p_id]
 
         for tt, d, pxl in zip(twotheta, spacings, L_pixels):

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -34,7 +34,7 @@ from wxtbx.phil_controls.intctrl import IntCtrl as PhilIntCtrl
 from wxtbx.phil_controls.ints import IntsCtrl
 from wxtbx.phil_controls.strctrl import StrCtrl
 
-from .slip_viewer.frame import XrayFrame
+from .slip_viewer.frame import XrayFrame, MASK_VAL
 from .viewer_tools import (
     ImageChooserControl,
     ImageCollectionWithSelection,
@@ -639,7 +639,9 @@ class SpotFrame(XrayFrame):
         # FIXME Currently assuming that all panels are in same plane
         p_id = detector.get_panel_intersection(beam.get_s0())
         if p_id == -1:
-            p_id = 0  # XXX beam doesn't intersect with any panels - is there a better solution?
+            p_id = (
+                0
+            )  # XXX beam doesn't intersect with any panels - is there a better solution?
         pan = detector[p_id]
 
         for tt, d, pxl in zip(twotheta, spacings, L_pixels):
@@ -1171,7 +1173,7 @@ class SpotFrame(XrayFrame):
     def mask_raw_data(self, raw_data):
         mask = self.get_mask(self.pyslip.tiles.raw_image)
         for rd, m in zip(raw_data, mask):
-            rd.set_selected(~m, -2)
+            rd.set_selected(~m, MASK_VAL)
 
     def __get_imageset_filter(self, reflections, imageset):
         # type: (flex.reflection_table, ImageSet) -> Optional[flex.bool]


### PR DESCRIPTION
Rather than using -2 to indicate masked pixels for all detectors, set explicitly-masked pixels to `MASK_VAL`. This fixes the problem with valid -2 values being shown as masked in the image viewer (#536). This branch also requires https://github.com/cctbx/cctbx_project/tree/non-pilatus-flags