### PR TITLE
DIALS 2.0.4

### DIFF
--- a/command_line/reindex.py
+++ b/command_line/reindex.py
@@ -9,7 +9,7 @@ import copy
 from libtbx import easy_pickle
 import iotbx.phil
 from cctbx import sgtbx
-from dxtbx.model import Crystal
+from rstbx.symmetry.constraints import parameter_reduction
 
 # from dials.util.command_line import Importer
 from dials.algorithms.indexing.assign_indices import AssignIndicesGlobal
@@ -121,6 +121,38 @@ def derive_change_of_basis_op(from_hkl, to_hkl):
     assert (change_of_basis_op.apply(from_hkl) == to_hkl).count(False) == 0
 
     return change_of_basis_op
+
+
+def reindex_experiments(experiments, cb_op, space_group=None):
+    reindexed_experiments = copy.deepcopy(experiments)
+
+    for crystal in reindexed_experiments.crystals():
+        cryst_reindexed = copy.deepcopy(crystal)
+        if space_group is not None:
+            # See also https://github.com/cctbx/cctbx_project/issues/424
+            cryst_reindexed.set_space_group(sgtbx.space_group("P 1"))
+            cryst_reindexed = cryst_reindexed.change_basis(cb_op)
+            cryst_reindexed.set_space_group(space_group)
+            S = parameter_reduction.symmetrize_reduce_enlarge(
+                cryst_reindexed.get_space_group()
+            )
+            S.set_orientation(cryst_reindexed.get_B())
+            S.symmetrize()
+            # Cache the scan-varying A matrices if applicable as these get lost
+            # when we call crystal.set_B()
+            A_varying = [
+                cryst_reindexed.get_A_at_scan_point(i)
+                for i in range(cryst_reindexed.num_scan_points)
+            ]
+            # Update the symmetrized B matrix
+            cryst_reindexed.set_B(S.orientation.reciprocal_matrix())
+            # Reapply the scan-varying A matrices
+            cryst_reindexed.set_A_at_scan_points(A_varying)
+        else:
+            cryst_reindexed = cryst_reindexed.change_basis(cb_op)
+        crystal.update(cryst_reindexed)
+
+    return reindexed_experiments
 
 
 def run(args):
@@ -278,28 +310,12 @@ experiments file must also be specified with the option: reference= """
         change_of_basis_op = sgtbx.change_of_basis_op(params.change_of_basis_op)
 
     if len(experiments):
-        for crystal in experiments.crystals():
-            cryst_orig = copy.deepcopy(crystal)
-            cryst_reindexed = cryst_orig.change_basis(change_of_basis_op)
-            if params.space_group is not None:
-                a, b, c = cryst_reindexed.get_real_space_vectors()
-                A_varying = [
-                    cryst_reindexed.get_A_at_scan_point(i)
-                    for i in range(cryst_reindexed.num_scan_points)
-                ]
-                cryst_reindexed = Crystal(
-                    a, b, c, space_group=params.space_group.group()
-                )
-                cryst_reindexed.set_A_at_scan_points(A_varying)
-            crystal.update(cryst_reindexed)
-
-            print("Old crystal:")
-            print(cryst_orig)
-            print()
-            print("New crystal:")
-            print(cryst_reindexed)
-            print()
-
+        space_group = params.space_group
+        if space_group is not None:
+            space_group = space_group.group()
+        experiments = reindex_experiments(
+            experiments, change_of_basis_op, space_group=space_group
+        )
         print("Saving reindexed experimental models to %s" % params.output.experiments)
         experiments.as_file(params.output.experiments)
 

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -6,7 +6,8 @@ import logging
 import random
 import sys
 
-from cctbx import sgtbx
+from cctbx import sgtbx, uctbx
+from cctbx.sgtbx.bravais_types import bravais_lattice
 from cctbx.sgtbx.lattice_symmetry import metric_subgroups
 from libtbx import Auto
 import iotbx.phil
@@ -107,9 +108,32 @@ output {
 )
 
 
-def map_to_minimum_cell(experiments, reflections, max_delta):
+def median_unit_cell(experiments):
+    uc_params = [flex.double() for i in range(6)]
+    for c in experiments.crystals():
+        for i, p in enumerate(c.get_unit_cell().parameters()):
+            uc_params[i].append(p)
+    return uctbx.unit_cell(parameters=[flex.median(p) for p in uc_params])
+
+
+def unit_cells_are_similar_to(
+    experiments, unit_cell, relative_length_tolerance, absolute_angle_tolerance
+):
+    return all(
+        expt.crystal.get_unit_cell().is_similar_to(
+            unit_cell,
+            relative_length_tolerance=relative_length_tolerance,
+            absolute_angle_tolerance=absolute_angle_tolerance,
+        )
+        for expt in experiments
+    )
+
+
+def change_of_basis_ops_to_minimum_cell(
+    experiments, max_delta, relative_length_tolerance, absolute_angle_tolerance
+):
     """
