### PR TITLE
Use experiment identifiers from import

### DIFF
--- a/algorithms/indexing/assign_indices.py
+++ b/algorithms/indexing/assign_indices.py
@@ -60,6 +60,10 @@ class AssignIndicesGlobal(AssignIndicesStrategy):
                 sel_cryst = crystal_ids == i_cryst
                 for i_expt in experiments.where(crystal=cryst, imageset=imgset):
                     expt_ids.set_selected(sel_cryst, i_expt)
+                    if experiments[i_expt].identifier:
+                        reflections.experiment_identifiers()[i_expt] = experiments[
+                            i_expt
+                        ].identifier
 
             reflections["miller_index"].set_selected(
                 isel.select(sel_imgset), miller_indices

--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -10,6 +10,7 @@ import dials.util
 import iotbx.phil
 import libtbx
 from dials.array_family import flex
+from dials.util.multi_dataset_handling import generate_experiment_identifiers
 from dials.algorithms.indexing import assign_indices
 from dials.algorithms.indexing import DialsIndexError, DialsIndexRefineError
 from dials.algorithms.indexing.compare_orientation_matrices import (
@@ -536,10 +537,13 @@ class Indexer(object):
                 self.d_min = self.params.refinement_protocol.d_min_start
 
             if len(experiments) == 0:
-                experiments.extend(self.find_lattices())
+                new_expts = self.find_lattices()
+                generate_experiment_identifiers(new_expts)
+                experiments.extend(new_expts)
             else:
                 try:
                     new = self.find_lattices()
+                    generate_experiment_identifiers(new)
                     experiments.extend(new)
                 except DialsIndexError:
                     logger.info("Indexing remaining reflections failed")

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -8,6 +8,7 @@ import libtbx
 from dxtbx.model.experiment_list import Experiment, ExperimentList
 from dials.array_family import flex
 from dials.algorithms.indexing.indexer import Indexer
+from dials.util.multi_dataset_handling import generate_experiment_identifiers
 from dials.algorithms.indexing.known_orientation import IndexerKnownOrientation
 from dials.algorithms.indexing.lattice_search import BasisVectorSearch, LatticeSearch
 from dials.algorithms.indexing.nave_parameters import NaveParameters
@@ -65,7 +66,9 @@ def e_refine(params, experiments, reflections, graph_verbose=False):
     assert params.refinement.reflections.outlier.algorithm in (
         None,
         "null",
-    ), "Cannot index, set refinement.reflections.outlier.algorithm=null"  # we do our own outlier rejection
+    ), (
+        "Cannot index, set refinement.reflections.outlier.algorithm=null"
+    )  # we do our own outlier rejection
 
     from dials.algorithms.refinement.refiner import RefinerFactory
 
@@ -130,12 +133,15 @@ class StillsIndexer(Indexer):
 
             # index multiple lattices per shot
             if len(experiments) == 0:
-                experiments.extend(self.find_lattices())
+                new = self.find_lattices()
+                generate_experiment_identifiers(new)
+                experiments.extend(new)
                 if len(experiments) == 0:
                     raise DialsIndexError("No suitable lattice could be found.")
             else:
                 try:
                     new = self.find_lattices()
+                    generate_experiment_identifiers(new)
                     experiments.extend(new)
                 except Exception as e:
                     logger.info("Indexing remaining reflections failed")

--- a/algorithms/indexing/test_index.py
+++ b/algorithms/indexing/test_index.py
@@ -9,6 +9,7 @@ import procrunner
 from scitbx import matrix
 from cctbx import uctbx
 from dxtbx.serialize import load
+from dxtbx.model import ExperimentList
 from dials.array_family import flex
 
 
@@ -67,6 +68,7 @@ def run_indexing(
     experiments_list = load.experiment_list(out_expts.strpath, check_format=False)
     assert len(experiments_list.crystals()) == n_expected_lattices
     indexed_reflections = flex.reflection_table.from_file(out_refls.strpath)
+    indexed_reflections.assert_experiment_identifiers_are_consistent(experiments_list)
     rmsds = None
 
     for i, experiment in enumerate(experiments_list):
@@ -100,6 +102,10 @@ def run_indexing(
         rmsds = (rmsd_x, rmsd_y, rmsd_z)
         for actual, expected in zip(rmsds, expected_rmsds):
             assert actual <= expected, "%s %s" % (rmsds, expected_rmsds)
+        assert experiment.identifier != ""
+        expt = ExperimentList()
+        expt.append(experiment)
+        reflections.assert_experiment_identifiers_are_consistent(expt)
 
     return _indexing_result(indexed_reflections, experiments_list, rmsds)
 

--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -766,12 +766,16 @@ class SpotFinder(object):
                     z0, z1 = experiment.scan.get_array_range()
                     z = table["xyzobs.px.value"].parts()[2]
                     table["id"].set_selected((z > z0) & (z < z1), i)
+                    if experiment.identifier:
+                        table.experiment_identifiers()[i] = experiment.identifier
                 else:
                     table["id"] = flex.int(table.nrows(), j)
+                    if experiment.identifier:
+                        table.experiment_identifiers()[j] = experiment.identifier
             missed = table["id"] == -1
             assert missed.count(True) == 0, missed.count(True)
-            reflections.extend(table)
 
+            reflections.extend(table)
             # Write a hot pixel mask
             if self.write_hot_mask:
                 if not imageset.external_lookup.mask.data.empty():

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -155,6 +155,8 @@ class _(object):
                 padding=padding,
             )
             rlist["id"] = cctbx.array_family.flex.int(len(rlist), i)
+            if e.identifier:
+                rlist.experiment_identifiers()[i] = e.identifier
             result.extend(rlist)
         return result
 

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -1182,7 +1182,7 @@ class _(object):
             values = list(identifiers.values())
             assert len(set(values)) == len(values), (len(set(values)), len(values))
             if "id" in self:
-                index = set(self["id"])
+                index = set(self["id"]).difference({-1})
                 for i in index:
                     assert i in identifiers, (i, list(identifiers))
         if experiments is not None:

--- a/command_line/assign_experiment_identifiers.py
+++ b/command_line/assign_experiment_identifiers.py
@@ -5,7 +5,7 @@ import sys
 
 from libtbx import phil
 from dials.util import show_mail_on_error, Sorry
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.array_family import flex
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
@@ -51,8 +51,9 @@ def run(args=None):
         parser.print_help()
         sys.exit()
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     reflections = parse_multiple_datasets(reflections)
     if len(experiments) != len(reflections):

--- a/command_line/augment_spots.py
+++ b/command_line/augment_spots.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import iotbx.phil
-from dials.util.options import OptionParser
-from dials.util.options import flatten_experiments
-from dials.util.options import flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.array_family import flex
 
 help_message = """
@@ -102,8 +100,9 @@ def run(args):
 
     params, options = parser.parse_args(show_diff_phil=True)
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(reflections) != 1:
         parser.print_help()

--- a/command_line/check_indexing_symmetry.py
+++ b/command_line/check_indexing_symmetry.py
@@ -11,8 +11,7 @@ from cctbx.miller import set as miller_set
 from cctbx.sgtbx import space_group as sgtbx_space_group
 from dials.algorithms.symmetry import origin
 from dials.array_family import flex
-from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util import log
 from dials.util.version import dials_version
 from libtbx.utils import format_float_with_standard_uncertainty
@@ -321,8 +320,9 @@ def run(args):
     log.config(logfile=params.output.log)
     logger.info(dials_version())
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if len(reflections) == 0 or len(experiments) == 0:
         parser.print_help()
         return

--- a/command_line/create_profile_model.py
+++ b/command_line/create_profile_model.py
@@ -58,7 +58,7 @@ class Script(object):
         from dials.algorithms.profile_model.factory import ProfileModelFactory
         from dials.util.command_line import Command
         from dials.array_family import flex
-        from dials.util.options import flatten_reflections, flatten_experiments
+        from dials.util.options import reflections_and_experiments_from_files
         from dials.util import Sorry
         from dials.util import log
 
@@ -66,8 +66,9 @@ class Script(object):
 
         # Parse the command line
         params, options = self.parser.parse_args(show_diff_phil=True)
-        reflections = flatten_reflections(params.input.reflections)
-        experiments = flatten_experiments(params.input.experiments)
+        reflections, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
         if len(reflections) == 0 and len(experiments) == 0:
             self.parser.print_help()
             return

--- a/command_line/detect_blanks.py
+++ b/command_line/detect_blanks.py
@@ -197,9 +197,7 @@ def blank_regions_from_sel(d):
 
 
 def run(args):
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     from dials.util import log
 
     usage = "dials.detect_blanks [options] models.expt observations.refl"
@@ -214,8 +212,9 @@ def run(args):
     )
 
     params, options = parser.parse_args()
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -14,6 +14,7 @@ from dxtbx.model.experiment_list import ExperimentListTemplateImporter
 from dxtbx.imageset import ImageGrid
 from dxtbx.imageset import ImageSequence
 from dials.util.options import flatten_experiments
+from dials.util.multi_dataset_handling import generate_experiment_identifiers
 from libtbx.phil import parse
 
 logger = logging.getLogger("dials.command_line.import")
@@ -89,6 +90,10 @@ phil_scope = parse(
       .help = "For JSON output use compact representation"
 
   }
+
+  identifier_type = *uuid timestamp None
+    .type = choice
+    .help = "Type of unique identifier to generate."
 
   input {
 
@@ -220,6 +225,9 @@ class ImageSetImporter(object):
                     )
             else:
                 raise Sorry("No experimetns found")
+
+        if self.params.identifier_type:
+            generate_experiment_identifiers(experiments, self.params.identifier_type)
 
         # Get a list of all imagesets
         imageset_list = experiments.imagesets()
@@ -572,6 +580,8 @@ class MetaDataUpdater(object):
                         )
                     )
 
+        if self.params.identifier_type:
+            generate_experiment_identifiers(experiments, self.params.identifier_type)
         # Return the experiments
         return experiments
 

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -403,11 +403,7 @@ def export_json(params, experiments, reflections):
 
 
 if __name__ == "__main__":
-    from dials.util.options import (
-        OptionParser,
-        flatten_experiments,
-        flatten_reflections,
-    )
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     from dials.util.version import dials_version
     from dials.util import log
 
@@ -443,8 +439,9 @@ if __name__ == "__main__":
         sys.exit()
 
     # Get the experiments and reflections
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     # do auto intepreting of intensity choice:
     # note that this may still fail certain checks further down the processing,

--- a/command_line/export_best.py
+++ b/command_line/export_best.py
@@ -94,11 +94,7 @@ class BestExporter(object):
 
 
 if __name__ == "__main__":
-    from dials.util.options import (
-        OptionParser,
-        flatten_experiments,
-        flatten_reflections,
-    )
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     from dials.util.version import dials_version
     from dials.util import log
     from dials.util import Sorry
@@ -133,8 +129,9 @@ if __name__ == "__main__":
         sys.exit()
 
     # Get the experiments and reflections
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     exporter = BestExporter(params, experiments, reflections)
     exporter.export()

--- a/command_line/filter_reflections.py
+++ b/command_line/filter_reflections.py
@@ -11,7 +11,7 @@ from tokenize import generate_tokens, TokenError, untokenize
 from cctbx import uctbx
 from dials.util import Sorry, log, show_mail_on_error
 from dials.util.filter_reflections import SumAndPrfIntensityReducer, SumIntensityReducer
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.array_family import flex
 from dials.algorithms.integration import filtering
 from libtbx.phil import parse
@@ -428,8 +428,9 @@ def run():
     )
 
     params, options = parser.parse_args(show_diff_phil=True)
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     log.config(verbosity=options.verbose)
 

--- a/command_line/find_hot_pixels.py
+++ b/command_line/find_hot_pixels.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 
 import iotbx.phil
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
 logger = logging.getLogger("dials.command_line.find_hot_pixels")
 
@@ -66,8 +66,9 @@ def run(args):
         logger.info("The following parameters have been modified:\n")
         logger.info(diff_phil)
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 and len(reflections) == 0:
         parser.print_help()

--- a/command_line/find_spots.py
+++ b/command_line/find_spots.py
@@ -127,7 +127,6 @@ class Script(object):
             generate_experiment_identifiers(
                 experiments
             )  # add identifier e.g. if coming straight from images
-        print(experiments.identifiers())
         if len(experiments) == 0:
             self.parser.print_help()
             return

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -211,7 +211,6 @@ def index(experiments, reflections, params):
                         continue
                     # Update the experiment ids by incrementing by the number of indexed
                     # experiments already in the list
-                    print(list(idx_refl.experiment_identifiers().keys()))
                     ##FIXME below, is i_expt correct - or should it be the
                     # index of the 'future'?
                     idx_refl["imageset_id"] = flex.size_t(idx_refl.size(), i_expt)

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -15,8 +15,7 @@ from dials.algorithms.indexing import DialsIndexError
 from dials.array_family import flex
 from dials.util.slice import slice_reflections
 from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections
-from dials.util.options import flatten_experiments
+from dials.util.options import reflections_and_experiments_from_files
 from dials.util.multi_dataset_handling import renumber_table_id_columns
 from dials.util import log
 from dials.util.version import dials_version
@@ -248,8 +247,9 @@ def run(phil=working_phil, args=None):
         logger.info("The following parameters have been modified:\n")
         logger.info(diff_phil)
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0:
         parser.print_help()

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -138,14 +138,15 @@ class Script(object):
     def run(self, args=None):
         """Perform the integration."""
         from dials.util.command_line import heading
-        from dials.util.options import flatten_reflections, flatten_experiments
+        from dials.util.options import reflections_and_experiments_from_files
         from dials.util import log
         from dials.util import Sorry
 
         # Parse the command line
         params, options = self.parser.parse_args(args=args, show_diff_phil=False)
-        reference = flatten_reflections(params.input.reflections)
-        experiments = flatten_experiments(params.input.experiments)
+        reference, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
         if len(reference) == 0 and len(experiments) == 0:
             self.parser.print_help()
             return

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -292,8 +292,14 @@ class Script(object):
                 good_expt_count = 0
 
                 def refl_extend(src, dest, eid):
-                    tmp = src.select(src["id"] == eid)
+                    old_id = eid
+                    new_id = good_expt_count
+                    tmp = src.select(src["id"] == old_id)
                     tmp["id"] = flex.int(len(tmp), good_expt_count)
+                    if old_id in tmp.experiment_identifiers():
+                        identifier = tmp.experiment_identifiers()[old_id]
+                        del tmp.experiment_identifiers()[old_id]
+                        tmp.experiment_identifiers()[new_id] = identifier
                     dest.extend(tmp)
 
                 for expt_id, experiment in enumerate(experiments):
@@ -382,7 +388,12 @@ class Script(object):
                 refls = filtered_refls.select(filtered_refls["id"] == expt_id)
                 if len(refls) > 0:
                     accepted_expts.append(expt)
-                    refls["id"] = flex.int(len(refls), len(accepted_expts) - 1)
+                    current_id = expt_id
+                    new_id = len(accepted_expts) - 1
+                    refls["id"] = flex.int(len(refls), new_id)
+                    if expt.identifier:
+                        del refls.experiment_identifiers()[current_id]
+                        refls.experiment_identifiers()[new_id] = expt.identifier
                     accepted_refls.extend(refls)
                 else:
                     logger.info(

--- a/command_line/plot_reflections.py
+++ b/command_line/plot_reflections.py
@@ -34,9 +34,7 @@ output {
 
 def run(args):
     usage = "dials.plot_reflections models.expt observations.refl [options]"
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     from scitbx.array_family import flex
     from scitbx import matrix
 
@@ -49,8 +47,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=True)
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if len(experiments.imagesets()) > 0:
         imageset = experiments.imagesets()[0]
         imageset.set_detector(experiments[0].detector)

--- a/command_line/reciprocal_lattice_viewer.py
+++ b/command_line/reciprocal_lattice_viewer.py
@@ -10,7 +10,7 @@ import wxtbx.app
 
 import dials.util.log
 from dials.util.reciprocal_lattice.viewer import ReciprocalLatticeViewer, phil_scope
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
 help_message = """
 Visualise the strong spots from spotfinding in reciprocal space.
@@ -36,8 +36,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=True)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -28,8 +28,7 @@ from dials.algorithms.refinement.corrgram import create_correlation_plots
 import dials.util.log
 from dials.util.version import dials_version
 from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections
-from dials.util.options import flatten_experiments
+from dials.util.options import reflections_and_experiments_from_files
 
 logger = logging.getLogger("dials.command_line.refine")
 
@@ -334,8 +333,10 @@ def run(args=None, phil=working_phil):
 
     # Parse the command line
     params, options = parser.parse_args(args=args, show_diff_phil=False)
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     # Configure the logging
     dials.util.log.config(verbosity=options.verbose, logfile=params.output.log)

--- a/command_line/refine_bravais_settings.py
+++ b/command_line/refine_bravais_settings.py
@@ -44,9 +44,7 @@ from dials.algorithms.indexing.bravais_settings import (
 )
 from dials.array_family import flex
 from dials.util import log
-from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections
-from dials.util.options import flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 
 
@@ -173,8 +171,9 @@ def run(args=None):
         logger.info("The following parameters have been modified:\n")
         logger.info(diff_phil)
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if len(reflections) == 0 or len(experiments) == 0:
         parser.print_help()
         return

--- a/command_line/reindex.py
+++ b/command_line/reindex.py
@@ -15,7 +15,7 @@ from rstbx.symmetry.constraints import parameter_reduction
 from dials.algorithms.indexing.assign_indices import AssignIndicesGlobal
 from dials.array_family import flex
 from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections, flatten_experiments
+from dials.util.options import reflections_and_experiments_from_files
 from dials.util.filter_reflections import filtered_arrays_from_experiments_reflections
 
 help_message = """
@@ -172,8 +172,9 @@ def run(args):
 
     params, options = parser.parse_args(show_diff_phil=True)
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if len(experiments) == 0 and len(reflections) == 0:
         parser.print_help()
         return

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -2438,7 +2438,7 @@ class Script(object):
 
     def run(self):
         """Run the script."""
-        from dials.util.options import flatten_reflections, flatten_experiments
+        from dials.util.options import reflections_and_experiments_from_files
 
         # Parse the command line arguments
         params, options = self.parser.parse_args(show_diff_phil=True)
@@ -2448,8 +2448,9 @@ class Script(object):
             self.parser.print_help()
             exit(0)
 
-        reflections = flatten_reflections(params.input.reflections)
-        experiments = flatten_experiments(params.input.experiments)
+        reflections, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
 
         # Analyse the reflections
         analyse = Analyser(

--- a/command_line/resolutionizer.py
+++ b/command_line/resolutionizer.py
@@ -7,8 +7,7 @@ import libtbx.phil
 
 from dials.util import resolutionizer
 from dials.util import log
-from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 from dials.util.multi_dataset_handling import parse_multiple_datasets
 
@@ -49,8 +48,9 @@ def run(args):
         return_unhandled=True, show_diff_phil=True
     )
 
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
     if (not reflections or not experiments) and not unhandled:
         parser.print_help()
         return

--- a/command_line/rl_csv.py
+++ b/command_line/rl_csv.py
@@ -2,8 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 import iotbx.phil
-from dials.util.options import OptionParser
-from dials.util.options import flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dxtbx.model import ExperimentList
 
 phil_scope = iotbx.phil.parse(
@@ -37,8 +36,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=False)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if not experiments or not reflections:
         parser.print_help()

--- a/command_line/rl_png.py
+++ b/command_line/rl_png.py
@@ -127,9 +127,7 @@ class PngScene(object):
 
 
 def run():
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
     from dials.util import log
 
     usage = "dials.rl_png [options] experiments.json observations.refl"
@@ -144,8 +142,9 @@ def run():
     )
 
     params, options = parser.parse_args()
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -25,8 +25,7 @@ from dxtbx.model import Experiment, ExperimentList
 from dials.algorithms.indexing.indexer import find_max_cell
 from dials.util import log
 from dials.util import Sorry
-from dials.util.options import OptionParser
-from dials.util.options import flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.slice import slice_reflections
 
 logger = logging.getLogger("dials.command_line.search_beam_position")
@@ -537,8 +536,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=False)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/sequence_to_stills.py
+++ b/command_line/sequence_to_stills.py
@@ -22,7 +22,7 @@ from dials.algorithms.refinement.prediction.managed_predictors import (
 from dials.array_family import flex
 from dials.model.data import Shoebox
 from dials.util import show_mail_on_error
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
 logger = logging.getLogger("dials.command_line.sequence_to_stills")
 
@@ -217,8 +217,9 @@ def run(args=None, phil=phil_scope):
         parser.print_help()
         return
 
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     (new_experiments, new_reflections) = sequence_to_stills(
         experiments, reflections, params

--- a/command_line/show.py
+++ b/command_line/show.py
@@ -187,9 +187,7 @@ def run(args):
 
     dials.util.log.print_banner()
 
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
     usage = "dials.show [options] models.expt | image_*.cbf"
 
@@ -204,8 +202,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(args=args, show_diff_phil=True)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 and len(reflections) == 0:
         parser.print_help()

--- a/command_line/slice_sequence.py
+++ b/command_line/slice_sequence.py
@@ -117,12 +117,13 @@ class Script(object):
     def run(self):
         """Execute the script."""
 
-        from dials.util.options import flatten_reflections, flatten_experiments
+        from dials.util.options import reflections_and_experiments_from_files
 
         # Parse the command line
         params, options = self.parser.parse_args(show_diff_phil=True)
-        reflections = flatten_reflections(params.input.reflections)
-        experiments = flatten_experiments(params.input.experiments)
+        reflections, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
 
         # Try to load the models and data
         slice_exps = len(experiments) > 0

--- a/command_line/split_experiments.py
+++ b/command_line/split_experiments.py
@@ -4,7 +4,7 @@ import functools
 from libtbx.phil import parse
 from dials.util import Sorry, show_mail_on_error
 from dials.util.export_mtz import match_wavelengths
-from dials.util.options import OptionParser, flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.array_family import flex
 from dxtbx.model.experiment_list import ExperimentList
 
@@ -114,10 +114,11 @@ class Script(object):
                     "The number of input reflections files does not match the "
                     "number of input experiments"
                 )
-
-        experiments = flatten_experiments(params.input.experiments)
-        if params.input.reflections:
-            reflections = flatten_reflections(params.input.reflections)[0]
+        reflections, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
+        if reflections:
+            reflections = reflections[0]
         else:
             reflections = None
 

--- a/command_line/spot_counts_per_image.py
+++ b/command_line/spot_counts_per_image.py
@@ -6,8 +6,7 @@ import sys
 import iotbx.phil
 from dials.util import tabulate
 from dials.array_family import flex
-from dials.util.options import OptionParser
-from dials.util.options import flatten_reflections, flatten_experiments
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.algorithms.spot_finding import per_image_analysis
 
 help_message = """
@@ -56,8 +55,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=False)
-    reflections = flatten_reflections(params.input.reflections)
-    experiments = flatten_experiments(params.input.experiments)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if not reflections and not experiments:
         parser.print_help()

