### PR TITLE
Allow controlling image_viewer via ZeroMQ

### DIFF
--- a/command_line/image_viewer.py
+++ b/command_line/image_viewer.py
@@ -112,6 +112,11 @@ include scope dials.algorithms.spot_prediction.reflection_predictor.phil_scope
 load_models = True
   .type = bool
   .help = "Whether to load every model, which matters for large image files"
+
+zmq_endpoint = None
+  .type = str
+  .help = "The endpoint to bind a zeromq PULL socket to, for recieving commands"
+  .expert_level = 3
 """,
     process_includes=True,
 )

--- a/newsfragments/1085.feature
+++ b/newsfragments/1085.feature
@@ -1,0 +1,4 @@
+Experimental: ``dials.image_viewer`` can be remotely controlled via a
+ZeroMQ endpoint with the ``zmq_endpoint`` PHIL parameter. Initially,
+the viewer can be commanded to load new images. This requires the
+(optional) ``pyzmq``package.

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -40,6 +40,7 @@ from .viewer_tools import (
     ImageChooserControl,
     ImageCollectionWithSelection,
     LegacyChooserAdapter,
+    EVT_ZEROMQ_EVENT,
 )
 
 try:
@@ -160,6 +161,7 @@ class SpotFrame(XrayFrame):
         self.Bind(EVT_LOADIMG, self.load_file_event)
 
         self.Bind(wx.EVT_UPDATE_UI, self.OnUpdateUIMask, id=self._id_mask)
+        self.Bind(EVT_ZEROMQ_EVENT, self.OnZeroMQEvent)
 
     def setup_toolbar(self):
         btn = self.toolbar.AddLabelTool(
@@ -1643,6 +1645,17 @@ class SpotFrame(XrayFrame):
             predicted_all.append(this_predicted)
 
         return predicted_all
+
+    def OnZeroMQEvent(self, event):
+        message = event.message
+        print("ZMQ Event recieved by gui:", message)
+        try:
+            if message["command"] == "load_image":
+                filename = message["image"]
+                self.load_image(filename)
+        except Exception:
+            print("Error parsing zeromq message")
+            raise
 
 
 class SpotSettingsFrame(SettingsFrame):

--- a/util/image_viewer/spotfinder_wrap.py
+++ b/util/image_viewer/spotfinder_wrap.py
@@ -2,6 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 from .slip_viewer.frame import chooser_wrapper as _chooser_wrapper
 
+import sys
+import wx
+
+import threading
+
+from .viewer_tools import ZeroMQEvent
+
 try:
     import resource
     import platform
@@ -47,6 +54,7 @@ class spot_wrapper(object):
     def __init__(self, params):
         self.params = params
         self.frame = None
+        self._zmq_thread = None
 
     def display(self, experiments, reflections):
         import wx
@@ -73,11 +81,72 @@ class spot_wrapper(object):
                 self.frame.add_file_name_or_data(chooser_wrapper(imageset, idx))
         # Make sure we load the first image as the current one
         self.frame.load_image(chooser_wrapper(imagesets[0], 0))
+
+        # If ZMQ required, setup the endpoint to dispatch messages to wx
+        if self.params.zmq_endpoint is not None:
+            self._setup_zmq_endpoint(self.params.zmq_endpoint)
+
         #   debug_memory_usage()
         app.MainLoop()
+
+        # Shut down the ZMQ endpoint if we created one
+        if self.params.zmq_endpoint is not None:
+            self._shutdown_zmq_endpoint()
 
     def load_image(self, filename):
         from dials.util.spotfinder_frame import create_load_image_event
 
         if self.frame is not None:
             create_load_image_event(self.frame, filename)
+
+    def _setup_zmq_endpoint(self, endpoint):
+        # type: (str) -> None
+        """Create and bind a ZMQ endpoint"""
+        try:
+            import zmq
+        except ImportError:
+            sys.exit("Error: ZMQ Endpoint requested but pyzmq not installed; aborting")
+        print("ZeroMQ binding requested at", endpoint)
+        self.zmq_context = zmq.Context()
+        self.zmq_socket = self.zmq_context.socket(zmq.PULL)
+        self.zmq_socket.bind(endpoint)
+        self._zmq_thread = ZMQEventListener(self.zmq_socket, self.frame)
+        self._zmq_thread.start()
+
+    def _shutdown_zmq_endpoint(self):
+        """Close the ZMQ endpoint"""
+        print("Shutting down ZMQ endpoint")
+        # Wait for the thread to end
+        if self._zmq_thread is not None:
+            self._zmq_thread.stop = True
+            self._zmq_thread.join()
+
+        self.zmq_socket.close()
+
+
+class ZMQEventListener(threading.Thread):
+    """Thread to listen for ZMQ events and dispatch them to the GUI.
+
+    Args:
+        socket: The ZeroMQ socket object to listen on
+        target: The WX container to forward messages to
+    """
+
+    def __init__(self, socket, target, *args, **kwargs):
+        super(ZMQEventListener, self).__init__(*args, **kwargs)
+        self.stop = False
+        self.socket = socket
+        self.target = target
+
+    def run(self):
+        while not self.stop:
+            event_count = self.socket.poll(timeout=0.1)
+            for _ in range(event_count):
+                message = self.socket.recv_json()
+                print("Recieved ZMQ Message: ", message)
+                self._handle_message(message)
+
+    def _handle_message(self, message):
+        # Just attach the message to an event and send it on
+        evt = ZeroMQEvent(message=message)
+        wx.PostEvent(self.target, evt)

--- a/util/image_viewer/viewer_tools.py
+++ b/util/image_viewer/viewer_tools.py
@@ -8,7 +8,11 @@ from __future__ import absolute_import, division, print_function
 import wx
 from orderedset import OrderedSet
 
+import wx.lib.newevent
+
 WX3 = wx.VERSION[0] == 3
+
+ZeroMQEvent, EVT_ZEROMQ_EVENT = wx.lib.newevent.NewEvent()
 
 
 class ImageCollectionWithSelection(OrderedSet):


### PR DESCRIPTION
This adds a `zmq_endpoint` PHIL parameter to image_viewer, that it binds a ZMQ
PULL socket to and listens for commands. At the moment, the only command is
to load a new image, and is a json messages of the form:

    {"command": "load_image", "image": "<filename>"}

This doesn't add a pyzmq dependency, so this will only work if explicitly
added to the distribution for now. It doesn't affect image_viewer at all
if pyzmq isn't present, but if you try to ask it to bind to an endpoint
without zeromq it'll exit with an error.

The primary usage for now has been for I24 serial online hitfinding, and
using dials.image_viewer to jump around the results.

example of code to trigger, `send.py`:
```python
import sys
import zmq

zmq_endpoint = sys.argv[1]
filename = sys.argv[2]

context = zmq.Context()
s = context.socket(zmq.PUSH)
s.connect(zmq_endpoint)
message = {"command": "load_image", "image": filename}
print("Sending message:", message, "to", zmq_endpoint)
s.send_json(message)
s.close()
```
And then
```
$ dials.image_viewer zmq_endpoint='tcp://127.0.0.1:5557' <initial_file>
$ python3 send.py tcp://127.0.0.1:5557 <new_image_file>
```

This is pretty early and experimental but allows some neat behaviour.