### PR TITLE
Don't always show saturated pixels

### DIFF
--- a/newsfragments/846.bugfix
+++ b/newsfragments/846.bugfix
@@ -1,0 +1,2 @@
+No longer show pixels that are above the trusted range upper bound as
+"saturated" on the "variance" image.

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -429,6 +429,7 @@ class XrayFrame(XFBaseClass):
             file_name_or_data=img,
             metrology_matrices=self.metrology_matrices,
             get_raw_data=get_raw_data,
+            show_saturated=(self.settings.display != "variance"),
         )
 
         # Initialise position zoom level for first image.  XXX Why do we

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -429,7 +429,7 @@ class XrayFrame(XFBaseClass):
             file_name_or_data=img,
             metrology_matrices=self.metrology_matrices,
             get_raw_data=get_raw_data,
-            show_saturated=(self.settings.display != "variance"),
+            show_saturated=(self.settings.display == "image"),
         )
 
         # Initialise position zoom level for first image.  XXX Why do we

--- a/util/image_viewer/slip_viewer/tile_generation.py
+++ b/util/image_viewer/slip_viewer/tile_generation.py
@@ -256,7 +256,13 @@ class _Tiles(object):
 
         self.show_untrusted = False
 
-    def set_image(self, file_name_or_data, metrology_matrices=None, get_raw_data=None):
+    def set_image(
+        self,
+        file_name_or_data,
+        metrology_matrices=None,
+        get_raw_data=None,
+        show_saturated=True,
+    ):
         self.reset_the_cache()
         if file_name_or_data is None:
             self.raw_image = None
@@ -298,10 +304,14 @@ class _Tiles(object):
                 color_scheme=self.current_color_scheme,
             )
         else:
+            if show_saturated:
+                saturation = self.raw_image.get_detector()[0].get_trusted_range()[1]
+            else:
+                saturation = 1e16
             self.flex_image = _get_flex_image(
                 brightness=self.current_brightness / 100,
                 data=raw_data[0],
-                saturation=self.raw_image.get_detector()[0].get_trusted_range()[1],
+                saturation=saturation,
                 vendortype=self.raw_image.get_vendortype(),
                 show_untrusted=self.show_untrusted,
                 color_scheme=self.current_color_scheme,
@@ -310,7 +320,7 @@ class _Tiles(object):
         if self.zoom_level >= 0:
             self.flex_image.adjust(color_scheme=self.current_color_scheme)
 
-    def set_image_data(self, raw_image_data):
+    def set_image_data(self, raw_image_data, show_saturated=True):
         self.reset_the_cache()
         # XXX Since there doesn't seem to be a good way to refresh the
         # image (yet), the metrology has to be applied here, and not
@@ -329,10 +339,14 @@ class _Tiles(object):
                 beam=self.raw_image.get_beam(),
             )
         else:
+            if show_saturated:
+                saturation = self.raw_image.get_detector()[0].get_trusted_range()[1]
+            else:
+                saturation = 1e16
             self.flex_image = _get_flex_image(
                 brightness=self.current_brightness / 100,
                 data=raw_image_data,
-                saturation=self.raw_image.get_detector()[0].get_trusted_range()[1],
+                saturation=saturation,
                 vendortype=self.raw_image.get_vendortype(),
                 show_untrusted=self.show_untrusted,
             )

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -929,7 +929,7 @@ class SpotFrame(XrayFrame):
 
     def show_filters(self):
         raw_data = self.get_raw_data(self.pyslip.tiles.raw_image)
-        show_saturated = self.settings.display != "variance"
+        show_saturated = self.settings.display == "image"
         self.pyslip.tiles.set_image_data(raw_data, show_saturated)
         self.pyslip.ZoomToLevel(self.pyslip.tiles.zoom_level)
         self.update_statusbar()  # XXX Not always working?

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -639,7 +639,9 @@ class SpotFrame(XrayFrame):
         # FIXME Currently assuming that all panels are in same plane
         p_id = detector.get_panel_intersection(beam.get_s0())
         if p_id == -1:
-            p_id = 0  # XXX beam doesn't intersect with any panels - is there a better solution?
+            p_id = (
+                0
+            )  # XXX beam doesn't intersect with any panels - is there a better solution?
         pan = detector[p_id]
 
         for tt, d, pxl in zip(twotheta, spacings, L_pixels):
@@ -831,7 +833,8 @@ class SpotFrame(XrayFrame):
                 for j, rd in enumerate(raw_data):
                     rd += raw_data_i[j]
 
-            self.pyslip.tiles.set_image_data(raw_data)
+            show_saturated = self.settings.display != "variance"
+            self.pyslip.tiles.set_image_data(raw_data, show_saturated)
 
             self.pyslip.ZoomToLevel(self.pyslip.tiles.zoom_level)
             self.update_statusbar()  # XXX Not always working?
@@ -926,7 +929,8 @@ class SpotFrame(XrayFrame):
 
     def show_filters(self):
         raw_data = self.get_raw_data(self.pyslip.tiles.raw_image)
-        self.pyslip.tiles.set_image_data(raw_data)
+        show_saturated = self.settings.display != "variance"
+        self.pyslip.tiles.set_image_data(raw_data, show_saturated)
         self.pyslip.ZoomToLevel(self.pyslip.tiles.zoom_level)
         self.update_statusbar()  # XXX Not always working?
         self.Layout()

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -833,8 +833,8 @@ class SpotFrame(XrayFrame):
                 for j, rd in enumerate(raw_data):
                     rd += raw_data_i[j]
 
-            show_saturated = self.settings.display != "variance"
-            self.pyslip.tiles.set_image_data(raw_data, show_saturated)
+            # Don't show summed images with overloads
+            self.pyslip.tiles.set_image_data(raw_data, show_saturated=False)
 
             self.pyslip.ZoomToLevel(self.pyslip.tiles.zoom_level)
             self.update_statusbar()  # XXX Not always working?


### PR DESCRIPTION
This PR controls the display of overloaded pixels with a yellow mask so that this only occurs when the display is of `"image"` type (not `"variance"`, fixing #846, or any other type of image). It also switches off this display when > 1 image is being summed.