--- a/command_line/spot_resolution_shells.py
+++ b/command_line/spot_resolution_shells.py
@@ -38,9 +38,7 @@ def spot_resolution_shells(experiments, reflections, params):
 
 
 def run(args):
-    from dials.util.options import OptionParser
-    from dials.util.options import flatten_experiments
-    from dials.util.options import flatten_reflections
+    from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
     usage = "dials.spot_resolution_shells [options] models.expt observations.refl"
 
@@ -54,8 +52,9 @@ def run(args):
     )
 
     params, options = parser.parse_args(show_diff_phil=True)
-    experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
 
     if len(experiments) == 0 or len(reflections) == 0:
         parser.print_help()

--- a/command_line/two_theta_refine.py
+++ b/command_line/two_theta_refine.py
@@ -32,8 +32,7 @@ from dials.util import log
 from dials.util.version import dials_version
 from dials.util import show_mail_on_error
 from dials.util.filter_reflections import filter_reflection_table
-from dials.util.options import flatten_experiments, flatten_reflections
-from dials.util.options import OptionParser
+from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.multi_dataset_handling import parse_multiple_datasets
 from dials.util import tabulate
 
@@ -429,8 +428,9 @@ class Script(object):
         reflections = flex.reflection_table()
 
         # loop through the input, building up the global lists
