### PR TITLE
Prefix logger.warning messages with "WARNING:"

### DIFF
--- a/newsfragments/1050.misc
+++ b/newsfragments/1050.misc
@@ -1,0 +1,3 @@
+Messages at warning level or higher have "WARN:" prepended to them in the
+log file to make them stand out from the usual information
+

--- a/util/log.py
+++ b/util/log.py
@@ -37,18 +37,6 @@ class ElapsedFormatter:
             return elapsed_msg + msg
 
 
-class LevelPrefixFormatter(logging.Formatter):
-    def format(self, record):
-
-        format_orig = self._fmt
-        if record.levelno == logging.WARNING:
-            self._fmt = "WARNING: %(msg)s"
-        result = logging.Formatter.format(self, record)
-        self._fmt = format_orig
-
-        return result
-
-
 def config(verbosity=0, logfile=None):
     """
     Configure the logging.
@@ -66,8 +54,6 @@ def config(verbosity=0, logfile=None):
     else:
         console = logging.StreamHandler(sys.stdout)
 
-    fmt = LevelPrefixFormatter()
-    console.setFormatter(fmt)
     dials_logger = logging.getLogger("dials")
     dials_logger.addHandler(console)
 

--- a/util/log.py
+++ b/util/log.py
@@ -26,7 +26,7 @@ class DialsLogfileFormatter:
         indent = len(prefix)
         msg = record.getMessage()
 
-        if record.levelno == logging.WARNING:
+        if record.levelno >= logging.WARNING:
             prefix = "WARN: "
             prefix = (indent - len(prefix)) * " " + prefix
 

--- a/util/log.py
+++ b/util/log.py
@@ -26,7 +26,7 @@ class ElapsedFormatter:
         indent = len(elapsed_msg)
         msg = record.getMessage()
 
-        if record.levelno == logging.WARNING:
+        if record.levelno >= logging.WARNING:
             msg = "WARNING: " + msg
 
         msg = msg.replace("\n", "\n" + " " * indent)

--- a/util/log.py
+++ b/util/log.py
@@ -12,29 +12,30 @@ except ImportError:
     ColorStreamHandler = None
 
 # https://stackoverflow.com/questions/25194864/python-logging-time-since-start-of-program/25196134#25196134
-class ElapsedFormatter:
+class DialsLogfileFormatter:
     """A formatter for log files that prepends messages with the elapsed time
-    since initialisation and prefixes warning messages with 'WARNING:'"""
+    or messages at warning level or above with 'WARNING:'"""
 
     def __init__(self):
         self.start_time = time.time()
-        self.elapsed_msg = ""
+        self.prefix = ""
 
     def format(self, record):
         elapsed_seconds = record.created - self.start_time
-        elapsed_msg = "{:6.1f}: ".format(elapsed_seconds)
-        indent = len(elapsed_msg)
+        prefix = "{:6.1f}: ".format(elapsed_seconds)
+        indent = len(prefix)
         msg = record.getMessage()
 
-        if record.levelno >= logging.WARNING:
-            msg = "WARNING: " + msg
+        if record.levelno == logging.WARNING:
+            prefix = "WARN: "
+            prefix = (indent - len(prefix)) * " " + prefix
 
         msg = msg.replace("\n", "\n" + " " * indent)
-        if elapsed_msg == self.elapsed_msg:
+        if prefix == self.prefix:
             return " " * indent + msg
         else:
-            self.elapsed_msg = elapsed_msg
-            return elapsed_msg + msg
+            self.prefix = prefix
+            return prefix + msg
 
 
 def config(verbosity=0, logfile=None):
@@ -65,7 +66,7 @@ def config(verbosity=0, logfile=None):
     if logfile:
         fh = logging.FileHandler(filename=logfile, mode="w")
         fh.setLevel(loglevel)
-        fh.setFormatter(ElapsedFormatter())
+        fh.setFormatter(DialsLogfileFormatter())
         dials_logger.addHandler(fh)
 
     dials_logger.setLevel(loglevel)


### PR DESCRIPTION
This is a way of prefixing warning messages and thus make them stand out from general information messages in a consistent way. Draft for comments whether we want this kind of behaviour. This is for #1034. 