### PR TITLE
Make merging statistics robust to statistics errors from too few reflections

### DIFF
--- a/algorithms/scaling/scaling_library.py
+++ b/algorithms/scaling/scaling_library.py
@@ -15,18 +15,18 @@ import uuid
 import pkg_resources
 from copy import deepcopy
 
-import iotbx.merging_statistics
 from cctbx import miller, crystal, uctbx
 from dxtbx.model import Experiment
 from dials.array_family import flex
-from dials.util.options import OptionParser
-from dials.util import Sorry
 from dials.algorithms.scaling.Ih_table import IhTable
 from dials.algorithms.scaling.model.model import KBScalingModel
 from dials.algorithms.scaling.scaling_utilities import (
     calculate_prescaling_correction,
     DialsMergingStatisticsError,
 )
+from dials.util.merging_statistics import dataset_statistics
+from dials.util.options import OptionParser
+from dials.util import Sorry
 from iotbx import cif, mtz
 from libtbx import phil
 from mock import Mock
@@ -399,7 +399,7 @@ def merging_stats_from_scaled_array(
             "Dataset contains no equivalent reflections, merging statistics cannot be calculated."
         )
     try:
-        result = iotbx.merging_statistics.dataset_statistics(
+        result = dataset_statistics(
             i_obs=scaled_miller_array,
             n_bins=n_bins,
             anomalous=False,
@@ -413,7 +413,7 @@ def merging_stats_from_scaled_array(
             intensities_anom = intensities_anom.map_to_asu().customized_copy(
                 info=scaled_miller_array.info()
             )
-            anom_result = iotbx.merging_statistics.dataset_statistics(
+            anom_result = dataset_statistics(
                 i_obs=intensities_anom,
                 n_bins=n_bins,
                 anomalous=True,

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -6,16 +6,18 @@ from __future__ import absolute_import, division, print_function
 
 import json
 
-import iotbx.merging_statistics
-import pytest
 import procrunner
-from libtbx import phil
+import pytest
+
+from dials.algorithms.scaling.algorithm import ScalingAlgorithm, prepare_input
+from dials.array_family import flex
+from dials.util.merging_statistics import dataset_statistics
+from dials.util.options import OptionParser
 from dxtbx.serialize import load
 from dxtbx.model.experiment_list import ExperimentList
 from dxtbx.model import Crystal, Scan, Beam, Goniometer, Detector, Experiment
-from dials.array_family import flex
-from dials.util.options import OptionParser
-from dials.algorithms.scaling.algorithm import ScalingAlgorithm, prepare_input
+import iotbx.merging_statistics
+from libtbx import phil
 
 
 def run_one_scaling(working_directory, argument_list):
@@ -51,7 +53,7 @@ def get_merging_stats(
         scaled_unmerged_mtz, data_labels=data_labels
     )
     i_obs = i_obs.customized_copy(anomalous_flag=False, info=i_obs.info())
-    result = iotbx.merging_statistics.dataset_statistics(
+    result = dataset_statistics(
         i_obs=i_obs,
         n_bins=n_bins,
         anomalous=anomalous,

--- a/report/test_plots.py
+++ b/report/test_plots.py
@@ -19,7 +19,7 @@ from dials.report.plots import (
     AnomalousPlotter,
 )
 from dials.util.batch_handling import batch_manager
-from iotbx.merging_statistics import dataset_statistics
+from dials.util.merging_statistics import dataset_statistics
 
 
 @pytest.fixture

--- a/util/export_mmcif.py
+++ b/util/export_mmcif.py
@@ -5,13 +5,13 @@ import logging
 import math
 import time
 
-import dials.util.version
-from dials.util.filter_reflections import filter_reflection_table
-import iotbx.cif.model
-from cctbx.sgtbx import bravais_types
-from cctbx import miller
 from cctbx import crystal as cctbxcrystal
-from iotbx.merging_statistics import dataset_statistics
+from cctbx import miller
+from cctbx.sgtbx import bravais_types
+from dials.util.filter_reflections import filter_reflection_table
+from dials.util.merging_statistics import dataset_statistics
+import dials.util.version
+import iotbx.cif.model
 from libtbx import Auto
 
 logger = logging.getLogger(__name__)

--- a/util/merging_statistics.py
+++ b/util/merging_statistics.py
@@ -1,0 +1,44 @@
+"""
+An augmentation of iotbx.merging_statistics, kinder in the case of few reflections.
+
+This module provides a decorated version of iotbx.merging_statistics.data_statistics
+that tries to be more accommodating in the case of few reflections, as in a small
+molecule or small wedge data set.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from iotbx import merging_statistics
+
+
+def dataset_statistics(*args, **kwargs):
+    # type: (...) -> merging_statistics.dataset_statistics
+    """
+    Calculate merging statistics, handling errors arising from too few reflections.
+
+    Try to return a iotbx.merging_statistics.dataset_statistics instance with default
+    parameters.  If a StatisticsError is encountered because of too few reflections,
+    try again using the 'counting_sorted' binning algorithm.  If that still doesn't
+    work, progressively reduce the number of bins until successful, or re-raise the
+    StatisticsError if no success is possible with fewer than six bins.
+
+    Args:
+        *args:  Positional arguments of iotbx.merging_statistics.dataset_statistics.
+        **kwargs:  Keyword arguments of iotbx.merging_statistics.dataset_statistics.
+
+    Returns:
+        An iotbx. merging_statistics.dataset_statistics object containing the
+        calculated merging statistics.
+    """
+    while True:
+        try:
+            return merging_statistics.dataset_statistics(*args, **kwargs)
+        except merging_statistics.StatisticsError:
+            if kwargs["binning_method"] != "counting_sorted":
+                kwargs["binning_method"] = "counting_sorted"
+            elif kwargs["n_bins"] > 8:
+                kwargs["n_bins"] -= 3
+            else:
+                raise
+
+            continue

--- a/util/resolutionizer.py
+++ b/util/resolutionizer.py
@@ -15,6 +15,7 @@ from dials.util.batch_handling import (
     assign_batches_to_reflections,
 )
 from dials.util.filter_reflections import filter_reflection_table
+from dials.util.merging_statistics import dataset_statistics
 
 logger = logging.getLogger(__name__)
 
@@ -369,9 +370,7 @@ class Resolutionizer(object):
 
         self._intensities = i_obs
 
-        import iotbx.merging_statistics
-
-        self._merging_statistics = iotbx.merging_statistics.dataset_statistics(
+        self._merging_statistics = dataset_statistics(
             i_obs=i_obs,
             n_bins=self._params.nbins,
             cc_one_half_significance_level=self._params.cc_half_significance_level,


### PR DESCRIPTION
Anywhere where we use `iotbx.merging_statistics.dataset_statistics`, we are at risk of encountering errors such as `iotbx.merging_statistics.StatisticsError` when there are very few observations.  This is common in small molecule work and work-arounds to this have already been necessary in xia2 (see https://github.com/xia2/xia2/commit/974960cb0f9cccc700e369a349d13df7d0c40ee2) since the module in question was never designed with small molecule data in mind.

This PR introduces a decorated version of `iotbx.merging_statistics.dataset_statistics`, which tries the following until the first success:
1. to calculate the merging statistics with the standard default behaviour of `iotbx.merging_statistics.dataset_statistics`,
2. to calculate the merging statistics with the `"counting_sorted"` binning method, which aims to have roughly equal numbers of reflections in each bin,
3. to retain the `"counting_sorted"` binning method and progressively reduce the number of bins until there are fewer than six bins at which point,
4. it re-raises the `StatisticsError`.

This is clearly not a true fix, just an ugly work-around.  Improvement suggestions welcome.

There are a few resorted imports too.