-        reflections_list = flatten_reflections(params.input.reflections)
-        experiments = flatten_experiments(params.input.experiments)
+        reflections_list, experiments = reflections_and_experiments_from_files(
+            params.input.reflections, params.input.experiments
+        )
 
         reflections_list = parse_multiple_datasets(reflections_list)
         for refs in reflections_list:

--- a/newsfragments/1086.feature
+++ b/newsfragments/1086.feature
@@ -1,0 +1,1 @@
+Programs now generate a unique identifier for each experiment created, and reflection tables are linked via the experiment_identifiers map

--- a/test/command_line/test_import.py
+++ b/test/command_line/test_import.py
@@ -44,6 +44,8 @@ def test_can_import_multiple_sequences(dials_data, tmpdir):
         tmpdir.join("experiments_multiple_sequences.expt").strpath
     )
     assert len(experiments) == 2
+    for experiment in experiments:
+        assert experiment.identifier != ""
 
 
 def test_with_mask(dials_data, tmpdir):
@@ -66,6 +68,7 @@ def test_with_mask(dials_data, tmpdir):
     experiments = load.experiment_list(
         tmpdir.join("experiments_with_mask.expt").strpath
     )
+    assert experiments[0].identifier != ""
     assert (
         experiments[0].imageset.external_lookup.mask.filename == mask_filename.strpath
     )
