### PR TITLE
Trim scan

### DIFF
--- a/algorithms/refinement/refiner.py
+++ b/algorithms/refinement/refiner.py
@@ -170,6 +170,7 @@ class RefinerFactory(object):
             "xyzcal.px",
             "xyzobs.mm.variance",
             "flags",
+            "shoebox",
             "delpsical.weights",
         ]
         # NB xyzobs.px.value & xyzcal.px required by SauterPoon outlier rejector

--- a/algorithms/refinement/refiner.py
+++ b/algorithms/refinement/refiner.py
@@ -152,6 +152,75 @@ def _copy_experiments_for_refining(experiments):
     return out_list
 
 
+def _trim_scans_to_observations(experiments, reflections):
+    """Check the range of each scan matches the range of observed data and
+    trim to scan to match if it is too wide"""
+
+    # Get observed image number (or at least observed phi)
+    obs_phi = reflections["xyzobs.mm.value"].parts()[2]
+    try:
+        obs_z = reflections["xyzobs.px.value"].parts()[2]
+    except KeyError:
+        obs_z = None
+
+    # Get z_min and z_max from shoeboxes if present
+    try:
+        shoebox = reflections["shoebox"]
+        bb = shoebox.bounding_boxes()
+        z_min, z_max = bb.parts()[4:]
+        if z_min.all_eq(0):
+            shoebox = None
+    except KeyError:
+        shoebox = None
+
+    for iexp, exp in enumerate(experiments):
+
+        sel = reflections["id"] == iexp
+        isel = sel.iselection()
+        if obs_z is not None:
+            exp_z = obs_z.select(isel)
+        else:
+            exp_phi = obs_phi.select(isel)
+            exp_z = exp.scan.get_array_index_from_angle(exp_phi, deg=False)
+
+        start, stop = exp.scan.get_array_range()
+        min_exp_z = flex.min(exp_z)
+        max_exp_z = flex.max(exp_z)
+
+        # If observed array range is correct, skip to next experiment
+        if int(min_exp_z) == start and int(math.ceil(max_exp_z)) == stop:
+            continue
+
+        # Extend array range either by shoebox size, or 0.5 deg if shoebox not available
+        if shoebox is not None:
+            obs_start = z_min.select(isel)
+            obs_stop = z_max.select(isel)
+            obs_start = obs_start[flex.first_index(exp_z, min_exp_z)]
+            obs_stop = obs_stop[flex.first_index(exp_z, max_exp_z)] + 1
+        else:
+            obs_start = min_exp_z
+            obs_stop = max_exp_z
+            half_deg_in_images = int(math.ceil(0.5 / exp.scan.get_oscillation()[1]))
+            obs_start -= half_deg_in_images
+            obs_stop += half_deg_in_images
+
+        # Convert obs_start, obs_stop from position in array range to integer image number
+        if obs_start > start or obs_stop < stop:
+            im_start = max(start, obs_start + 1)
+            im_stop = min(obs_stop + 1, stop)
+
+            logger.warning(
+                "The reflections do not fill the scan range. The scan will be trimmed "
+                "to images {{{0},{1}}} to match the range of observed data".format(
+                    im_start, im_stop
+                )
+            )
+
+            exp.scan.set_image_range((im_start, im_stop))
+
+    return experiments
+
+
 class RefinerFactory(object):
     """Factory class to create refiners"""
 
@@ -240,8 +309,11 @@ class RefinerFactory(object):
         if params.refinement.parameterisation.scan_varying is libtbx.Auto:
             params.refinement.parameterisation.scan_varying = False
 
-        # calculate reflection block_width if required for scan-varying refinement
+        # Trim scans and calculate reflection block_width if required for scan-varying refinement
         if params.refinement.parameterisation.scan_varying:
+
+            experiments = _trim_scans_to_observations(experiments, reflections)
+
             from dials.algorithms.refinement.reflection_manager import BlockCalculator
 
             block_calculator = BlockCalculator(experiments, reflections)

