### PR TITLE
Use uuid identifiers post-integration

### DIFF
--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -64,9 +64,12 @@ def prepare_input(params, experiments, reflections):
             params.dataset_selection.exclude_datasets,
             params.dataset_selection.use_datasets,
         )
+        ids = flex.size_t()
+        for r in reflections:
+            ids.extend(r.experiment_identifiers().keys())
         logger.info(
-            "\nDataset unique identifiers for retained datasets are %s \n",
-            list(experiments.identifiers()),
+            "\nDataset ids for retained datasets are: %s \n",
+            ",".join(str(i) for i in ids),
         )
 
     #### Split the reflections tables into a list of reflection tables,
@@ -89,9 +92,10 @@ def prepare_input(params, experiments, reflections):
 
     #### Assign experiment identifiers.
     experiments, reflections = assign_unique_identifiers(experiments, reflections)
-    logger.info(
-        "\nDataset unique identifiers are %s \n", list(experiments.identifiers())
-    )
+    ids = flex.size_t()
+    for r in reflections:
+        ids.extend(r.experiment_identifiers().keys())
+    logger.info("\nDataset ids are: %s \n", ",".join(str(i) for i in ids))
     reflections, experiments = exclude_image_ranges_for_scaling(
         reflections, experiments, params.exclude_images
     )

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -220,9 +220,8 @@ class ScalingModelObserver(Observer):
         active_scalers = getattr(scaler, "active_scalers", False)
         if not active_scalers:
             active_scalers = [scaler]
-        for s in active_scalers:
-            id_ = s.experiment.identifier
-            self.data[id_] = s.experiment.scaling_model.to_dict()
+        for i, s in enumerate(active_scalers):
+            self.data[i] = s.experiment.scaling_model.to_dict()
 
     def make_plots(self):
         """Generate scaling model component plot data."""
@@ -280,15 +279,14 @@ class ScalingOutlierObserver(Observer):
         active_scalers = getattr(scaler, "active_scalers")
         if not active_scalers:
             active_scalers = [scaler]
-        for scaler in active_scalers:
-            id_ = scaler.experiment.identifier
+        for j, scaler in enumerate(active_scalers):
             outlier_isel = scaler.suitable_refl_for_scaling_sel.iselection().select(
                 scaler.outliers
             )
             x, y, z = (
                 scaler.reflection_table["xyzobs.px.value"].select(outlier_isel).parts()
             )