@@ -119,6 +122,7 @@ def test_override_geometry(dials_data, tmpdir):
     assert tmpdir.join("override_geometry.expt").check(file=1)
 
     experiments = load.experiment_list(tmpdir.join("override_geometry.expt").strpath)
+    assert experiments[0].identifier != ""
     imgset = experiments[0].imageset
 
     beam = imgset.get_beam()
@@ -164,6 +168,7 @@ def test_import_beam_centre(dials_data, tmpdir):
 
     experiments = load.experiment_list(tmpdir.join("mosflm_beam_centre.expt").strpath)
     imgset = experiments[0].imageset
+    assert experiments[0].identifier != ""
     beam_centre = imgset.get_detector()[0].get_beam_centre(imgset.get_beam().get_s0())
     assert beam_centre == pytest.approx((200, 100))
 
@@ -206,6 +211,7 @@ def test_slow_fast_beam_centre(dials_regression, run_in_tmpdir):
 
     experiments = load.experiment_list("slow_fast_beam_centre.expt")
     imgset = experiments[0].imageset
+    assert experiments[0].identifier != ""
     # beam centre on 18th panel
     s0 = imgset.get_beam().get_s0()
     beam_centre = imgset.get_detector()[18].get_beam_centre_px(s0)
@@ -248,6 +254,9 @@ def test_from_image_files(dials_data, tmpdir):
     )
     assert not result.returncode
     assert tmpdir.join("imported.expt").check(file=1)