--- a/algorithms/refinement/refiner.py
+++ b/algorithms/refinement/refiner.py
@@ -154,7 +154,7 @@ def _copy_experiments_for_refining(experiments):
 
 def _trim_scans_to_observations(experiments, reflections):
     """Check the range of each scan matches the range of observed data and
-    trim to scan to match if it is too wide"""
+    trim the scan to match if it is too wide"""
 
     # Get observed image number (or at least observed phi)
     obs_phi = reflections["xyzobs.mm.value"].parts()[2]
@@ -193,21 +193,19 @@ def _trim_scans_to_observations(experiments, reflections):
 
         # Extend array range either by shoebox size, or 0.5 deg if shoebox not available
         if shoebox is not None:
-            obs_start = z_min.select(isel)
-            obs_stop = z_max.select(isel)
-            obs_start = obs_start[flex.first_index(exp_z, min_exp_z)]
-            obs_stop = obs_stop[flex.first_index(exp_z, max_exp_z)] + 1
+            obs_start = flex.min(z_min.select(isel))
+            obs_stop = flex.max(z_max.select(isel))
         else:
-            obs_start = min_exp_z
-            obs_stop = max_exp_z
+            obs_start = int(min_exp_z)
+            obs_stop = int(math.ceil(max_exp_z))
             half_deg_in_images = int(math.ceil(0.5 / exp.scan.get_oscillation()[1]))
             obs_start -= half_deg_in_images
             obs_stop += half_deg_in_images
 
         # Convert obs_start, obs_stop from position in array range to integer image number
         if obs_start > start or obs_stop < stop:
-            im_start = max(start, obs_start + 1)
-            im_stop = min(obs_stop + 1, stop)
+            im_start = max(start, obs_start)
+            im_stop = min(obs_stop, stop)
 
             logger.warning(
                 "The reflections do not fill the scan range. The scan will be trimmed "

--- a/algorithms/refinement/reflection_manager.py
+++ b/algorithms/refinement/reflection_manager.py
@@ -147,10 +147,12 @@ class BlockCalculator(object):
 
         # Extend either by shoebox size, or 0.5 deg if shoebox not available
         if shoeboxes:
-            sb = shoeboxes[flex.first_index(exp_phi, min_phi)]
-            min_phi = scan.get_angle_from_image_index(sb.bbox[4], deg=False)
-            sb = shoeboxes[flex.first_index(exp_phi, max_phi)]
-            max_phi = scan.get_angle_from_image_index(sb.bbox[5] + 1, deg=False)
+            bb = shoeboxes.bounding_boxes()
+            first_im, last_im = bb.parts()[4:]
+            first_im = first_im[flex.first_index(exp_phi, min_phi)]
+            min_phi = scan.get_angle_from_image_index(first_im, deg=False)
+            last_im = last_im[flex.first_index(exp_phi, max_phi)] + 1
+            max_phi = scan.get_angle_from_image_index(last_im, deg=False)
         else:
             min_phi -= 0.008726645
             max_phi += 0.008726645

--- a/algorithms/refinement/reflection_manager.py
+++ b/algorithms/refinement/reflection_manager.py
@@ -178,7 +178,7 @@ class BlockCalculator(object):
         phi_obs = self._reflections["xyzobs.mm.value"].parts()[2]
         try:
             shoebox = self._reflections["shoebox"]
-        except AttributeError:
+        except KeyError:
             shoebox = None
 
         for iexp, exp in enumerate(self._experiments):
@@ -223,7 +223,7 @@ class BlockCalculator(object):
         phi_obs = self._reflections["xyzobs.mm.value"].parts()[2]
         try:
             shoebox = self._reflections["shoebox"]
-        except AttributeError:
+        except KeyError:
             shoebox = None
 
         for iexp, exp in enumerate(self._experiments):

--- a/newsfragments/1025.bugfix
+++ b/newsfragments/1025.bugfix
@@ -1,0 +1,3 @@
+Scan-varying refinement no longer fails when the scan is wider than the
+observed reflections (e.g. when the crystal has died). Instead, the scan
+is first trimmed to match the range of the diffraction.

--- a/test/algorithms/refinement/test_refiner_config.py
+++ b/test/algorithms/refinement/test_refiner_config.py
@@ -10,6 +10,9 @@ from dials.algorithms.refinement import DialsRefineConfigError, RefinerFactory
 from dials.array_family import flex
 from dxtbx.model.experiment_list import ExperimentListFactory
 from libtbx import phil
+from dials.util.slice import slice_reflections
+from dials.algorithms.refinement.refiner import _trim_scans_to_observations
+from copy import deepcopy
 
 
 @pytest.mark.parametrize(
@@ -48,3 +51,51 @@ def test_multi_panel_parameterisations(
             params, reflections, experiments
         )
         assert refiner.experiment_type == "stills"
+
+
+def test_trim_scans_to_observations(dials_data):
+
+    # Use 4 scan data for this test
+    data_dir = dials_data("l_cysteine_dials_output")
+    experiments = ExperimentListFactory.from_json_file(
+        (data_dir / "indexed.expt").strpath, check_format=False
+    )
+    reflections = flex.reflection_table.from_file((data_dir / "indexed.refl").strpath)
+
+    # Check the image range is what we expect
+    image_ranges = [e.scan.get_image_range() for e in experiments]
+    for a, b in zip(image_ranges, [(1, 1700), (1, 1700), (1, 1700), (1, 1800)]):
+        assert a == b
+
+    # If image range unchanged, nothing should happen
+    trim_expt = _trim_scans_to_observations(deepcopy(experiments), reflections)
+    new_ranges = [e.scan.get_image_range() for e in trim_expt]
+    for a, b in zip(image_ranges, new_ranges):
+        assert a == b
+
+    # Slice 20 images off head and tail
+    sliced_ranges = [(r[0] + 20, r[1] - 20) for r in image_ranges]
+    sliced = slice_reflections(reflections, sliced_ranges)
+
+    # Now trimmed scans should have ranges array ranges equal to their min, max
+    # shoebox z coords
+    trim_expt = _trim_scans_to_observations(deepcopy(experiments), sliced)
+    new_ranges = [e.scan.get_image_range() for e in trim_expt]
+
+    for i, e in enumerate(trim_expt):
+        refs = sliced.select(sliced["id"] == i)
+        bb = refs["shoebox"].bounding_boxes()
+        z_min, z_max = bb.parts()[4:]
+        assert new_ranges[i] == (min(z_min), max(z_max))
+
+    # Now delete shoebox data. Trimmed scans will be wider than the observed
+    # range by >0.5 deg at each end
+    del sliced["shoebox"]
+    trim_expt = _trim_scans_to_observations(deepcopy(experiments), sliced)
+    new_ranges = [e.scan.get_image_range() for e in trim_expt]
+    for i, e in enumerate(trim_expt):
+        refs = sliced.select(sliced["id"] == i)
+        z = refs["xyzobs.px.value"].parts()[2]
+        im_width = e.scan.get_oscillation()[1]
+        assert ((min(z) - new_ranges[i][0]) / im_width) > 0.5
+        assert ((new_ranges[i][1] - max(z)) / im_width) > 0.5


### PR DESCRIPTION
For #1025 and xia2/xia2#381, `dials.refine scan_varying=true` will now trim scans to the observed reflection range rather than complain.

@graeme-winter this is the PR you were looking for earlier!