### PR TITLE
DIALS 2.0.3

### DIFF
--- a/algorithms/profile_model/gaussian_rs/calculator.py
+++ b/algorithms/profile_model/gaussian_rs/calculator.py
@@ -763,7 +763,7 @@ def _select_reflections_for_sigma_calc(reflections, min_number_of_refl=10000):
     from dials.array_family import flex
 
     n_ref = reflections.size()
-    if n_ref > min_number_of_refl:
+    if n_ref >= min_number_of_refl:
         # ideally use well-sampled selection from refinement
         used_in_ref = reflections.get_flags(reflections.flags.used_in_refinement)
         n_used_in_ref = used_in_ref.count(True)

--- a/algorithms/profile_model/gaussian_rs/calculator.py
+++ b/algorithms/profile_model/gaussian_rs/calculator.py
@@ -767,7 +767,7 @@ def _select_reflections_for_sigma_calc(reflections, min_number_of_refl=10000):
         # ideally use well-sampled selection from refinement
         used_in_ref = reflections.get_flags(reflections.flags.used_in_refinement)
         n_used_in_ref = used_in_ref.count(True)
-        if n_used_in_ref > min_number_of_refl:
+        if n_used_in_ref >= min_number_of_refl:
             selected_reflections = reflections.select(used_in_ref)
             logger.debug(
                 "Using %s reflections with used_in_refinement flag for sigma calculation",

--- a/command_line/image_viewer.py
+++ b/command_line/image_viewer.py
@@ -83,6 +83,8 @@ mask = None
 
 include scope rstbx.phil.phil_preferences.iotbx_defs_viewer_detail
 
+include scope dials.util.options.format_phil_scope
+
 masking {
   include scope dials.util.masking.phil_scope
 }

--- a/command_line/spot_counts_per_image.py
+++ b/command_line/spot_counts_per_image.py
@@ -66,7 +66,7 @@ def run(args):
         sys.exit("Only one reflection list may be passed")
     reflections = reflections[0]
     expts = set(reflections["id"])
-    if max(expts) >= len(experiments.imagesets()):
+    if len(expts) and max(expts) >= len(experiments.imagesets()):
         sys.exit("Unknown experiments in reflection list")
 
     if params.id is not None:


### PR DESCRIPTION
* Fix crash in `dials.integrate`
* Fix crash in `dials.spot_counts_per_image` (#1022)
* Fix support for DLS VMXi EIGER 1 4M
* Fix support for DLS I23 data
* Catch an exception if image file has zero bytes
* Enable dynamic shadowing if `dials.image_viewer` is called on image files directly
* xia2: Copy integration results to DataFiles (xia2/xia2#379)
* xia2: Correctly set untrusted regions on multi-panel detectors with XDS pipeline (xia2/xia2#387)
* xia2: Fix crash when running `dials.symmetry` in multisweep mode (xia2/xia2#390)