+    # check that an experiment identifier is assigned
+    exp = load.experiment_list(tmpdir.join("imported.expt").strpath)
+    assert exp[0].identifier != ""
 
 
 def test_from_template(dials_data, tmpdir):
@@ -265,6 +274,9 @@ def test_from_template(dials_data, tmpdir):
     )
     assert not result.returncode
     assert tmpdir.join("imported.expt").check(file=1)
+    # check that an experiment identifier is assigned
+    exp = load.experiment_list(tmpdir.join("imported.expt").strpath)
+    assert exp[0].identifier != ""
 
 
 def test_extrapolate_scan(dials_data, tmpdir):
@@ -283,6 +295,9 @@ def test_extrapolate_scan(dials_data, tmpdir):
     )
     assert not result.returncode
     assert tmpdir.join("import_extrapolate.expt").check(file=1)
+    # check that an experiment identifier is assigned
+    exp = load.experiment_list(tmpdir.join("import_extrapolate.expt").strpath)
+    assert exp[0].identifier != ""
 
 
 def test_import_still_sequence_as_experiments(dials_data, tmpdir):
@@ -299,6 +314,8 @@ def test_import_still_sequence_as_experiments(dials_data, tmpdir):
 
     imported_exp = load.experiment_list(tmpdir.join(out).strpath)
     assert len(imported_exp) == len(image_files)
