### PR TITLE
Fast masking

### DIFF
--- a/util/masking.py
+++ b/util/masking.py
@@ -155,7 +155,14 @@ class MaskGenerator(object):
             if self.params.use_trusted_range:
                 trusted_mask = None
                 low, high = panel.get_trusted_range()
-                for image_index, _ in enumerate(imageset.indices()):
+
+                # Take 10 evenly-spaced images from the imageset. Pixels outside
+                # the trusted mask on all of these images are considered bad and
+                # masked. https://github.com/dials/dials/issues/1061
+                stride = max(int(len(imageset) / 10), 1)
+                image_indices = range(0, len(imageset), stride)
+
+                for image_index in image_indices:
                     image_data = imageset.get_raw_data(image_index)[index].as_double()
                     frame_mask = (image_data > low) & (image_data < high)
                     if trusted_mask is None:
@@ -163,15 +170,8 @@ class MaskGenerator(object):
                     else:
                         trusted_mask = trusted_mask | frame_mask
 
-                    # Pixels outside the trusted mask on at least 100 images
-                    # are considered bad and masked.
-                    # https://github.com/dials/dials/issues/1061
-                    if image_index >= 100:
-                        break
-
                     if trusted_mask.count(False) == 0:
                         break
-
                 mask = trusted_mask
             else:
                 mask = flex.bool(flex.grid(im.all()), True)

--- a/util/masking.py
+++ b/util/masking.py
@@ -145,7 +145,7 @@ class MaskGenerator(object):
         image = imageset.get_raw_data(0)
         assert len(detector) == len(image)
 
-        # Create the mask for each image
+        # Create the mask for each panel
         masks = []
         for index, (im, panel) in enumerate(zip(image, detector)):
 
@@ -162,6 +162,12 @@ class MaskGenerator(object):
                         trusted_mask = frame_mask
                     else:
                         trusted_mask = trusted_mask | frame_mask
+
+                    # Pixels outside the trusted mask on at least 100 images
+                    # are considered bad and masked.
+                    # https://github.com/dials/dials/issues/1061
+                    if image_index >= 100:
+                        break
 
                     if trusted_mask.count(False) == 0:
                         break


### PR DESCRIPTION
Dumb workaround for #1061

Pixels outside the trusted mask on at least 100 images
are considered bad and masked