### PR TITLE
Simplify rmsd convergence tests

### DIFF
--- a/algorithms/scaling/error_model/engine.py
+++ b/algorithms/scaling/error_model/engine.py
@@ -172,9 +172,10 @@ class ErrorModelRefinery(object):
         except IndexError:
             return False
 
-        tests = [abs((r2 - r1) / r2) < self._avals_tolerance if r2 > 0 else True]
-
-        return all(tests)
+        if r2 > 0:
+            return abs((r2 - r1) / r2) < self._avals_tolerance
+        else:
+            return True
 
     def _refine_a(self):
         parameterisation = ErrorModelA_APM(self.model)

--- a/algorithms/scaling/scaling_refiner.py
+++ b/algorithms/scaling/scaling_refiner.py
@@ -179,11 +179,10 @@ class ScalingRefinery(object):
         except IndexError:
             return False
 
-        tests = [
-            abs((r2[0] - r1[0]) / r2[0]) < self._rmsd_tolerance if r2[0] > 0 else True
-        ]
-
-        return all(tests)
+        if r2 > 0:
+            return abs((r2[0] - r1[0]) / r2[0]) < self._rmsd_tolerance
+        else:
+            return True
 
     def prepare_for_step(self):
         """Update the parameterisation and prepare the target function. Overwrites

--- a/algorithms/scaling/scaling_refiner.py
+++ b/algorithms/scaling/scaling_refiner.py
@@ -179,7 +179,7 @@ class ScalingRefinery(object):
         except IndexError:
             return False
 
-        if r2 > 0:
+        if r2[0] > 0:
             return abs((r2[0] - r1[0]) / r2[0]) < self._rmsd_tolerance
         else:
             return True


### PR DESCRIPTION
The list comprehension and `all()` were probably legacy from dials.refine, which has a 3D RMSD (X, Y and Z) and thus tests each dimension. These uses in scaling appear to have a 1D RMSD only, so this can be simplified, making the functions easier to read.