+    for exp in imported_exp:
+        assert exp.identifier != ""
 
     iset = set(exp.imageset for exp in imported_exp)
     assert len(iset) == 1
@@ -323,6 +340,8 @@ def test_import_still_sequence_as_experiments_subset(dials_data, tmpdir):
 
     imported_exp = load.experiment_list(tmpdir.join(out).strpath)
     assert len(imported_exp) == len(image_files)
+    for exp in imported_exp:
+        assert exp.identifier != ""
 
     iset = set(exp.imageset for exp in imported_exp)
     assert len(iset) == 1
@@ -346,6 +365,8 @@ def test_import_still_sequence_as_experiments_split_subset(dials_data, tmpdir):
 
     imported_exp = load.experiment_list(tmpdir.join(out).strpath)
     assert len(imported_exp) == len(image_files)
+    for exp in imported_exp:
+        assert exp.identifier != ""
 
     iset = set(exp.imageset for exp in imported_exp)
     assert len(iset) == 2
@@ -368,6 +389,8 @@ def test_with_convert_sequences_to_stills(dials_data, tmpdir):
     experiments = load.experiment_list(
         tmpdir.join("experiments_as_stills.expt").strpath
     )
+    for exp in experiments:
+        assert exp.identifier != ""
 
     # should be no goniometers
     assert experiments.scans() == [None]

--- a/test/command_line/test_integrate.py
+++ b/test/command_line/test_integrate.py
@@ -5,16 +5,24 @@ import math
 import os
 import shutil
 
+from dxtbx.serialize import load
 from dials.array_family import flex
 import procrunner
 
 
 def test2(dials_data, tmpdir):
     # Call dials.integrate
+
+    exp = load.experiment_list(
+        dials_data("centroid_test_data").join("experiments.json").strpath
+    )
+    exp[0].identifier = "foo"
+    exp.as_json(tmpdir.join("modified_input.json").strpath)
+
     result = procrunner.run(
         [
             "dials.integrate",
-            dials_data("centroid_test_data").join("experiments.json"),
+            "modified_input.json",
             "profile.fitting=False",
             "integration.integrator=3d",
             "prediction.padding=0",
@@ -23,6 +31,9 @@ def test2(dials_data, tmpdir):
     )
     assert not result.returncode and not result.stderr
 
+    experiments = load.experiment_list(tmpdir.join("integrated.expt").strpath)
+    assert experiments[0].identifier == "foo"
+
     table = flex.reflection_table.from_file(tmpdir / "integrated.refl")
     mask = table.get_flags(table.flags.integrated, all=False)
     assert len(table) == 1996
@@ -30,6 +41,8 @@ def test2(dials_data, tmpdir):
     assert "id" in table
     for row in table.rows():
         assert row["id"] == 0
+
+    assert dict(table.experiment_identifiers()) == {0: "foo"}
 
     originaltable = table
 
@@ -48,6 +61,7 @@ def test2(dials_data, tmpdir):
     j["scan"][0]["image_range"] = [11, 19]
     assert j["scan"][0]["oscillation"] == [0.0, 0.2]
     j["scan"][0]["oscillation"] = [360.0, 0.2]
+    j["experiment"][0]["identifier"] = "bar"
     with tmpdir.join("models.expt").open("w") as fh:
         json.dump(j, fh)
 
@@ -64,7 +78,11 @@ def test2(dials_data, tmpdir):
     )
     assert not result.returncode and not result.stderr
 
+    experiments = load.experiment_list(tmpdir.join("integrated.expt").strpath)
+    assert experiments[0].identifier == "bar"
+
     table = flex.reflection_table.from_file(tmpdir / "integrated.refl")
+    assert dict(table.experiment_identifiers()) == {0: "bar"}
     mask1 = table.get_flags(table.flags.integrated, all=False)
     assert len(table) == 1996
     assert mask1.count(True) == 1666
@@ -93,10 +111,17 @@ def test2(dials_data, tmpdir):
 
 
 def test_integration_with_sampling(dials_data, tmpdir):
