### PR TITLE
Handle selecting a reflection table with experiment identifiers

### DIFF
--- a/array_family/boost_python/flex_reflection_table.cc
+++ b/array_family/boost_python/flex_reflection_table.cc
@@ -580,24 +580,7 @@ namespace dials { namespace af { namespace boost_python {
     return result;
   }
 
-  /**
-   * Extend the identifiers
-   */
-  void reflection_table_extend_identifiers(reflection_table &self,
-                                           const reflection_table &other) {
-    typedef reflection_table::experiment_map_type::const_iterator const_iterator;
-    typedef reflection_table::experiment_map_type::iterator iterator;
-    for (const_iterator it = other.experiment_identifiers()->begin();
-         it != other.experiment_identifiers()->end();
-         ++it) {
-      iterator found = self.experiment_identifiers()->find(it->first);
-      if (found == self.experiment_identifiers()->end()) {
-        (*self.experiment_identifiers())[it->first] = it->second;
-      } else if (it->second != found->second) {
-        throw DIALS_ERROR("Experiment identifiers do not match");
-      }
-    }
-  }
+
 
   /**
    * Select a number of rows from the table via an index array
@@ -609,7 +592,6 @@ namespace dials { namespace af { namespace boost_python {
   T reflection_table_select_rows_index(const T &self,
                                        const af::const_ref<std::size_t> &index) {
     T result = flex_table_suite::select_rows_index<T>(self, index);
-    reflection_table_extend_identifiers(result, self);
     return result;
   }
 
@@ -623,7 +605,6 @@ namespace dials { namespace af { namespace boost_python {
   T reflection_table_select_rows_flags(const T &self,
                                        const af::const_ref<bool> &flags) {
     T result = flex_table_suite::select_rows_flags<T>(self, flags);
-    reflection_table_extend_identifiers(result, self);
     return result;
   }
 
@@ -637,7 +618,7 @@ namespace dials { namespace af { namespace boost_python {
   T reflection_table_select_cols_keys(const T &self,
                                       const af::const_ref<std::string> &keys) {
     T result = flex_table_suite::select_cols_keys<T>(self, keys);
-    reflection_table_extend_identifiers(result, self);
+    flex_table_suite::reflection_table_extend_identifiers(result, self);
     return result;
   }
 
@@ -650,7 +631,7 @@ namespace dials { namespace af { namespace boost_python {
   template <typename T>
   T reflection_table_select_cols_tuple(const T &self, boost::python::tuple keys) {
     T result = flex_table_suite::select_cols_tuple<T>(self, keys);
-    reflection_table_extend_identifiers(result, self);
+    flex_table_suite::reflection_table_extend_identifiers(result, self);
     return result;
   }
 
@@ -658,7 +639,7 @@ namespace dials { namespace af { namespace boost_python {
    * Extend the reflection table
    */
   void reflection_table_extend(reflection_table &self, const reflection_table &other) {
-    reflection_table_extend_identifiers(self, other);
+    flex_table_suite::reflection_table_extend_identifiers(self, other);
     flex_table_suite::extend(self, other);
   }
 
@@ -666,7 +647,7 @@ namespace dials { namespace af { namespace boost_python {
    * Update the reflection table
    */
   void reflection_table_update(reflection_table &self, const reflection_table &other) {
-    reflection_table_extend_identifiers(self, other);
+    flex_table_suite::reflection_table_extend_identifiers(self, other);
     flex_table_suite::update(self, other);
   }
 

--- a/array_family/boost_python/flex_table_suite.h
+++ b/array_family/boost_python/flex_table_suite.h
@@ -16,7 +16,7 @@
 #include <iterator>
 #include <iostream>
 #include <sstream>
-#include <unordered_set>
+#include <set>
 #include <boost/python.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/slice.hpp>
@@ -643,7 +643,7 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
     // Get the id column (if it exists) and make a set of unique values
     if (self.contains("id")){
       af::shared<int> col = result["id"];
-      std::unordered_set<int> new_ids(col.begin(), col.end());
+      std::set<int> new_ids(col.begin(), col.end());
 
       // Copy across identifiers for ids in new table
       typedef typename T::experiment_map_type::const_iterator const_iterator;

--- a/array_family/boost_python/flex_table_suite.h
+++ b/array_family/boost_python/flex_table_suite.h
@@ -751,7 +751,6 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
     for (expt_const_iterator expt = expts.begin(); expt != expts.end(); ++expt) {
 
       std::string identifier = expt->get_identifier();
-      std::cout << identifier << std::endl;
       int id_value = -1;
       for (const_iterator it = self.experiment_identifiers()->begin();
           it != self.experiment_identifiers()->end();

--- a/array_family/boost_python/flex_table_suite.h
+++ b/array_family/boost_python/flex_table_suite.h
@@ -647,11 +647,11 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
 
       // Copy across identifiers for ids in new table
       typedef typename T::experiment_map_type::const_iterator const_iterator;
-      for (const int &i: new_ids){
+      for (std::set<int>::iterator i = new_ids.begin(); i != new_ids.end(); ++i){
         for (const_iterator it = self.experiment_identifiers()->begin();
           it != self.experiment_identifiers()->end();
           ++it) {
-          if (it->first == i){
+          if (it->first == *i){
             (*result.experiment_identifiers())[it->first] = it->second;
           }
         }

--- a/newsfragments/1077.misc
+++ b/newsfragments/1077.misc
@@ -1,0 +1,1 @@
+Add ability to directly select a reflection table subset using an experiment object

--- a/test/array_family/test_identifiers_handling.py
+++ b/test/array_family/test_identifiers_handling.py
@@ -1,0 +1,105 @@
+"""Test for new experiment identifier features"""
+from dials.array_family import flex
+from dxtbx.model import Experiment, ExperimentList
+
+
+def test_selection_identifier_propagation():
+    """
+    If experiment idenfitiers are set, then when selecting on a reflection
+    table, copy across any for the same id.
+
+    If no identifiers are set, then nothing should happen."""
+
+    # Test when identifiers & id column set.
+    refl = flex.reflection_table()
+    refl["id"] = flex.int([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    refl.experiment_identifiers()[0] = "0"
+    refl.experiment_identifiers()[1] = "1"
+    refl.experiment_identifiers()[2] = "2"
+
+    new_refl = refl.select(refl["id"] == 0)
+    assert list(new_refl.experiment_identifiers().keys()) == [0]
+    assert list(new_refl.experiment_identifiers().values()) == ["0"]
+
+    # test with no identifiers set, but there is an id column
+    refl = flex.reflection_table()
+    refl["id"] = flex.int([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    new_refl = refl.select(refl["id"] == 0)
+    assert new_refl.ncols() == 1
+    assert list(new_refl.experiment_identifiers().keys()) == []
+    assert list(new_refl.experiment_identifiers().values()) == []
+
+    # Test selections still work when nothing id related is set.
+    refl = flex.reflection_table()
+    refl["x"] = flex.int([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    new_refl = refl.select(refl["x"] == 0)
+    assert new_refl.ncols() == 1
+    assert list(new_refl.experiment_identifiers().keys()) == []
+    assert list(new_refl.experiment_identifiers().values()) == []
+
+
+def test_select_using_experiment():
+    """
+    want to be able to do:
+    for exp in experiments:
+        refl = reflections.select(exp)
+
+    rather than:
+    for i, _ in enumerate(experiments):
+        refl = reflections.select(refl["id"] == i)
+    """
+    exp1 = Experiment(identifier="1")
+    exp2 = Experiment(identifier="2")
+
+    refl = flex.reflection_table()
+    refl["id"] = flex.int([0, 0, 0, 1, 1, 1])
+    refl["idx"] = flex.int([0, 1, 2, 3, 4, 5])
+    refl.experiment_identifiers()[0] = "0"
+    refl.experiment_identifiers()[1] = "1"
+
+    sel_refl = refl.select(exp1)
+    assert list(sel_refl.experiment_identifiers().keys()) == [1]
+    assert list(sel_refl.experiment_identifiers().values()) == ["1"]
+    assert list(sel_refl["idx"]) == [3, 4, 5]
+
+    # Test returns nothing if no match
+    sel_refl = refl.select(exp2)
+    assert list(sel_refl.experiment_identifiers().keys()) == []
+    assert list(sel_refl.experiment_identifiers().values()) == []
+    assert not sel_refl
+
+    # Test returns nothing if no identifiers set. Thought is that this is
+    # more useful than raising a dxtbx assert error, as it allows handling within
+    # python in case identifiers not set.
+    refl = flex.reflection_table()
+    refl["idx"] = flex.int([0, 1, 2, 3, 4, 5])
+    sel_refl = refl.select(exp1)
+    assert list(sel_refl.experiment_identifiers().keys()) == []
+    assert list(sel_refl.experiment_identifiers().values()) == []
+    assert not sel_refl
+
+
+def test_select_using_experiments():
+    """Test selecting using an experimentlist
+
+    e.g refl = reflections.select(experiments) to select a subset of the
+    data from an experimentlist."""
+
+    refl = flex.reflection_table()
+    refl["id"] = flex.int([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    refl["idx"] = flex.int([0, 1, 2, 3, 4, 5, 6, 7, 8])
+    refl.experiment_identifiers()[0] = "0"
+    refl.experiment_identifiers()[1] = "1"
+    refl.experiment_identifiers()[2] = "2"
+    experiments = ExperimentList(
+        [
+            Experiment(identifier="0"),
+            Experiment(identifier="2"),
+            Experiment(identifier="3"),
+        ]
+    )
+
+    sel_refl = refl.select(experiments)
+    assert list(sel_refl.experiment_identifiers().keys()) == [0, 2]
+    assert list(sel_refl.experiment_identifiers().values()) == ["0", "2"]
+    assert list(sel_refl["idx"]) == [0, 1, 2, 6, 7, 8]

--- a/test/array_family/test_identifiers_handling.py
+++ b/test/array_family/test_identifiers_handling.py
@@ -17,9 +17,9 @@ def test_selection_identifier_propagation():
     refl.experiment_identifiers()[1] = "1"
     refl.experiment_identifiers()[2] = "2"
 
-    new_refl = refl.select(refl["id"] == 0)
-    assert list(new_refl.experiment_identifiers().keys()) == [0]
-    assert list(new_refl.experiment_identifiers().values()) == ["0"]
+    new_refl = refl.select(refl["id"] == 1)
+    assert list(new_refl.experiment_identifiers().keys()) == [1]
+    assert list(new_refl.experiment_identifiers().values()) == ["1"]
 
     # test with no identifiers set, but there is an id column
     refl = flex.reflection_table()

--- a/test/command_line/test_filter_reflections.py
+++ b/test/command_line/test_filter_reflections.py
@@ -11,7 +11,7 @@ def reflections(tmpdir_factory):
     rt = flex.reflection_table.empty_standard(6)
     rt["iobs"] = flex.size_t_range(len(rt))
     rt["panel"] = flex.size_t_range(len(rt))
-    rt["id"] = flex.size_t([0] * 5 + [1])
+    rt["id"] = flex.int([0] * 5 + [1])
     rt["d"] = flex.double([50, 40, 3.0, 2.5, 2.0, 1.0])
     mask1 = flex.bool([True] * 3 + [False] * 3)
     mask2 = flex.bool([True, False] * 3)


### PR DESCRIPTION
This short PR introduces some new functionality for handling reflection table selections when experiment identifiers are set, to form the basis for future work.

As suggested by @dagewa in #902, the experiment identifiers should be updated when making a selection. So for the case of `new_refl = refl.select(selection_array)`, e.g. `new_refl = refl.select(refl["id"] == 0)`,  if `refl` contains an id column and identifiers are set, then the identifiers map is now set in `new_refl`for all ids in `new_refl["id"]`. This differs from the current behaviour, where all of the identifiers are copied across to the new table, which could cause issues later on.

Also implemented are two new select methods, for passing an Experiment or ExperimentList to reflections.select(), to allow
```
for exp in experiments:
    refl = reflections.select(exp)
```
or
```
for elist in experimentlists:
    refl = reflections.select(elist)
```
as opposed to the current motif
```
for i, exp in enumerate(experiments):
     refl = reflections.select(refl["id"] == i)
```
for a reflection table `reflections` containing data from multiple experiments.