-    Map experiments and reflections to the minimum cell
+    Compute change of basis ops to map experiments to the minimum cell
 
     Map to the minimum cell via the best cell, which appears to guarantee that the
     resulting minimum cells are consistent.
@@ -120,21 +144,60 @@ def map_to_minimum_cell(experiments, reflections, max_delta):
 
     Returns: The experiments and reflections mapped to the minimum cell
     """
-    cb_ops = []
-    for expt, refl in zip(experiments, reflections):
+
+    median_cell = median_unit_cell(experiments)
+    unit_cells_are_similar = unit_cells_are_similar_to(
+        experiments, median_cell, relative_length_tolerance, absolute_angle_tolerance
+    )
+    centring_symbols = [
+        bravais_lattice(group=expt.crystal.get_space_group()).centring_symbol
+        for expt in experiments
+    ]
+    if unit_cells_are_similar and len(set(centring_symbols)) == 1:
         groups = metric_subgroups(
-            expt.crystal.get_crystal_symmetry(),
+            experiments[0]
+            .crystal.get_crystal_symmetry()
+            .customized_copy(unit_cell=median_cell),
             max_delta,
             enforce_max_delta_for_generated_two_folds=True,
         )
         group = groups.result_groups[0]
         cb_op_best_to_min = group["best_subsym"].change_of_basis_op_to_minimum_cell()
-        cb_op_inp_min = cb_op_best_to_min * group["cb_op_inp_best"]
+        cb_ops = [cb_op_best_to_min * group["cb_op_inp_best"]] * len(experiments)
+    else:
+        cb_ops = []
+        for expt in experiments:
+            groups = metric_subgroups(
+                expt.crystal.get_crystal_symmetry(),
+                max_delta,
+                enforce_max_delta_for_generated_two_folds=True,
+            )
+            group = groups.result_groups[0]
+            cb_op_best_to_min = group[
+                "best_subsym"
+            ].change_of_basis_op_to_minimum_cell()
+            cb_op_inp_min = cb_op_best_to_min * group["cb_op_inp_best"]
+            cb_ops.append(cb_op_inp_min)
+    return cb_ops
+
+
+def apply_change_of_basis_ops(experiments, reflections, change_of_basis_ops):
+    """
+    Apply the given change of basis ops to the input experiments and reflections
+
+    Args:
+        experiments (ExperimentList): a list of experiments.
+        reflections (list): a list of reflection tables
+        change_of_basis_ops (list): a list of cctbx.sgtbx.change_of_basis_op
+
+    Returns: The experiments and reflections after application of the change of basis ops
+    """
+
+    for expt, refl, cb_op_inp_min in zip(experiments, reflections, change_of_basis_ops):
         refl["miller_index"] = cb_op_inp_min.apply(refl["miller_index"])
         expt.crystal = expt.crystal.change_basis(cb_op_inp_min)
         expt.crystal.set_space_group(sgtbx.space_group())
-        cb_ops.append(cb_op_inp_min)
-    return experiments, reflections, cb_ops
+    return experiments, reflections
 
 
 def symmetry(experiments, reflection_tables, params=None):
@@ -156,11 +219,18 @@ def symmetry(experiments, reflection_tables, params=None):
         logger.info("Performing Laue group analysis")
         logger.info("")
 
-        # transform models into miller arrays
+        # Transform models into miller arrays
         n_datasets = len(experiments)
 
-        experiments, reflection_tables, cb_ops = map_to_minimum_cell(
-            experiments, reflection_tables, params.lattice_symmetry_max_delta
+        # Map experiments and reflections to minimum cell
+        cb_ops = change_of_basis_ops_to_minimum_cell(
+            experiments,
+            params.lattice_symmetry_max_delta,
+            params.relative_length_tolerance,
+            params.absolute_angle_tolerance,
+        )
+        experiments, reflection_tables = apply_change_of_basis_ops(
+            experiments, reflection_tables, cb_ops
         )
 
         datasets = filtered_arrays_from_experiments_reflections(

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -200,6 +200,25 @@ def apply_change_of_basis_ops(experiments, reflections, change_of_basis_ops):
     return experiments, reflections
 
 
+def eliminate_sys_absent(experiments, reflections):
+    for i, expt in enumerate(experiments):
+        if expt.crystal.get_space_group().n_ltr() > 1:
+            effective_group = expt.crystal.get_space_group().build_derived_reflection_intensity_group(
+                anomalous_flag=True
+            )
+            sys_absent_flags = effective_group.is_sys_absent(
+                reflections[i]["miller_index"]
+            )
+            if sys_absent_flags.count(True):
+                reflections[i] = reflections[i].select(~sys_absent_flags)
+                logger.info(
+                    "Eliminating %i systematic absences for experiment %s",
+                    sys_absent_flags.count(True),
+                    expt.identifier,
+                )
+    return reflections
+
+
 def symmetry(experiments, reflection_tables, params=None):
     """
     Run symmetry analysis