+
+    exp = load.experiment_list(
+        dials_data("centroid_test_data").join("experiments.json").strpath
+    )
+    exp[0].identifier = "foo"
+    exp.as_json(tmpdir.join("modified_input.json").strpath)
+
     result = procrunner.run(
         [
             "dials.integrate",
-            dials_data("centroid_test_data").join("experiments.json"),
+            "modified_input.json",
             "profile.fitting=False",
             "sampling.integrate_all_reflections=False",
             "prediction.padding=0",
@@ -104,16 +129,26 @@ def test_integration_with_sampling(dials_data, tmpdir):
         working_directory=tmpdir,
     )
     assert not result.returncode and not result.stderr
+    experiments = load.experiment_list(tmpdir.join("integrated.expt").strpath)
+    assert experiments[0].identifier == "foo"
 
     table = flex.reflection_table.from_file(tmpdir / "integrated.refl")
     assert len(table) == 1000
+    assert dict(table.experiment_identifiers()) == {0: "foo"}
 
 
 def test_integration_with_sample_size(dials_data, tmpdir):
+
+    exp = load.experiment_list(
+        dials_data("centroid_test_data").join("experiments.json").strpath
+    )
+    exp[0].identifier = "foo"
+    exp.as_json(tmpdir.join("modified_input.json").strpath)
+
     result = procrunner.run(
         [
             "dials.integrate",
-            dials_data("centroid_test_data").join("experiments.json"),
+            "modified_input.json",
             "profile.fitting=False",
             "sampling.integrate_all_reflections=False",
             "sampling.minimum_sample_size=500",
@@ -122,36 +157,43 @@ def test_integration_with_sample_size(dials_data, tmpdir):
         working_directory=tmpdir,
     )
     assert not result.returncode and not result.stderr
-
+    experiments = load.experiment_list(tmpdir.join("integrated.expt").strpath)
+    assert experiments[0].identifier == "foo"
     table = flex.reflection_table.from_file(tmpdir / "integrated.refl")
     assert len(table) == 500
+    assert dict(table.experiment_identifiers()) == {0: "foo"}
 
 
-def test_multi_sequence(dials_regression, tmpdir):
+def test_multi_sweep(dials_regression, tmpdir):
+
+    expts = os.path.join(
+        dials_regression, "integration_test_data", "multi_sweep", "experiments.json"
+    )
+
+    experiments = load.experiment_list(expts)
+    for i, expt in enumerate(experiments):
+        expt.identifier = str(100 + i)
+    experiments.as_json(tmpdir.join("modified_input.json").strpath)
+
+    refls = os.path.join(
+        dials_regression, "integration_test_data", "multi_sweep", "indexed.pickle"
+    )
+
     result = procrunner.run(
-        [
-            "dials.integrate",
-            os.path.join(
-                dials_regression,
-                "integration_test_data",
-                "multi_sweep",
-                "experiments.json",
-            ),
-            os.path.join(
-                dials_regression,
-                "integration_test_data",
-                "multi_sweep",
-                "indexed.pickle",
-            ),
-            "prediction.padding=0",
-        ],
+        ["dials.integrate", "modified_input.json", refls, "prediction.padding=0"],
         working_directory=tmpdir,
     )
     assert not result.returncode and not result.stderr
     assert (tmpdir / "integrated.refl").check()
+    assert (tmpdir / "integrated.expt").check()
+
+    experiments = load.experiment_list(tmpdir.join("integrated.expt").strpath)
+    for i, expt in enumerate(experiments):
+        assert expt.identifier == str(100 + i)
 
     table = flex.reflection_table.from_file(tmpdir / "integrated.refl")
     assert len(table) == 4020
+    assert dict(table.experiment_identifiers()) == {0: "100", 1: "101"}
 
     # Check the results
     T1 = table[:2010]
@@ -173,15 +215,20 @@ def test_multi_sequence(dials_regression, tmpdir):
 
 
 def test_multi_lattice(dials_regression, tmpdir):
+
+    expts = os.path.join(
+        dials_regression, "integration_test_data", "multi_lattice", "experiments.json"
+    )
+
+    experiments = load.experiment_list(expts)
+    for i, expt in enumerate(experiments):
+        expt.identifier = str(100 + i)
+    experiments.as_json(tmpdir.join("modified_input.json").strpath)
+
     result = procrunner.run(
         [
             "dials.integrate",
-            os.path.join(
-                dials_regression,
-                "integration_test_data",
-                "multi_lattice",
-                "experiments.json",
-            ),
+            "modified_input.json",
             os.path.join(
                 dials_regression,
                 "integration_test_data",
@@ -194,9 +241,15 @@ def test_multi_lattice(dials_regression, tmpdir):
     )
     assert not result.returncode and not result.stderr
     assert tmpdir.join("integrated.refl").check()
+    assert tmpdir.join("integrated.expt").check()
+
+    experiments = load.experiment_list(tmpdir.join("integrated.expt").strpath)
+    for i, expt in enumerate(experiments):
+        assert expt.identifier == str(100 + i)
 
     table = flex.reflection_table.from_file(tmpdir / "integrated.refl")
     assert len(table) == 5605
+    assert dict(table.experiment_identifiers()) == {0: "100", 1: "101"}
 
     # Check output contains from two lattices
     exp_id = list(set(table["id"]))
@@ -240,6 +293,9 @@ def test_output_rubbish(dials_data, tmpdir):
     assert "id" in table
     for row in table.rows():
         assert row["id"] == 0
+
+    assert list(table.experiment_identifiers().keys()) == [0]
+    assert list(table.experiment_identifiers().values())  # not empty
 
 
 def test_integrate_with_kapton(dials_regression, tmpdir):

--- a/test/command_line/test_preservation_of_experiment_identifiers.py
+++ b/test/command_line/test_preservation_of_experiment_identifiers.py
@@ -1,0 +1,212 @@
+"""Test for the preservation of identifiers in dials processing."""
+import procrunner
+from dxtbx.serialize import load
+from dials.array_family import flex
+
+
+def test_preservation_of_identifiers(dials_data, tmpdir):
+    """Run the dials processing workflow, checking for preservation of identifiers.
+
+    This is just a simple case. The individual programs that are expected to
+    change the identifiers are tested separately, this is to check that the
+    other programs maintain the identifiers through processing.
+    """
+
+    # First import - should set a unique id.
+    image_files = dials_data("centroid_test_data").listdir("centroid*.cbf", sort=True)
+    result = procrunner.run(
+        ["dials.import", "output.experiments=imported.expt"]
+        + [f.strpath for f in image_files],
+        working_directory=tmpdir.strpath,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("imported.expt").check(file=1)
+
+    imported_exp_path = tmpdir.join("imported.expt").strpath
+    experiments = load.experiment_list(imported_exp_path)
+    import_expt_id = experiments[0].identifier
+    assert import_expt_id != ""
+
+    # Now find spots.
+    result = procrunner.run(
+        ["dials.find_spots", imported_exp_path, "output.reflections=strong.refl"],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("strong.refl").check(file=1)
+
+    strong_refl_path = tmpdir.join("strong.refl").strpath
+    reflections = flex.reflection_table.from_file(strong_refl_path)
+    assert dict(reflections.experiment_identifiers()) == {0: import_expt_id}
+
+    # Now index
+    result = procrunner.run(
+        [
+            "dials.index",
+            strong_refl_path,
+            imported_exp_path,
+            "output.reflections=indexed.refl",
+            "output.experiments=indexed.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("indexed.refl").check(file=1)
+    assert tmpdir.join("indexed.expt").check(file=1)
+
+    indexed_exp_path = tmpdir.join("indexed.expt").strpath
+    experiments = load.experiment_list(indexed_exp_path)
+    indexed_refl_path = tmpdir.join("indexed.refl").strpath
+    reflections = flex.reflection_table.from_file(indexed_refl_path)
+
+    indexed_expt_id = experiments[0].identifier
+    assert indexed_expt_id != ""
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now refine bravais setting
+    result = procrunner.run(
+        ["dials.refine_bravais_settings", indexed_refl_path, indexed_exp_path],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("bravais_setting_9.expt").check(file=1)
+
+    bravais_exp_path = tmpdir.join("bravais_setting_9.expt").strpath
+    experiments = load.experiment_list(bravais_exp_path)
+    assert experiments[0].identifier == indexed_expt_id
+
+    # Now reindex
+    result = procrunner.run(
+        [
+            "dials.reindex",
+            indexed_refl_path,
+            indexed_exp_path,
+            "change_of_basis_op=b,c,a",
+            "output.reflections=reindexed.refl",
+            "output.experiments=reindexed.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("reindexed.expt").check(file=1)
+    assert tmpdir.join("reindexed.refl").check(file=1)
+
+    reindexed_exp_path = tmpdir.join("reindexed.expt").strpath
+    experiments = load.experiment_list(reindexed_exp_path)
+    reindexed_refl_path = tmpdir.join("reindexed.refl").strpath
+    reflections = flex.reflection_table.from_file(reindexed_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now refine
+    result = procrunner.run(
+        [
+            "dials.refine",
+            reindexed_refl_path,
+            reindexed_exp_path,
+            "output.reflections=refined.refl",
+            "output.experiments=refined.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("refined.expt").check(file=1)
+    assert tmpdir.join("refined.refl").check(file=1)
+
+    refined_exp_path = tmpdir.join("refined.expt").strpath
+    experiments = load.experiment_list(refined_exp_path)
+    refined_refl_path = tmpdir.join("refined.refl").strpath
+    reflections = flex.reflection_table.from_file(refined_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now integrate
+    result = procrunner.run(
+        [
+            "dials.integrate",
+            refined_refl_path,
+            refined_exp_path,
+            "output.reflections=integrated.refl",
+            "output.experiments=integrated.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("integrated.expt").check(file=1)
+    assert tmpdir.join("integrated.refl").check(file=1)
+
+    integrated_exp_path = tmpdir.join("integrated.expt").strpath
+    experiments = load.experiment_list(integrated_exp_path)
+    integrated_refl_path = tmpdir.join("integrated.refl").strpath
+    reflections = flex.reflection_table.from_file(integrated_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now run cosym (symmetry fails due to small amount of data)
+    result = procrunner.run(
+        [
+            "dials.symmetry",
+            integrated_refl_path,
+            integrated_exp_path,
+            "output.reflections=symmetrized.refl",
+            "output.experiments=symmetrized.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("symmetrized.expt").check(file=1)
+    assert tmpdir.join("symmetrized.refl").check(file=1)
+
+    symmetrized_exp_path = tmpdir.join("symmetrized.expt").strpath
+    experiments = load.experiment_list(symmetrized_exp_path)
+    symmetrized_refl_path = tmpdir.join("symmetrized.refl").strpath
+    reflections = flex.reflection_table.from_file(symmetrized_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now scale
+    result = procrunner.run(
+        [
+            "dials.scale",
+            symmetrized_refl_path,
+            symmetrized_exp_path,
+            "output.reflections=scaled.refl",
+            "output.experiments=scaled.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("scaled.expt").check(file=1)
+    assert tmpdir.join("scaled.refl").check(file=1)
+
+    scaled_exp_path = tmpdir.join("scaled.expt").strpath
+    experiments = load.experiment_list(scaled_exp_path)
+    scaled_refl_path = tmpdir.join("scaled.refl").strpath
+    reflections = flex.reflection_table.from_file(scaled_refl_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]
+    assert dict(reflections.experiment_identifiers()) == {0: indexed_expt_id}
+
+    # Now do two-theta refine
+    result = procrunner.run(
+        [
+            "dials.two_theta_refine",
+            scaled_refl_path,
+            scaled_exp_path,
+            "output.experiments=tt.expt",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("tt.expt").check(file=1)
+
+    tt_exp_path = tmpdir.join("tt.expt").strpath
+    experiments = load.experiment_list(tt_exp_path)
+
+    assert list(experiments.identifiers()) == [indexed_expt_id]


### PR DESCRIPTION
This is an updated version of a previous PR (#902).

The idea is the same, generate a unique (uuid) string identifier on import, do the same when discovering lattices upon indexing, and propagate through the processing (and checking each time so that files without identifiers still work for back compatibility). Most of the file changes are updating the flatten_reflections/flatten_experiments calls, to handle any order of input data from the command line.

At the moment, most programs don't really use the identifier to any particular benefit, that can come as part of future work as required.

I have also generated a uuid in the stills indexer as a demonstration, and checked that stills processing still completes fine (although there are possibly more complex workflows that i am not able to properly check?). Without the changes to `stills_indexer.py`, no identifiers are generated (at any point in stills processing), and the processing completes the same. I would like to ask for feedback from @asmit3 or @phyy-nx as to which option is preferred:
1) Generate a uuid now, as per this PR, and let you guys change the format of this to timestamp at a later point if interested.
2) Leave `stills_indexer.py` unchanged, so that no identifiers are generated for stills at present (although this may cause issues if using the regular indexer for stills which is sometimes done?)
3) Let you add to this PR to generate a timestamp identifier in `stills_indexer.py`.