### PR TITLE
Fixes for dials 1029 and 1030

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,69 @@
-Dials 2.0 (2019-10-23)
+DIALS 2.1 (2019-12-12)
+======================
+
+Features
+--------
+
+- We now fully support Python 3 environments.
+- MessagePack is now the default reflection table file format. Temporarily, the
+  environment variable ``DIALS_USE_PICKLE`` can be used to revert to the previous
+  pickle-based format, however this will be removed in a future version. (#986)
+- new option for dials.show 'show_shared_models=True' displays which beam, crystal, and detector models are used across experiments (#996)
+- Import still image sequence as N experiments dereferencing into one image set
+  rather than one experiment. (#1014)
+- Add `reflection_table.get` method for defaulted column access (#1031)
+
+
+Bugfixes
+--------
+
+- Don't use -2 to indicate masked pixels, except for DECTRIS detectors where this
+  is to be expected. (#536)
+- No longer show pixels that are above the trusted range upper bound as
+  "saturated" on the "variance" image. (#846)
+- Correctly account for scan-varying crystals while providing a scan range to
+  dials.integrate (#962)
+- Ensure that generated masks do not include pixels that are overloaded on a few
+  images, but only pixels that are always outside the trusted range. (#978)
+- Rewritten parameter auto-reduction code for dials.refine provides finer-grained
+  fixing of individual parameters rather than whole parameterisations and
+  correctly takes constrained parameters into account (#990)
+- Fix output of predictions in dials.refine.
+  A recently-introduced bug meant that the updated predictions weren't
+  being copied to the output reflections file. (#991)
+- Allow scan-varying refinement where either the crystal cell or
+  orientation is fixed. (#999)
+- Respect batch= option to dials.symmetry - can reduce time taken for finding
+  the symmetry for large data sets. (#1000)
+- Scan-varying refinement no longer fails when the scan is wider than the
+  observed reflections (e.g. when the crystal has died). Instead, the scan
+  is first trimmed to match the range of the diffraction. (#1025)
+- If convert_sequences_to_stills then delete the goniometer and scan. (#1035)
+- Correctly account for scan-varying crystals in dials.slice_sequence (#1040)
+- Eliminate systematic absences before applying change of basis op to minimum 
+  cell in dials.symmetry. (#1064)
+
+
+Improved Documentation
+----------------------
+
+- Add "Extending DIALS" page to developer documentation (#893)
+
+
+Deprecations and Removals
+-------------------------
+
+- The command dials.analyse_output was removed.
+  Its replacement, dials.report, will give you more useful output. (#1009)
+
+
+Misc
+----
+
+- #983, #1004
+
+
+DIALS 2.0 (2019-10-23)
 ======================
 
 Features

--- a/algorithms/indexing/test_index.py
+++ b/algorithms/indexing/test_index.py
@@ -65,11 +65,16 @@ def run_indexing(
     assert out_refls.check()
 
     experiments_list = load.experiment_list(out_expts.strpath, check_format=False)
-    assert len(experiments_list.crystals()) == n_expected_lattices
+    assert (
+        len([c for c in experiments_list.crystals() if c is not None])
+        == n_expected_lattices
+    )
     indexed_reflections = flex.reflection_table.from_file(out_refls.strpath)
     rmsds = None
 
     for i, experiment in enumerate(experiments_list):
+        if experiment.crystal is None:
+            continue
         assert unit_cells_are_similar(
             experiment.crystal.get_unit_cell(),
             expected_unit_cell,

--- a/algorithms/indexing/test_index.py
+++ b/algorithms/indexing/test_index.py
@@ -617,7 +617,11 @@ def test_multiple_experiments(dials_regression, tmpdir):
     expected_hall_symbol = " P 1"
     expected_rmsds = (0.1, 0.07, 0.0)
 
-    extra_args = ["stills.indexer=sequences", "joint_indexing=False"]
+    extra_args = [
+        "stills.indexer=sequences",
+        "joint_indexing=False",
+        "outlier.algorithm=sauter_poon",
+    ]
 
     run_indexing(
         pickle_path,

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -114,6 +114,7 @@ def _index_experiments(experiments, reflections, params, known_crystal_models=No
             params=params,
         )
         idxr.index()
+        assert idxr.refined_reflections.size() > 0
         idx_refl = copy.deepcopy(idxr.refined_reflections)
         idx_refl.extend(idxr.unindexed_reflections)
         return idxr.refined_experiments, idx_refl

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -168,6 +168,11 @@ def index(experiments, reflections, params):
     # using imageset id as an ersatz experiment id
     reflections["origin_id"] = copy.deepcopy(reflections["imageset_id"])
 
+    # legacy size_t map - used to be that the imageset_id table was a size_t
+    # in the datablock days, and this is still exercised in tests...
+    if hasattr(reflections["origin_id"], "as_int"):
+        reflections["origin_id"] = reflections["origin_id"].as_int()
+
     if len(experiments) == 1 or params.indexing.joint_indexing:
         indexed_experiments, indexed_reflections = _index_experiments(
             experiments,
@@ -223,6 +228,7 @@ def index(experiments, reflections, params):
     indexed_reflections["id"].set_selected(
         sel, indexed_reflections["id"] + len(experiments)
     )
+
     indexed_reflections["id"].set_selected(~sel, indexed_reflections["origin_id"])
     experiments.extend(indexed_experiments)
 

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -205,8 +205,11 @@ def index(experiments, reflections, params):
                     if idx_expts is None:
                         indexed_reflections.extend(idx_refl)
                         continue
+                    orig_id = idx_refl["id"].deep_copy()
+                    # Update the experiment ids by incrementing by the number of indexed
+                    # experiments already in the list
                     for j_expt, _ in enumerate(idx_expts):
-                        sel = idx_refl["id"] == j_expt
+                        sel = orig_id == j_expt
                         idx_refl["id"].set_selected(
                             sel, len(indexed_experiments) + j_expt
                         )

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -9,7 +9,6 @@ import sys
 
 import iotbx.phil
 from dxtbx.model.experiment_list import ExperimentList
-from dxtbx.imageset import ImageSetFactory
 from dials.algorithms.indexing import indexer
 from dials.algorithms.indexing import DialsIndexError
 from dials.array_family import flex
@@ -156,19 +155,6 @@ def index(experiments, reflections, params):
             if i > 0:
                 reflections[0].extend(reflections[i])
     reflections = reflections[0]
-
-    # If there are scan and goniometer objects present but the oscillation angle is zero
-    # then expt.scan and expt.goniometer to None, as the behaviour of some downstream
-    # algorithms depend on the presence/absence of these objects
-    for expt in experiments:
-        if (
-            expt.goniometer is not None
-            and expt.scan is not None
-            and expt.scan.is_still()
-        ):
-            expt.imageset = ImageSetFactory.imageset_from_anyset(expt.imageset)
-            expt.goniometer = None
-            expt.scan = None
 
     if params.indexing.image_range:
         reflections = slice_reflections(reflections, params.indexing.image_range)

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -226,14 +226,24 @@ def index(experiments, reflections, params):
                     indexed_reflections.extend(idx_refl)
                     indexed_experiments.extend(idx_expts)
 
-    sel = indexed_reflections["id"] != -1
-    indexed_reflections["id"].set_selected(
-        sel, indexed_reflections["id"] + len(experiments)
-    )
+    # pass through only experiments without crystals
+    input_experiments = ExperimentList()
+    for e in experiments:
+        if e.crystal is None:
+            input_experiments.append(e)
 
-    indexed_reflections["id"].set_selected(~sel, indexed_reflections["origin_id"])
+    # only reassign unindexed reflections to input experiments if there
+    # are input experiments
+    if len(input_experiments):
+        sel = indexed_reflections["id"] != -1
+        indexed_reflections["id"].set_selected(
+            sel, indexed_reflections["id"] + len(input_experiments)
+        )
+
+        indexed_reflections["id"].set_selected(~sel, indexed_reflections["origin_id"])
+
     if indexed_experiments:
-        experiments.extend(indexed_experiments)
+        input_experiments.extend(indexed_experiments)
 
     return experiments, indexed_reflections
 

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -183,7 +183,9 @@ def index(experiments, reflections, params):
             max_workers=params.indexing.nproc
         ) as pool:
             futures = []
+            n_expt = len(experiments)
             for i_expt, expt in enumerate(experiments):
+                logger.info("Indexing experiment %d / %d" % (i_expt, n_expt))
                 refl = reflections.select(reflections["imageset_id"] == i_expt)
                 refl["imageset_id"] = flex.size_t(len(refl), 0)
                 futures.append(

--- a/command_line/show.py
+++ b/command_line/show.py
@@ -45,6 +45,9 @@ show_flags = False
 show_identifiers = False
   .type = bool
   .help = "Show experiment identifiers map if set"
+show_image_statistics = False
+  .type = bool
+  .help = "Deprecated option, please use image_statistics instead"
 image_statistics{
   show_corrected = False
     .type = bool
@@ -214,6 +217,12 @@ def run(args):
         if not all(e.beam for e in experiments):
             sys.exit("Error: experiment has no beam")
         print(show_experiments(experiments, show_scan_varying=params.show_scan_varying))
+
+        if params.show_image_statistics:
+            print(
+                "WARNING: show_image_statistics is deprecated. Please use image_statistics.show_raw or image_statistics.show_corrected instead"
+            )
+            params.image_statistics.show_raw = True
 
         if params.image_statistics.show_raw:
             show_image_statistics(experiments, "raw")

--- a/doc/sphinx/_static/dials-styles.css
+++ b/doc/sphinx/_static/dials-styles.css
@@ -145,3 +145,17 @@ a.button {
 a.button:hover {
   text-decoration:none;
 }
+
+div.twocol {
+  overflow: auto;
+}
+
+div.leftside {
+  height: 80px;
+  padding: 0px 10px 0px 0px;
+  float: left;
+}
+
+div.rightside {
+  margin-left: 10px;
+}

--- a/doc/sphinx/documentation/programs/dials_cosym.rst
+++ b/doc/sphinx/documentation/programs/dials_cosym.rst
@@ -37,20 +37,20 @@ In this case, the unit cell analysis found 1 cluster of 4 datasets in :math:`P\,
 As a result, all datasets will be carried forward for symmetry analysis.
 
 Each dataset is then normalised using maximum likelihood isotropic Wilson scaling,
-reporting an estimated Wilson :math:`B` value and scaled factor for each dataset:
+reporting an estimated Wilson :math:`B` value and scale factor for each dataset:
 
 .. dials_tutorial_include:: multi_crystal/dials.cosym.log
    :start-at: Normalising intensities for dataset
    :end-at: -2.67
 
 A high resolution cutoff is then determined by analysis of CC½ and <I>/<σ(I)> as a
-function of resolution.
+function of resolution:
 
 .. dials_tutorial_include:: multi_crystal/dials.cosym.log
    :start-at: Estimation of resolution
    :end-at: reflections with d
 
-Next, the programs performs automatic determination of the number of dimensions for
+Next, the program performs automatic determination of the number of dimensions for
 analysis. This calculates the functional of equation 2 of
 `Gildea, R. J. & Winter, G. (2018)`_ for each dimension from 2 up to the number of
 symmetry operations in the lattice group. The analysis needs to use sufficient

--- a/doc/sphinx/documentation/tutorials/multi_crystal_symmetry_and_scaling.rst
+++ b/doc/sphinx/documentation/tutorials/multi_crystal_symmetry_and_scaling.rst
@@ -95,7 +95,8 @@ to explore the different steps and address this issue.
 
 Manual reprocessing
 -------------------
-The first step is Laue/Patterson group analysis using :samp:`dials.cosym`:
+The first step is Laue/Patterson group analysis using
+:doc:`dials.cosym <../programs/dials_cosym>`:
 
 .. dials_tutorial_include:: multi_crystal/dials.cosym.cmd
 

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -44,8 +44,15 @@ Mirror sites: `DIALS-East`_, `DIALS-West`_, `dials.github.io`_.
 Funding
 =======
 
-DIALS development at `Diamond Light Source`_ is supported by the `Wellcome Trust`_,
-`Diamond Light Source`_, and `STFC`_ via `CCP4`_.
+DIALS development at `Diamond Light Source`_ is performed by employees of
+`Diamond Light Source`_, and `STFC`_ via `CCP4`_. We are supported by funding
+from `Wellcome`_ for grant 218270/Z/19/Z: *DIALS: making serial crystallography
+data analysis accessible for biomedical researchers.*
+
+.. image:: https://dials.github.io/images/logos/wellcome.png
+    :height: 50px
+    :alt: Wellcome
+    :target: `Wellcome`_
 
 DIALS development at `Lawrence Berkeley National Laboratory`_ is
 supported by `National Institutes of Health`_ / `National Institute of General Medical Sciences`_
@@ -53,7 +60,7 @@ grant R01-GM117126.  Work at LBNL is performed under
 `Department of Energy`_ contract DE-AC02-05CH11231.
 
 .. _`issue`: https://github.com/dials/dials/issues
-.. _`Wellcome Trust`: https://wellcome.ac.uk/
+.. _`Wellcome`: https://wellcome.ac.uk/
 .. _`STFC`: https://stfc.ukri.org/
 .. _`CCP4`: http://www.ccp4.ac.uk/
 .. _`Diamond Light Source`: http://www.diamond.ac.uk/

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -45,14 +45,25 @@ Funding
 =======
 
 DIALS development at `Diamond Light Source`_ is performed by employees of
-`Diamond Light Source`_, and `STFC`_ via `CCP4`_. We are supported by funding
-from `Wellcome`_ for grant 218270/Z/19/Z: *DIALS: making serial crystallography
-data analysis accessible for biomedical researchers.*
+`Diamond Light Source`_, and `STFC`_ via `CCP4`_.
 
-.. image:: https://dials.github.io/images/logos/wellcome.png
-    :height: 50px
-    :alt: Wellcome
-    :target: `Wellcome`_
+.. container:: twocol
+
+   .. container:: leftside
+
+        .. image:: https://dials.github.io/images/logos/wellcome.png
+           :alt: Wellcome
+           :target: `Wellcome`_
+           :height: 70px
+
+   .. container:: rightside
+
+        We are supported by funding
+        from `Wellcome`_ for grant 218270/Z/19/Z: *DIALS: making serial crystallography
+        data analysis accessible for biomedical researchers.*
+
+.. rst-class:: clear-both
+
 
 DIALS development at `Lawrence Berkeley National Laboratory`_ is
 supported by `National Institutes of Health`_ / `National Institute of General Medical Sciences`_

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -39,21 +39,22 @@ For feature requests, bug reports or any other information, please contact
 the DIALS developers at dials-support@lists.sourceforge.net, or post an
 `issue`_.
 
+Mirror sites: `DIALS-East`_, `DIALS-West`_, `dials.github.io`_.
+
 Funding
 =======
 
 DIALS development at `Diamond Light Source`_ is supported by the `Wellcome Trust`_,
-`Diamond Light Source`_, and `CCP4`_.
+`Diamond Light Source`_, and `STFC`_ via `CCP4`_.
 
 DIALS development at `Lawrence Berkeley National Laboratory`_ is
 supported by `National Institutes of Health`_ / `National Institute of General Medical Sciences`_
 grant R01-GM117126.  Work at LBNL is performed under
 `Department of Energy`_ contract DE-AC02-05CH11231.
 
-Mirror sites: `DIALS-East`_, `DIALS-West`_, `dials.github.io`_.
-
 .. _`issue`: https://github.com/dials/dials/issues
 .. _`Wellcome Trust`: https://wellcome.ac.uk/
+.. _`STFC`: https://stfc.ukri.org/
 .. _`CCP4`: http://www.ccp4.ac.uk/
 .. _`Diamond Light Source`: http://www.diamond.ac.uk/
 .. _`Lawrence Berkeley National Laboratory`: http://www.lbl.gov/

--- a/newsfragments/1000.bugfix
+++ b/newsfragments/1000.bugfix
@@ -1,2 +1,0 @@
-Respect batch= option to dials.symmetry - can reduce time taken for finding
-the symmetry for large data sets.

--- a/newsfragments/1004.misc
+++ b/newsfragments/1004.misc
@@ -1,5 +1,0 @@
-Use tabulate in place of libtbx.table_utils:
-- Replace libtbx.table_utils.simple_table with tabulate
-- Replace libtbx.table_utils.format with tabulate
-- Centralise default format for tabulate
-- Default tablefmt="psql"

--- a/newsfragments/1009.removal
+++ b/newsfragments/1009.removal
@@ -1,2 +1,0 @@
-The command dials.analyse_output was removed.
-Its replacement, dials.report, will give you more useful output.

--- a/newsfragments/1014.feature
+++ b/newsfragments/1014.feature
@@ -1,3 +1,0 @@
-Import still image sequence as N experiments dereferencing into one image set
-rather than one experiment.
-

--- a/newsfragments/1025.bugfix
+++ b/newsfragments/1025.bugfix
@@ -1,3 +1,0 @@
-Scan-varying refinement no longer fails when the scan is wider than the
-observed reflections (e.g. when the crystal has died). Instead, the scan
-is first trimmed to match the range of the diffraction.

--- a/newsfragments/1031.feature
+++ b/newsfragments/1031.feature
@@ -1,1 +1,0 @@
-Add `reflection_table.get` method for defaulted column access

--- a/newsfragments/1035.bugfix
+++ b/newsfragments/1035.bugfix
@@ -1,2 +1,0 @@
-If convert_sequences_to_stills then delete the goniometer and scan.
-

--- a/newsfragments/1040.bugfix
+++ b/newsfragments/1040.bugfix
@@ -1,1 +1,0 @@
-Correctly account for scan-varying crystals in dials.slice_sequence

--- a/newsfragments/1064.bugfix
+++ b/newsfragments/1064.bugfix
@@ -1,2 +1,0 @@
-Eliminate systematic absences before applying change of basis op to minimum 
-cell in dials.symmetry.

--- a/newsfragments/536.bugfix
+++ b/newsfragments/536.bugfix
@@ -1,2 +1,0 @@
-Don't use -2 to indicate masked pixels, except for DECTRIS detectors where this
-is to be expected.

--- a/newsfragments/846.bugfix
+++ b/newsfragments/846.bugfix
@@ -1,2 +1,0 @@
-No longer show pixels that are above the trusted range upper bound as
-"saturated" on the "variance" image.

--- a/newsfragments/893.doc
+++ b/newsfragments/893.doc
@@ -1,1 +1,0 @@
-Add "Extending DIALS" page to developer documentation

--- a/newsfragments/962.bugfix
+++ b/newsfragments/962.bugfix
@@ -1,2 +1,0 @@
-Correctly account for scan-varying crystals while providing a scan range to
-dials.integrate

--- a/newsfragments/978.bugfix
+++ b/newsfragments/978.bugfix
@@ -1,2 +1,0 @@
-Ensure that generated masks do not include pixels that are overloaded on a few
-images, but only pixels that are always outside the trusted range.

--- a/newsfragments/983.misc
+++ b/newsfragments/983.misc
@@ -1,5 +1,0 @@
-Allow unicode output in HTML report
-
-Previously, unicode characters in the output from DIALS commands would cause dials.report to exit with an error.  This fixes that, so now DIALS programs can write all the unicode they want.
-
-Μπορῶ νὰ φάω σπασμένα γυαλιὰ χωρὶς νὰ πάθω τίποτα.

--- a/newsfragments/986.feature
+++ b/newsfragments/986.feature
@@ -1,3 +1,0 @@
-MessagePack is now the default reflection table file format. Temporarily, the
-environment variable ``DIALS_USE_PICKLE`` can be used to revert to the previous
-pickle-based format, however this will be removed in a future version.

--- a/newsfragments/990.bugfix
+++ b/newsfragments/990.bugfix
@@ -1,3 +1,0 @@
-Rewritten parameter auto-reduction code for dials.refine provides finer-grained
-fixing of individual parameters rather than whole parameterisations and
-correctly takes constrained parameters into account

--- a/newsfragments/991.bugfix
+++ b/newsfragments/991.bugfix
@@ -1,4 +1,0 @@
-Fix output of predictions in dials.refine.
-A recently-introduced bug meant that the updated predictions weren't
-being copied to the output reflections file.
-

--- a/newsfragments/996.feature
+++ b/newsfragments/996.feature
@@ -1,1 +1,0 @@
-new option for dials.show 'show_shared_models=True' displays which beam, crystal, and detector models are used across experiments

--- a/newsfragments/999.bugfix
+++ b/newsfragments/999.bugfix
@@ -1,2 +1,0 @@
-Allow scan-varying refinement where either the crystal cell or
-orientation is fixed.

--- a/test/command_line/test_cluster_unit_cell.py
+++ b/test/command_line/test_cluster_unit_cell.py
@@ -1,8 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
+import glob
 import os
-
 import pytest
+
+import procrunner
+
+from cctbx import crystal
+from dxtbx.model.experiment_list import ExperimentList, ExperimentListFactory
+from dials.command_line import cluster_unit_cell
 
 
 def test_dials_cluster_unit_cell_command_line(dials_regression, run_in_tmpdir):
@@ -12,32 +18,31 @@ def test_dials_cluster_unit_cell_command_line(dials_regression, run_in_tmpdir):
     data_dir = os.path.join(
         dials_regression, "refinement_test_data", "multi_narrow_wedges"
     )
-    import glob
-
     experiments = glob.glob(os.path.join(data_dir, "data/sweep_*/experiments.json"))
-
-    import procrunner
 
     result = procrunner.run(
         command=["dials.cluster_unit_cell", "plot.show=False"] + experiments,
         print_stdout=False,
     )
     assert not result.returncode
-
-    # print result
     assert os.path.exists("cluster_unit_cell.png")
 
-    from dxtbx.model.experiment_list import ExperimentList, ExperimentListFactory
-    from dials.command_line import cluster_unit_cell
 
+def test_cluster_unit_cell_api(dials_regression):
+    pytest.importorskip("scipy")
+    pytest.importorskip("xfel")
+
+    data_dir = os.path.join(
+        dials_regression, "refinement_test_data", "multi_narrow_wedges"
+    )
     experiments = ExperimentList(
         [
             ExperimentListFactory.from_json_file(expt, check_format=False)[0]
-            for expt in experiments
+            for expt in glob.glob(
+                os.path.join(data_dir, "data/sweep_*/experiments.json")
+            )
         ]
     )
-    from cctbx import crystal
-
     crystal_symmetries = [
         crystal.symmetry(
             unit_cell=expt.crystal.get_unit_cell(),

--- a/test/command_line/test_show.py
+++ b/test/command_line/test_show.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import shutil
 
 import procrunner
 
@@ -412,3 +413,18 @@ def test_dials_show_shared_models(dials_data, capsys):
     stdout, stderr = capsys.readouterr()
     assert not stderr
     assert "Experiment / Models" in stdout
+
+
+def test_dials_show_centroid_test_data_image_zero(dials_data, tmpdir):
+    """Integration test: import image 0; show import / show works"""
+
+    im1 = dials_data("centroid_test_data").join("centroid_0001.cbf").strpath
+    im0 = tmpdir.join("centroid_0000.cbf").strpath
+
+    shutil.copyfile(im1, im0)
+
+    result = procrunner.run(("dials.import", im0), working_directory=tmpdir)
+    assert not result.returncode and not result.stderr
+
+    result = procrunner.run(("dials.show", "imported.expt"), working_directory=tmpdir)
+    assert not result.returncode and not result.stderr

--- a/test/command_line/test_show.py
+++ b/test/command_line/test_show.py
@@ -337,7 +337,7 @@ def test_dials_show_image_statistics(dials_regression):
         dials_regression, "image_examples", "DLS_I23", "germ_13KeV_0001.cbf"
     )
     result = procrunner.run(
-        ["dials.show", "show_image_statistics=true", path],
+        ["dials.show", "image_statistics.show_raw=true", path],
         environment_override={"DIALS_NOBANNER": "1"},
     )
     assert not result.returncode and not result.stderr
@@ -355,7 +355,7 @@ def test_dials_show_image_statistics_with_no_image_data(dials_regression):
         dials_regression, "indexing_test_data", "i04_weak_data", "datablock_orig.json"
     )
     result = procrunner.run(
-        ["dials.show", "show_image_statistics=true", path],
+        ["dials.show", "image_statistics.show_raw=true", path],
         environment_override={"DIALS_NOBANNER": "1"},
     )
     assert result.returncode == 1 and result.stderr


### PR DESCRIPTION
Keep goniometers and scans around if provided in input
Keep input experiments in output from dials.index
Keep experiment id column pointing at input experiment for unindexed reflections