@@ -223,12 +242,16 @@ def symmetry(experiments, reflection_tables, params=None):
         n_datasets = len(experiments)
 
         # Map experiments and reflections to minimum cell
+        # Eliminate reflections that are systematically absent due to centring
+        # of the lattice, otherwise they would lead to non-integer miller indices
+        # when reindexing to a primitive setting
         cb_ops = change_of_basis_ops_to_minimum_cell(
             experiments,
             params.lattice_symmetry_max_delta,
             params.relative_length_tolerance,
             params.absolute_angle_tolerance,
         )
+        reflection_tables = eliminate_sys_absent(experiments, reflection_tables)
         experiments, reflection_tables = apply_change_of_basis_ops(
             experiments, reflection_tables, cb_ops
         )

--- a/newsfragments/1064.bugfix
+++ b/newsfragments/1064.bugfix
@@ -1,0 +1,2 @@
+Eliminate systematic absences before applying change of basis op to minimum 
+cell in dials.symmetry.

--- a/test/command_line/test_cosym.py
+++ b/test/command_line/test_cosym.py
@@ -5,14 +5,11 @@ import pytest
 import procrunner
 
 from cctbx import sgtbx, uctbx
-import scitbx.matrix
 from dxtbx.serialize import load
-from dxtbx.model import Crystal, Experiment
 from dials.array_family import flex
 from dials.algorithms.symmetry.cosym._generate_test_data import (
     generate_experiments_reflections,
 )
-from dials.command_line.cosym import cosym
 
 
 @pytest.mark.parametrize("space_group", [None, "P 1", "P 4"])
@@ -178,20 +175,3 @@ def test_synthetic(
             )
         assert str(expt.crystal.get_space_group().info()) == str(space_group.info())
         assert expt.crystal.get_space_group() == space_group
-
-
-def test_eliminate_sys_absent():
-    refl = flex.reflection_table()
-    refl["miller_index"] = flex.miller_index(
-        [(-31, -5, -3), (-25, -3, -3), (0, 1, 0), (-42, -8, -2)]
-    )
-    sgi = sgtbx.space_group_info("C121")
-    uc = sgi.any_compatible_unit_cell(volume=1000)
-    B = scitbx.matrix.sqr(uc.fractionalization_matrix()).transpose()
-    expt = Experiment(crystal=Crystal(B, space_group=sgi.group(), reciprocal=True))
-    reflections = cosym._eliminate_sys_absent([expt], [refl])
-    assert list(reflections[0]["miller_index"]) == [
-        (-31, -5, -3),
-        (-25, -3, -3),
-        (-42, -8, -2),
-    ]

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -4,6 +4,7 @@ import itertools
 import math
 
 from past.builtins import basestring, unicode
+import six
 
 import wx
 from cctbx import crystal, uctbx
@@ -528,8 +529,8 @@ class SpotFrame(XrayFrame):
 
         # If given a string, we need to load and convert to a chooser_wrapper
         if isinstance(file_name_or_data, basestring):
-            # dxtbx/Boost cannot currently handle unicode here
-            if isinstance(file_name_or_data, unicode):
+            if six.PY2 and isinstance(file_name_or_data, unicode):
+                # dxtbx/Boost cannot currently handle unicode here
                 file_name_or_data = file_name_or_data.encode("utf-8")
             experiments = ExperimentListFactory.from_filenames([file_name_or_data])
             assert len(experiments) == 1


### PR DESCRIPTION
* dials.image_viewer: fix image loading in Python 3
* dials.reindex / dials.symmetry: more robust reindexing when space group is given
* dials.symmetry: fix for multi-sweep centred data sets (#1037)
* dials.symmetry: eliminate systematic absences before applying change of basis op to minimum 
cell (#1064)