-            self.data[id_] = {
+            self.data[j] = {
                 "x": list(x),
                 "y": list(y),
                 "z": list(z),

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -110,14 +110,18 @@ class ScalingSummaryGenerator(Observer):
         valid_ranges = get_valid_image_ranges(scaling_script.experiments)
         image_ranges = get_image_ranges(scaling_script.experiments)
         msg = []
-        for (img, valid, exp) in zip(
-            image_ranges, valid_ranges, scaling_script.experiments
+        for (img, valid, refl) in zip(
+            image_ranges, valid_ranges, scaling_script.reflections
         ):
             if valid:
                 if len(valid) > 1 or valid[0][0] != img[0] or valid[-1][1] != img[1]:
                     msg.append(
-                        "Excluded images for experiment identifier: %s, image range: %s, limited range: %s"
-                        % (exp.identifier, list(img), list(valid))
+                        "Excluded images for experiment id: %s, image range: %s, limited range: %s"
+                        % (
+                            refl.experiment_identifiers().keys()[0],
+                            list(img),
+                            list(valid),
+                        )
                     )
         if msg:
             msg = ["Summary of image ranges removed:"] + msg

--- a/algorithms/scaling/scale_and_filter.py
+++ b/algorithms/scaling/scale_and_filter.py
@@ -63,6 +63,7 @@ def log_cycle_results(results, scaling_script, filter_script):
     if removal_summary["mode"] == "image_group":
         cycle_results["image_ranges_removed"] = removal_summary["image_ranges_removed"]
     cycle_results["removed_datasets"] = removal_summary["experiments_fully_removed"]
+    cycle_results["removed_ids"] = removal_summary["experiment_ids_fully_removed"]
 
     cycle_results["n_removed"] = filter_script.results_summary["dataset_removal"][
         "n_reflections_removed"
@@ -186,8 +187,8 @@ class AnalysisResults(object):
                     )
                     msg += "  Removed image ranges: \n    %s" % removed
             else:
-                if res["removed_datasets"]:
-                    msg += "  Removed datasets: %s\n" % res["removed_datasets"]
+                if res["removed_ids"]:
+                    msg += "  Removed datasets: %s\n" % res["removed_ids"]
             msg += (
                 "  cumulative %% of reflections removed: %.3f\n"
                 % res["cumul_percent_removed"]

--- a/algorithms/scaling/scaler.py
+++ b/algorithms/scaling/scaler.py
@@ -1210,7 +1210,7 @@ class MultiScalerBase(ScalerBase):
                 n = scaler.scaling_selection.count(True)
                 rows.append(
                     [
-                        i,
+                        scaler.reflection_table.experiment_identifiers().keys()[0],
                         str(n_connected_by_dataset[i]),
                         str(total_indiv_dataset[i]),
                         str(loc_indices.size()),

--- a/algorithms/scaling/scaler.py
+++ b/algorithms/scaling/scaler.py
@@ -1210,7 +1210,7 @@ class MultiScalerBase(ScalerBase):
                 n = scaler.scaling_selection.count(True)
                 rows.append(
                     [
-                        scaler.experiment.identifier,
+                        i,
                         str(n_connected_by_dataset[i]),
                         str(total_indiv_dataset[i]),
                         str(loc_indices.size()),

--- a/algorithms/scaling/scaler_factory.py
+++ b/algorithms/scaling/scaler_factory.py
@@ -71,7 +71,8 @@ class ScalerFactory(object):
         assert experiment.identifier in id_vals, (experiment.identifier, list(id_vals))
         assert len(id_vals) == 1, list(id_vals)
         logger.info(
-            "The experiment identifier for this dataset is %s", experiment.identifier
+            "The experiment id for this dataset is %s.",
+            reflection_table.experiment_identifiers().keys()[0],
         )
 
 
@@ -85,9 +86,7 @@ class SingleScalerFactory(ScalerFactory):
         cls.ensure_experiment_identifier(experiment, reflection_table)
 
         logger.info(
-            "Preprocessing data for scaling. The id assigned to this \n"
-            "dataset is %s, and the scaling model type being applied is %s. \n",
-            list(reflection_table.experiment_identifiers().values())[0],
+            "The scaling model type being applied is %s. \n",
             experiment.scaling_model.id_,
         )
 

--- a/algorithms/scaling/scaling_library.py
+++ b/algorithms/scaling/scaling_library.py
@@ -11,6 +11,7 @@ ExperimentLists.
 from __future__ import absolute_import, division, print_function
 
 import logging
+import uuid
 import pkg_resources
 from copy import deepcopy
 
@@ -26,7 +27,6 @@ from dials.algorithms.scaling.scaling_utilities import (
     calculate_prescaling_correction,
     DialsMergingStatisticsError,
 )
-from dials.util.multi_dataset_handling import get_next_unique_id
 from iotbx import cif, mtz
 from libtbx import phil
 from mock import Mock
@@ -506,11 +506,9 @@ def create_datastructures_for_target_mtz(experiments, mtz_file):
 
     exp = Experiment()
     exp.crystal = deepcopy(experiments[0].crystal)
-    used_ids = experiments.identifiers()
-    unique_id = get_next_unique_id(len(used_ids), used_ids)
-    exp.identifier = str(unique_id)
-    r_t.experiment_identifiers()[unique_id] = str(unique_id)
-    r_t["id"] = flex.int(r_t.size(), unique_id)
+    exp.identifier = str(uuid.uuid4())
+    r_t.experiment_identifiers()[len(experiments)] = exp.identifier
+    r_t["id"] = flex.int(r_t.size(), len(experiments))
 
     # create a new KB scaling model for the target and set as scaled to fix scale
     # for targeted scaling.
@@ -569,10 +567,8 @@ def create_datastructures_for_structural_model(reflections, experiments, cif_fil
     rt["intensity"] = icalc
     rt["miller_index"] = miller_idx
 
-    used_ids = experiments.identifiers()
-    unique_id = get_next_unique_id(len(used_ids), used_ids)
-    exp.identifier = str(unique_id)
-    rt.experiment_identifiers()[unique_id] = str(unique_id)
-    rt["id"] = flex.int(rt.size(), unique_id)
+    exp.identifier = str(uuid.uuid4())
+    rt.experiment_identifiers()[len(experiments)] = exp.identifier
+    rt["id"] = flex.int(rt.size(), len(experiments))
 
     return exp, rt

--- a/algorithms/scaling/test_observers.py
+++ b/algorithms/scaling/test_observers.py
@@ -97,7 +97,7 @@ def test_ScalingModelObserver():
 
     observer = ScalingModelObserver()
     observer.update(scaler1)
-    assert observer.data["0"] == KB_dict
+    assert observer.data[0] == KB_dict
 
     msg = observer.return_model_error_summary()
     assert msg != ""
@@ -123,8 +123,8 @@ def test_ScalingModelObserver():
     multiscaler.active_scalers = [scaler1, scaler2]
     observer.data = {}
     observer.update(multiscaler)
-    assert observer.data["0"] == KB_dict
-    assert observer.data["1"] == KB_dict
+    assert observer.data[0] == KB_dict
+    assert observer.data[1] == KB_dict
 
     mock_func = mock.Mock()
     mock_func.return_value = {"plot": {"layout": {"title": ""}}}
@@ -163,7 +163,7 @@ def test_ScalingOutlierObserver():
     observer = ScalingOutlierObserver()
     observer.update(scaler)
     assert observer.data == {
-        "0": {
+        0: {
             "x": [10],
             "y": [11],
             "z": [12],
@@ -181,7 +181,7 @@ def test_ScalingOutlierObserver():
     with mock.patch("dials.algorithms.scaling.observers.plot_outliers", new=mock_func):
         r = observer.make_plots()
         assert mock_func.call_count == 1
-        assert mock_func.call_args_list == [mock.call(observer.data["0"])]
+        assert mock_func.call_args_list == [mock.call(observer.data[0])]
         assert all(
             i in r["outlier_plots"] for i in ["outlier_plot_0", "outlier_plot_z0"]
         )

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -157,12 +157,12 @@ def test_scale_script_prepare_input():
 
     params, exp, reflections = generate_test_input()
     # Try to use use_datasets when not identifiers set
-    params.dataset_selection.use_datasets = ["0"]
+    params.dataset_selection.use_datasets = [0]
     with pytest.raises(ValueError):
         _ = ScalingAlgorithm(params, exp, reflections)
     # Try to use use_datasets when not identifiers set
     params.dataset_selection.use_datasets = None
-    params.dataset_selection.exclude_datasets = ["0"]
+    params.dataset_selection.exclude_datasets = [0]
     with pytest.raises(ValueError):
         _ = ScalingAlgorithm(params, exp, reflections)
 
@@ -176,7 +176,7 @@ def test_scale_script_prepare_input():
     list2 = ExperimentList().append(exp[1])
     reflections[0].assert_experiment_identifiers_are_consistent(list1)
     reflections[1].assert_experiment_identifiers_are_consistent(list2)
-    params.dataset_selection.use_datasets = ["0"]
+    params.dataset_selection.use_datasets = [0]
     params, exp, script_reflections = prepare_input(params, exp, reflections)
 
     assert len(script_reflections) == 1
@@ -186,8 +186,8 @@ def test_scale_script_prepare_input():
     exp[0].identifier = "0"
     reflections[0].experiment_identifiers()[0] = "0"
     exp[1].identifier = "1"
-    reflections[1].experiment_identifiers()[0] = "1"
-    params.dataset_selection.exclude_datasets = ["0"]
+    reflections[1].experiment_identifiers()[1] = "1"
+    params.dataset_selection.exclude_datasets = [0]
     params, exp, script_reflections = prepare_input(params, exp, reflections)
 
     assert len(script_reflections) == 1
@@ -496,7 +496,10 @@ def test_scale_and_filter_dataset_mode(dials_data, tmpdir):
     assert tmpdir.join("analysis_results.json").check()
     with open(tmpdir.join("analysis_results.json").strpath) as f:
         analysis_results = json.load(f)
-    assert analysis_results["cycle_results"]["1"]["removed_datasets"] == ["4"]
+
+    assert analysis_results["cycle_results"]["1"]["removed_datasets"] == [
+        analysis_results["initial_expids_and_image_ranges"][4][0]
+    ]
 
 
 def test_scale_array(dials_data, tmpdir):

--- a/algorithms/scaling/test_scale_and_filter.py
+++ b/algorithms/scaling/test_scale_and_filter.py
@@ -86,6 +86,7 @@ def test_scale_and_filter_results_logging():
             "mode": "image_group",
             "image_ranges_removed": [[(6, 10), 0]],
             "experiments_fully_removed": [],
+            "experiment_ids_fully_removed": [],
             "n_reflections_removed": 50,
         },
         "mean_cc_half": 80.0,

--- a/command_line/compute_delta_cchalf.py
+++ b/command_line/compute_delta_cchalf.py
@@ -10,7 +10,7 @@ from dials.algorithms.statistics.delta_cchalf import PerImageCChalfStatistics
 from dials.array_family import flex
 from dials.util import Sorry
 from dials.util.exclude_images import exclude_image_ranges_for_scaling
-from dials.util.multi_dataset_handling import select_datasets_on_ids
+from dials.util.multi_dataset_handling import select_datasets_on_identifiers
 
 matplotlib.use("Agg")
 from matplotlib import pylab
@@ -375,7 +375,6 @@ class Script(object):
                 exp_id, image_range = image_group_to_expid_and_range[
                     id_
                 ]  # numerical id
-                identifier = reflections.experiment_identifiers()[exp_id]
                 if (
                     expid_to_image_groups[exp_id][-1] == id_
                     or expid_to_image_groups[exp_id][0] == id_
@@ -384,11 +383,11 @@ class Script(object):
                     logger.info(
                         "Removing image range %s from experiment %s",
                         image_range,
-                        identifier,
+                        exp_id,
                     )
                     exclude_images.append(
                         [
-                            identifier
+                            str(exp_id)
                             + ":"
                             + str(image_range[0])
                             + ":"
@@ -405,11 +404,10 @@ class Script(object):
             ids_to_remove = other_potential_ids_to_remove
         for id_ in other_potential_ids_to_remove:
             exp_id, image_range = image_group_to_expid_and_range[id_]
-            identifier = reflections.experiment_identifiers()[exp_id]
             logger.info(
                 """Image range %s from experiment %s is below the cutoff, but not at the edge of a sweep.""",
                 image_range,
-                identifier,
+                exp_id,
             )
 
         # Now remove individual batches
@@ -443,7 +441,7 @@ class Script(object):
             ):  # if all removed above
                 experiments_to_delete.append(exp.identifier)
         if experiments_to_delete:
-            experiments, reflection_list = select_datasets_on_ids(
+            experiments, reflection_list = select_datasets_on_identifiers(
                 experiments, reflection_list, exclude_datasets=experiments_to_delete
             )
         assert len(reflection_list) == len(experiments)

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -13,7 +13,7 @@ from dials.command_line.symmetry import (
 )
 from dials.array_family import flex
 from dials.util import show_mail_on_error, Sorry
-from dials.util.options import flatten_experiments, flatten_reflections
+from dials.util.options import reflections_and_experiments_from_files
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
     parse_multiple_datasets,
@@ -328,8 +328,9 @@ def run(args):
         parser.print_help()
         sys.exit()
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     reflections = parse_multiple_datasets(reflections)
     if len(experiments) != len(reflections):

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -17,7 +17,7 @@ from dials.util.options import flatten_experiments, flatten_reflections
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
     parse_multiple_datasets,
-    select_datasets_on_ids,
+    select_datasets_on_identifiers,
 )
 from dials.util.observer import Subject
 from dials.util.filter_reflections import filtered_arrays_from_experiments_reflections
@@ -93,6 +93,12 @@ class cosym(Subject):
         self._experiments, self._reflections = self._filter_min_reflections(
             experiments, reflections
         )
+        self.ids_to_identifiers_map = {}
+        for table in self._reflections:
+            self.ids_to_identifiers_map.update(table.experiment_identifiers())
+        self.identifiers_to_ids_map = {
+            value: key for key, value in self.ids_to_identifiers_map.items()
+        }
 
         if len(self._experiments) > 1:
             # perform unit cell clustering
@@ -103,7 +109,7 @@ class cosym(Subject):
                     len(identifiers),
                     str(identifiers),
                 )
-                self._experiments, self._reflections = select_datasets_on_ids(
+                self._experiments, self._reflections = select_datasets_on_identifiers(
                     self._experiments, self._reflections, use_datasets=identifiers
                 )
 
@@ -225,7 +231,7 @@ class cosym(Subject):
             if len(refl) >= self.params.min_reflections:
                 identifiers.append(expt.identifier)
 
-        return select_datasets_on_ids(
+        return select_datasets_on_identifiers(
             experiments, reflections, use_datasets=identifiers
         )
 
@@ -234,7 +240,10 @@ class cosym(Subject):
         crystal_symmetries = [
             expt.crystal.get_crystal_symmetry() for expt in experiments
         ]
-        lattice_ids = experiments.identifiers()
+        # lattice ids used to label plots, so want numerical ids
+        lattice_ids = [
+            self.identifiers_to_ids_map[i] for i in experiments.identifiers()
+        ]
 
         ucs = UnitCellCluster.from_crystal_symmetries(
             crystal_symmetries, lattice_ids=lattice_ids
@@ -257,7 +266,8 @@ class cosym(Subject):
                 largest_cluster_lattice_ids = cluster_lattice_ids
 
         dataset_selection = largest_cluster_lattice_ids
-        return dataset_selection
+        # now convert to actual identifiers for selection
+        return [self.ids_to_identifiers_map[i] for i in dataset_selection]
 
 
 help_message = """

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -8,7 +8,7 @@ import logging
 import sys
 
 from dials.util import log, show_mail_on_error, Sorry
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 from dials.util.export_mtz import match_wavelengths
 from dials.algorithms.merging.merge import (
@@ -126,8 +126,9 @@ def run(args=None):
         parser.print_help()
         sys.exit()
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     log.config(verbosity=options.verbose, logfile=params.output.log)
     logger.info(dials_version())

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -39,7 +39,7 @@ import sys
 from libtbx import phil
 from six.moves import cStringIO as StringIO
 from dials.util import log, show_mail_on_error, Sorry
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 from dials.algorithms.scaling.algorithm import ScalingAlgorithm, ScaleAndFilterAlgorithm
 from dials.algorithms.scaling.observers import (
@@ -217,8 +217,9 @@ def run(args=None, phil=phil_scope):  # type: (List[str], phil.scope) -> None
         parser.print_help()
         sys.exit()
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     log.config(verbosity=options.verbose, logfile=params.output.log)
     logger.info(dials_version())

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -15,7 +15,7 @@ import iotbx.phil
 
 from dials.array_family import flex
 from dials.util import log, show_mail_on_error
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
@@ -473,8 +473,9 @@ def run(args=None):
         parser.print_help()
         sys.exit()
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     reflections = parse_multiple_datasets(reflections)
 

--- a/test/command_line/test_assign_experiment_identifiers.py
+++ b/test/command_line/test_assign_experiment_identifiers.py
@@ -37,9 +37,9 @@ def test_assign_identifiers(dials_data, run_in_tmpdir):
     r = flex.reflection_table.from_file("assigned.refl")
     e = load.experiment_list("assigned.expt", check_format=False)
     r.assert_experiment_identifiers_are_consistent(e)
-    assert list(r.experiment_identifiers().values()) == ["0", "1"]
+    assert list(r.experiment_identifiers().values()) != ["", ""]
     assert list(r.experiment_identifiers().keys()) == [0, 1]
-    assert list(e.identifiers()) == ["0", "1"]
+    assert list(e.identifiers()) == list(r.experiment_identifiers().values())
 
     # now run again, with already assigned data
     pickle_path_list = ["assigned.refl"]
@@ -49,9 +49,9 @@ def test_assign_identifiers(dials_data, run_in_tmpdir):
     r = flex.reflection_table.from_file("assigned.refl")
     e = load.experiment_list("assigned.expt", check_format=False)
     r.assert_experiment_identifiers_are_consistent(e)
-    assert list(r.experiment_identifiers().values()) == ["0", "1"]
+    assert list(r.experiment_identifiers().values()) != ["", ""]
     assert list(r.experiment_identifiers().keys()) == [0, 1]
-    assert list(e.identifiers()) == ["0", "1"]
+    assert list(e.identifiers()) == list(r.experiment_identifiers().values())
 
     # now run again, with adding more data
     pickle_path_list = ["assigned.refl"]

--- a/test/util/test_exclude_images.py
+++ b/test/util/test_exclude_images.py
@@ -30,20 +30,25 @@ def make_scanless_experiment(expid="1"):
 def test_parse_exclude_images_commands():
     """Test for namesake function"""
     commands = [["1:101:200"], ["0:201:300"]]
-    ranges = _parse_exclude_images_commands(commands, [])
+    r1 = flex.reflection_table()
+    r1.experiment_identifiers()[1] = "1"
+    r0 = flex.reflection_table()
+    r0.experiment_identifiers()[0] = "0"
+    tables = [r0, r1]
+    ranges = _parse_exclude_images_commands(commands, [], tables)
     assert ranges == [("1", (101, 200)), ("0", (201, 300))]
     experiments = ["1", "2"]
     short_command = [["101:200"]]
     with pytest.raises(ValueError):
-        _ = _parse_exclude_images_commands(short_command, experiments)
+        _ = _parse_exclude_images_commands(short_command, experiments, tables)
     mock_exp = Mock()
     mock_exp.identifier = "1"
-    ranges = _parse_exclude_images_commands(short_command, [mock_exp])
+    ranges = _parse_exclude_images_commands(short_command, [mock_exp], tables)
     assert ranges == [("1", (101, 200))]
     with pytest.raises(ValueError):
-        _ = _parse_exclude_images_commands([["1:101-200"]], [mock_exp])
+        _ = _parse_exclude_images_commands([["1:101-200"]], [mock_exp], tables)
     with pytest.raises(ValueError):
-        _ = _parse_exclude_images_commands([["1:101:a"]], [])
+        _ = _parse_exclude_images_commands([["1:101:a"]], [], tables)
 
 
 def test_set_get_initial_valid_image_ranges():
@@ -63,18 +68,23 @@ def test_exclude_image_ranges_from_scans():
         [make_scan_experiment(expid="0"), make_scan_experiment(expid="1")]
     )
     exclude_images = [["0:81:100"], ["1:61:80"]]
-    explist = exclude_image_ranges_from_scans(explist, exclude_images)
+    r1 = flex.reflection_table()
+    r1.experiment_identifiers()[1] = "1"
+    r0 = flex.reflection_table()
+    r0.experiment_identifiers()[0] = "0"
+    tables = [r0, r1]
+    explist = exclude_image_ranges_from_scans(tables, explist, exclude_images)
     assert list(explist[0].scan.get_valid_image_ranges("0")) == [(1, 80)]
     assert list(explist[1].scan.get_valid_image_ranges("1")) == [(1, 60), (81, 100)]
     # Try excluding a range that already has been excluded
-    explist = exclude_image_ranges_from_scans(explist, [["1:70:80"]])
+    explist = exclude_image_ranges_from_scans(tables, explist, [["1:70:80"]])
     assert list(explist[0].scan.get_valid_image_ranges("0")) == [(1, 80)]
     assert list(explist[1].scan.get_valid_image_ranges("1")) == [(1, 60), (81, 100)]
     scanlessexplist = ExperimentList([make_scanless_experiment()])
     with pytest.raises(ValueError):
-        _ = exclude_image_ranges_from_scans(scanlessexplist, [["0:1:100"]])
+        _ = exclude_image_ranges_from_scans(tables, scanlessexplist, [["0:1:100"]])
     # Now try excluding everything, should set an empty array
-    explist = exclude_image_ranges_from_scans(explist, [["1:1:100"]])
+    explist = exclude_image_ranges_from_scans(tables, explist, [["1:1:100"]])
     assert list(explist[0].scan.get_valid_image_ranges("0")) == [(1, 80)]
     assert list(explist[1].scan.get_valid_image_ranges("1")) == []
 
@@ -101,13 +111,15 @@ def test_exclude_image_ranges_for_scaling():
     )
     refl1.set_flags(flex.bool(5, False), refl1.flags.user_excluded_in_scaling)
     refl2 = copy.deepcopy(refl1)
+    refl1.experiment_identifiers()[0] = "0"
+    refl2.experiment_identifiers()[1] = "1"
     explist = ExperimentList(
         [
             make_scan_experiment(image_range=(2, 20), expid="0"),
             make_scan_experiment(image_range=(2, 20), expid="1"),
         ]
     )
-    refls, exps = exclude_image_ranges_for_scaling(
+    refls, explist = exclude_image_ranges_for_scaling(
         [refl1, refl2], explist, [["1:11:20"]]
     )
     assert list(explist[0].scan.get_valid_image_ranges("0")) == [(2, 20)]

--- a/test/util/test_multi_dataset_handling.py
+++ b/test/util/test_multi_dataset_handling.py
@@ -136,30 +136,22 @@ def test_assignment_of_unique_identifiers_when_refl_table_ids_are_present(
     experiments, reflections
 ):
     assert list(experiments.identifiers()) == ["", "", ""]
-    exp, rts = assign_unique_identifiers(experiments, reflections)
-    expected_identifiers = ["0", "1", "2"]
-    expected_ids = [0, 1, 2]
-    # Check that identifiers are set in experiments and reflection table.
-    assert list(exp.identifiers()) == expected_identifiers
-    for i, refl in enumerate(rts):
-        assert refl.experiment_identifiers()[i] == expected_identifiers[i]
+    expts, rts = assign_unique_identifiers(experiments, reflections)
+    for i, (expt, refl) in enumerate(zip(expts, rts)):
         assert set(refl["id"]) == {i}
-        assert i == expected_ids[i]
+        assert expt.identifier != ""
+        assert refl.experiment_identifiers()[i] == expt.identifier
 
 
 def test_assign_identifiers_where_none_are_set_but_refl_table_ids_have_duplicates(
     experiments, reflections
 ):
     reflections[2]["id"] = flex.int([0, 0])
-    exp, rts = assign_unique_identifiers(experiments, reflections)
-    expected_identifiers = ["0", "1", "2"]
-    # Check that identifiers are set in experiments and reflection table.
-    assert list(exp.identifiers()) == expected_identifiers
-    expected_ids = [0, 1, 2]
-    for i, refl in enumerate(rts):
-        assert refl.experiment_identifiers()[i] == expected_identifiers[i]
+    expts, rts = assign_unique_identifiers(experiments, reflections)
+    for i, (expt, refl) in enumerate(zip(expts, rts)):
         assert set(refl["id"]) == {i}
-        assert i == expected_ids[i]
+        assert expt.identifier != ""
+        assert refl.experiment_identifiers()[i] == expt.identifier
 
 
 def test_raise_exception_when_existing_identifiers_are_inconsistent(
@@ -168,7 +160,7 @@ def test_raise_exception_when_existing_identifiers_are_inconsistent(
     reflections[1].experiment_identifiers()[0] = "5"
     # should raise an assertion error for inconsistent identifiers
     with pytest.raises(ValueError):
-        exp, rts = assign_unique_identifiers(experiments_024, reflections)
+        _, __ = assign_unique_identifiers(experiments_024, reflections)
 
 
 def test_cases_where_all_set_whether_reflection_table_is_split_or_not(
@@ -197,7 +189,7 @@ def test_raise_exception_if_unequal_experiments_and_reflections(experiments_024)
     del reflections_multi[0].experiment_identifiers()[4]
     del reflections_multi[0]["id"][2]
     with pytest.raises(ValueError):
-        exp, rts = assign_unique_identifiers(experiments_024, reflections_multi)
+        _, __ = assign_unique_identifiers(experiments_024, reflections_multi)
 
 
 def test_assigned_identifiers_are_kept_when_assigning_rest(experiments, reflections):
@@ -205,15 +197,12 @@ def test_assigned_identifiers_are_kept_when_assigning_rest(experiments, reflecti
     # set for the rest
     experiments[0].identifier = "1"
     reflections[0].experiment_identifiers()[0] = "1"
-    exp, rts = assign_unique_identifiers(experiments, reflections)
-    expected_identifiers = ["1", "0", "2"]
-    assert list(exp.identifiers()) == expected_identifiers
-    expected_ids = [0, 1, 2]
-    for i, refl in enumerate(rts):
-        id_ = refl["id"][0]
-        assert refl.experiment_identifiers()[id_] == expected_identifiers[i]
-        assert set(refl["id"]) == {id_}
-        assert id_ == expected_ids[i]
+    expts, rts = assign_unique_identifiers(experiments, reflections)
+    assert expts.identifiers()[0] == "1"
+    for i, (expt, refl) in enumerate(zip(expts, rts)):
+        assert set(refl["id"]) == {i}
+        assert expt.identifier != ""
+        assert refl.experiment_identifiers()[i] == expt.identifier
 
 
 def test_assigning_specified_identifiers(experiments, reflections):

--- a/test/util/test_multi_dataset_handling.py
+++ b/test/util/test_multi_dataset_handling.py
@@ -56,7 +56,7 @@ def reflections_024(reflections):
 
 
 def test_select_specific_datasets_using_id(experiments_024, reflections_024):
-    use_datasets = ["0", "2"]
+    use_datasets = [0, 1]
     experiments, refl = select_datasets_on_ids(
         experiments_024, reflections_024, use_datasets=use_datasets
     )
@@ -91,7 +91,7 @@ def test_raise_exception_when_excluding_non_existing_dataset(
 ):
     with pytest.raises(ValueError):
         experiments, refl = select_datasets_on_ids(
-            experiments_024, reflections_024, exclude_datasets=["1"]
+            experiments_024, reflections_024, exclude_datasets=["3"]
         )
 
 
@@ -126,7 +126,9 @@ def test_correct_handling_with_multi_dataset_table(experiments_024):
     reflections.experiment_identifiers()[1] = "2"
     reflections.experiment_identifiers()[2] = "4"
     exp, refl = select_datasets_on_ids(
-        experiments_024, [reflections], exclude_datasets=["2"]
+        experiments_024,
+        [reflections],
+        exclude_datasets=["1"],  # i.e. the second dataset
     )
     assert list(refl[0].experiment_identifiers().values()) == ["0", "4"]
     assert list(refl[0]["id"]) == [0, 2]

--- a/util/exclude_images.py
+++ b/util/exclude_images.py
@@ -21,12 +21,14 @@ phil_scope = iotbx.phil.parse(
 )
 
 
-def exclude_image_ranges_from_scans(experiments, exclude_images):
+def exclude_image_ranges_from_scans(reflections, experiments, exclude_images):
     """Using an exclude_images phil option, modify the valid image ranges for each
     experiment in the scan (if it exists). Requires experiment identifiers to be
     set already."""
     experiments = set_initial_valid_image_ranges(experiments)
-    ranges_to_remove = _parse_exclude_images_commands(exclude_images, experiments)
+    ranges_to_remove = _parse_exclude_images_commands(
+        exclude_images, experiments, reflections
+    )
     experiments = _remove_ranges_from_valid_image_ranges(experiments, ranges_to_remove)
     return experiments
 
@@ -73,19 +75,22 @@ def get_selection_for_valid_image_ranges(reflection_table, experiment):
     return flex.bool(reflection_table.size(), True)  # else say all valid
 
 
-def _parse_exclude_images_commands(commands, experiments):
+def _parse_exclude_images_commands(commands, experiments, reflections):
     """Parse a list of list of command line options.
 
     e.g. commands = [['1:101:200'], ['0:201:300']]
     or commands = [[101:200]] allowable for a single experiment.
-    builds and returns a list of tuples (exp_id, (start, stop))"""
+    builds and returns a list of tuples (exp_id, (start, stop))
+
+
+    """
     ranges_to_remove = []
     for com in commands:
         vals = com[0].split(":")
         if len(vals) == 2:
             if len(experiments) > 1:
                 raise ValueError(
-                    "Exclude images must be in the form exp:start:stop for multiple experiments"
+                    "Exclude images must be in the form experimentnumber:start:stop for multiple experiments"
                 )
             else:
                 ranges_to_remove.append(
@@ -94,9 +99,15 @@ def _parse_exclude_images_commands(commands, experiments):
         else:
             if len(vals) != 3:
                 raise ValueError(
-                    "Exclude images must be input in the form exp:start:stop, or start:stop for a single experiment"
+                    "Exclude images must be input in the form experimentnumber:start:stop, or start:stop for a single experiment"
                 )
-            ranges_to_remove.append((vals[0], (int(vals[1]), int(vals[2]))))
+            dataset_id = int(vals[0])
+            for table in reflections:
+                if dataset_id in table.experiment_identifiers():
+                    expid = table.experiment_identifiers()[dataset_id]
+                    ranges_to_remove.append((expid, (int(vals[1]), int(vals[2]))))
+                    break
+
     return ranges_to_remove
 
 
@@ -104,8 +115,10 @@ def _remove_ranges_from_valid_image_ranges(experiments, ranges_to_remove):
     """Update the valid_image_ranges for each experiment in the scans. Uses set
     arithmetic to determine image ranges to keep and sets a new list of ranges in
     the scan.valid_image_ranges dict."""
+    ids = list(experiments.identifiers())
     for r in ranges_to_remove:
-        exp = experiments[experiments.find(r[0])]
+        idx = ids.index(r[0])
+        exp = experiments[idx]
         if not exp.scan:
             raise ValueError("Trying to exclude a scanless experiment")
         current_range = exp.scan.get_valid_image_ranges(
@@ -152,7 +165,9 @@ Functions for scaling
 def exclude_image_ranges_for_scaling(reflections, experiments, exclude_images):
     """Set the initial valid ranges, then exclude in the exp.scan and set
     user_excluded_in_scaling flags."""
-    experiments = exclude_image_ranges_from_scans(experiments, exclude_images)
+    experiments = exclude_image_ranges_from_scans(
+        reflections, experiments, exclude_images
+    )
     for refl, exp in zip(reflections, experiments):
         sel = get_selection_for_valid_image_ranges(refl, exp)
         refl.set_flags(~sel, refl.flags.user_excluded_in_scaling)

--- a/util/filter_reflections.py
+++ b/util/filter_reflections.py
@@ -180,10 +180,7 @@ def filtered_arrays_from_experiments_reflections(
                 intensity_to_use = "intensity.prf"
 
         try:
-            logger.info(
-                "Filtering reflections for dataset %s"
-                % (expt.identifier if expt.identifier else idx)
-            )
+            logger.info("Filtering reflections for dataset %s" % idx)
             refl = filter_reflection_table(
                 refl,
                 intensity_choice,

--- a/util/multi_dataset_handling.py
+++ b/util/multi_dataset_handling.py
@@ -264,6 +264,11 @@ def select_datasets_on_ids(
     if exclude_datasets:
         identifiers_to_exclude = []
         for k in exclude_datasets:
+            if int(k) not in id_map:
+                raise ValueError(
+                    """Attempting to select datasets based on identifiers that
+are not found in the experiment list / reflection tables."""
+                )
             identifiers_to_exclude.append(id_map[int(k)])
         return select_datasets_on_identifiers(
             experiments, reflection_table_list, exclude_datasets=identifiers_to_exclude
@@ -271,6 +276,11 @@ def select_datasets_on_ids(
     elif use_datasets:
         identifiers_to_use = []
         for k in use_datasets:
+            if int(k) not in id_map:
+                raise ValueError(
+                    """Attempting to select datasets based on identifiers that
+are not found in the experiment list / reflection tables."""
+                )
             identifiers_to_use.append(id_map[int(k)])
         return select_datasets_on_identifiers(
             experiments, reflection_table_list, use_datasets=identifiers_to_use

--- a/util/multi_dataset_handling.py
+++ b/util/multi_dataset_handling.py
@@ -179,22 +179,6 @@ def parse_multiple_datasets(reflections):
     return single_reflection_tables
 
 
-def get_next_unique_id(unique_id, used_ids):
-    """
-    Test a list of used id strings to see if it contains str(unique_id)
-
-    Args:
-        unique_id (int): Integer value to be converted to str
-        used_ids (list): A list of strings
-
-    Returns:
-        (int): The lowest int >= unique_id for which str(int) is not in used_ids
-    """
-    while str(unique_id) in used_ids:
-        unique_id += 1
-    return unique_id
-
-
 def assign_unique_identifiers(experiments, reflections, identifiers=None):
     """
     Assign unique experiment identifiers to experiments and reflections lists.
@@ -249,14 +233,11 @@ def assign_unique_identifiers(experiments, reflections, identifiers=None):
     if len(set(used_str_ids)) != len(reflections):
         # if not all set, then need to fill in the rest. Keep the identifier if
         # it is already set, and reset table id column from 0..n-1
-        unique_id = 0
         for i, (exp, refl) in enumerate(zip(experiments, reflections)):
             if exp.identifier == "":
-                unique_id = get_next_unique_id(unique_id, used_str_ids)
-                strid = "%i" % unique_id
+                strid = str(uuid.uuid4())
                 exp.identifier = strid
                 refl.experiment_identifiers()[i] = strid
-                unique_id += 1
             else:
                 k = list(refl.experiment_identifiers().keys())[0]
                 expid = list(refl.experiment_identifiers().values())[0]

--- a/util/multi_dataset_handling.py
+++ b/util/multi_dataset_handling.py
@@ -250,6 +250,36 @@ def assign_unique_identifiers(experiments, reflections, identifiers=None):
 def select_datasets_on_ids(
     experiments, reflection_table_list, exclude_datasets=None, use_datasets=None
 ):
+    # transform dataset ids to identifiers
+    if not use_datasets and not exclude_datasets:
+        return experiments, reflection_table_list
+    if use_datasets and exclude_datasets:
+        raise ValueError(
+            "The options use_datasets and exclude_datasets cannot be used in conjuction."
+        )
+
+    id_map = {}
+    for table in reflection_table_list:
+        id_map.update(table.experiment_identifiers())
+    if exclude_datasets:
+        identifiers_to_exclude = []
+        for k in exclude_datasets:
+            identifiers_to_exclude.append(id_map[int(k)])
+        return select_datasets_on_identifiers(
+            experiments, reflection_table_list, exclude_datasets=identifiers_to_exclude
+        )
+    elif use_datasets:
+        identifiers_to_use = []
+        for k in use_datasets:
+            identifiers_to_use.append(id_map[int(k)])
+        return select_datasets_on_identifiers(
+            experiments, reflection_table_list, use_datasets=identifiers_to_use
+        )
+
+
+def select_datasets_on_identifiers(
+    experiments, reflection_table_list, exclude_datasets=None, use_datasets=None
+):
     """
     Select a subset of experiments and reflection tables based on identifiers.
 


### PR DESCRIPTION
This PR implements the experiment identifier changes to use uuids, for scaling, symmetry, cosym, compute_delta_cchalf (the programs already generating identifiers). This is a subset of the previous PR, to make the changeset more manageable. The rest of the changes for indexing, integration etc. should follow on fairly simply.

Mainly affects scaling, but also touches on symmetry determination programs. The basic gist of the changes is that instead of printing the identifier in the output, which is now a large string, the dataset id should be printed instead i.e. 0, 1, 2 etc. Therefore there _shouldn't_ be any of the uuids printed, but would welcome developer testing for this in log/html plots. The behaviour should be functionally the same.

These command line scripts have also been updated to call the combined flatten experiments/reflections function, which now sorts out the order of the input files if identifiers are present.

This PR is also the subset need to fix #1032 🙂 
Fixes #1032 
