### PR TITLE
Convert sequences to stills on import: delete scan & gonio to make properly stills

### DIFF
--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -318,6 +318,9 @@ class ManualGeometryUpdater(object):
 
         if self.params.geometry.convert_sequences_to_stills:
             imageset = ImageSetFactory.imageset_from_anyset(imageset)
+            for j in imageset.indices():
+                imageset.set_scan(None, j)
+                imageset.set_goniometer(None, j)
         if not isinstance(imageset, ImageSequence):
             if self.params.geometry.convert_stills_to_sequences:
                 imageset = self.convert_stills_to_sequence(imageset)

--- a/newsfragments/1035.bugfix
+++ b/newsfragments/1035.bugfix
@@ -1,0 +1,2 @@
+If convert_sequences_to_stills then delete the goniometer and scan.
+

--- a/test/command_line/test_import.py
+++ b/test/command_line/test_import.py
@@ -285,3 +285,30 @@ def test_extrapolate_scan(dials_data, tmpdir):
     )
     assert not result.returncode
     assert tmpdir.join("import_extrapolate.expt").check(file=1)
+
+
+def test_with_convert_sequences_to_stills(dials_data, tmpdir):
+    # Find the image files
+    image_files = dials_data("centroid_test_data").listdir("centroid*.cbf", sort=True)
+    result = procrunner.run(
+        [
+            "dials.import",
+            "convert_sequences_to_stills=True",
+            "output.experiments=experiments_as_stills.expt",
+        ]
+        + [f.strpath for f in image_files],
+        working_directory=tmpdir.strpath,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("experiments_as_stills.expt").check(file=1)
+
+    experiments = load.experiment_list(
+        tmpdir.join("experiments_as_stills.expt").strpath
+    )
+
+    # should be no goniometers
+    assert experiments.scans() == [None]
+    assert experiments.goniometers() == [None]
+
+    # should be same number of imagesets as images
+    assert len(experiments.imagesets()) == len(image_files)

--- a/test/command_line/test_import.py
+++ b/test/command_line/test_import.py
@@ -312,3 +312,6 @@ def test_with_convert_sequences_to_stills(dials_data, tmpdir):
 
     # should be same number of imagesets as images
     assert len(experiments.imagesets()) == len(image_files)
+
+    # all should call out as still too
+    assert experiments.all_stills()


### PR DESCRIPTION
If convert_sequences_to_stills then delete the goniometer and scan.

At the moment they are imported as a lot of sequences - see discussion in #1030