### PR TITLE
Stream reflectiontable msgpack directly to file

### DIFF
--- a/array_family/boost_python/flex_reflection_table.cc
+++ b/array_family/boost_python/flex_reflection_table.cc
@@ -11,6 +11,7 @@
 #include <boost/python.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
+#include <boost_adaptbx/python_streambuf.h>
 #include <numeric>
 #include <dials/array_family/boost_python/flex_table_suite.h>
 #include <dials/array_family/reflection_table.h>
@@ -28,6 +29,7 @@
 namespace dials { namespace af { namespace boost_python {
 
   using namespace boost::python;
+  using boost_adaptbx::python::streambuf;
   using dials::algorithms::profile_model::gaussian_rs::CoordinateSystem;
   using dials::model::Observation;
   using dials::model::Shoebox;
@@ -826,6 +828,16 @@ namespace dials { namespace af { namespace boost_python {
   }
 
   /**
+   * Pack the reflection table in msgpack format into a streambuf object
+   * @param self The reflection table
+   * @param output A streambuf object encapsulating a Python file-like object
+   */
+  void reflection_table_as_msgpack_to_file(reflection_table self, streambuf& output) {
+    streambuf::ostream os(output);
+    msgpack::pack(os, self);
+  }
+
+  /**
    * Override default reference func to avoid copying
    */
   bool reflection_table_reference_func(msgpack::type::object_type type,
@@ -989,6 +1001,7 @@ namespace dials { namespace af { namespace boost_python {
              &split_indices_by_experiment_id<flex_table_type>)
         .def("compute_phi_range", &compute_phi_range<flex_table_type>)
         .def("as_msgpack", &reflection_table_as_msgpack)
+        .def("as_msgpack_to_file", &reflection_table_as_msgpack_to_file)
         .def("from_msgpack", &reflection_table_from_msgpack)
         .staticmethod("from_msgpack")
         .def("experiment_identifiers", &T::experiment_identifiers)

--- a/array_family/boost_python/flex_reflection_table.cc
+++ b/array_family/boost_python/flex_reflection_table.cc
@@ -11,7 +11,7 @@
 #include <boost/python.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
-#include <boost_adaptbx/python_streambuf.h>
+#include <dials/util/python_streambuf.h>
 #include <numeric>
 #include <dials/array_family/boost_python/flex_table_suite.h>
 #include <dials/array_family/reflection_table.h>
@@ -29,7 +29,7 @@
 namespace dials { namespace af { namespace boost_python {
 
   using namespace boost::python;
-  using boost_adaptbx::python::streambuf;
+  using dials::util::streambuf;
   using dials::algorithms::profile_model::gaussian_rs::CoordinateSystem;
   using dials::model::Observation;
   using dials::model::Shoebox;

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -224,7 +224,7 @@ class _(object):
         if filename and hasattr(filename, "__fspath__"):
             filename = filename.__fspath__()
         with libtbx.smart_open.for_writing(filename, "wb") as outfile:
-            outfile.write(self.as_msgpack())
+            self.as_msgpack_to_file(boost.python.streambuf(python_file_obj=outfile))
 
     @staticmethod
     def from_msgpack_file(filename):

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -11,6 +11,7 @@ import boost.python
 import cctbx.array_family.flex
 import cctbx.miller
 import dials_array_family_flex_ext
+import dials.util.ext
 import libtbx.smart_open
 import six
 import six.moves.cPickle as pickle
@@ -224,7 +225,7 @@ class _(object):
         if filename and hasattr(filename, "__fspath__"):
             filename = filename.__fspath__()
         with libtbx.smart_open.for_writing(filename, "wb") as outfile:
-            self.as_msgpack_to_file(boost.python.streambuf(python_file_obj=outfile))
+            self.as_msgpack_to_file(dials.util.ext.streambuf(python_file_obj=outfile))
 
     @staticmethod
     def from_msgpack_file(filename):

--- a/newsfragments/1115.feature
+++ b/newsfragments/1115.feature
@@ -1,0 +1,1 @@
+Significantly reduce the amount of memory required to write .refl output files

--- a/util/SConscript
+++ b/util/SConscript
@@ -9,3 +9,7 @@ if os.name == "nt":
     env.Prepend(LIBS=["Advapi32"])
 
 env.SharedLibrary(target="#/lib/dials_util_ext", source=sources, LIBS=env["LIBS"])
+env.SharedLibrary(
+    target="#/lib/dials_util_streambuf_test_ext",
+    source="boost_python/streambuf_test_ext.cpp",
+)

--- a/util/boost_python/ext.cc
+++ b/util/boost_python/ext.cc
@@ -3,8 +3,47 @@
 #include <dials/util/scale_down_array.h>
 #include <dials/util/masking.h>
 #include <dials/util/export_mtz_helpers.h>
+#include <dials/util/python_streambuf.h>
 
+std::size_t dials::util::streambuf::default_buffer_size = 1024;
 namespace dials { namespace util { namespace boost_python {
+  struct python_streambuf_wrapper
+  {
+    typedef dials::util::streambuf wt;
+
+    static void
+    wrap()
+    {
+      using namespace boost::python;
+      class_<wt, boost::noncopyable>("streambuf", no_init)
+        .def(init<boost::python::object&, std::size_t>((
+          arg("python_file_obj"),
+          arg("buffer_size")=0)))
+        .def_readwrite(
+          "default_buffer_size", wt::default_buffer_size,
+          "The default size of the buffer sitting "
+          "between a Python file object and a C++ stream.")
+      ;
+    }
+  };
+
+  struct python_ostream_wrapper
+  {
+    typedef dials::util::ostream wt;
+
+    static void
+    wrap()
+    {
+      using namespace boost::python;
+      class_<std::ostream, boost::noncopyable>("std_ostream", no_init);
+      class_<wt, boost::noncopyable, bases<std::ostream> >("ostream", no_init)
+        .def(init<boost::python::object&, std::size_t>((
+          arg("python_file_obj"),
+          arg("buffer_size")=0)))
+      ;
+    }
+  };
+
 
   using namespace boost::python;
   BOOST_PYTHON_MODULE(dials_util_ext) {
@@ -32,5 +71,8 @@ namespace dials { namespace util { namespace boost_python {
     class_<ResolutionMaskGenerator>("ResolutionMaskGenerator", no_init)
       .def(init<const BeamBase &, const Panel &>())
       .def("apply", &ResolutionMaskGenerator::apply);
+
+    python_streambuf_wrapper::wrap();
+    python_ostream_wrapper::wrap();
   }
 }}}  // namespace dials::util::boost_python

--- a/util/boost_python/ext.cc
+++ b/util/boost_python/ext.cc
@@ -7,43 +7,32 @@
 
 std::size_t dials::util::streambuf::default_buffer_size = 1024;
 namespace dials { namespace util { namespace boost_python {
-  struct python_streambuf_wrapper
-  {
+  struct python_streambuf_wrapper {
     typedef dials::util::streambuf wt;
 
-    static void
-    wrap()
-    {
+    static void wrap() {
       using namespace boost::python;
       class_<wt, boost::noncopyable>("streambuf", no_init)
-        .def(init<boost::python::object&, std::size_t>((
-          arg("python_file_obj"),
-          arg("buffer_size")=0)))
-        .def_readwrite(
-          "default_buffer_size", wt::default_buffer_size,
-          "The default size of the buffer sitting "
-          "between a Python file object and a C++ stream.")
-      ;
+        .def(init<boost::python::object &, std::size_t>(
+          (arg("python_file_obj"), arg("buffer_size") = 0)))
+        .def_readwrite("default_buffer_size",
+                       wt::default_buffer_size,
+                       "The default size of the buffer sitting "
+                       "between a Python file object and a C++ stream.");
     }
   };
 
-  struct python_ostream_wrapper
-  {
+  struct python_ostream_wrapper {
     typedef dials::util::ostream wt;
 
-    static void
-    wrap()
-    {
+    static void wrap() {
       using namespace boost::python;
       class_<std::ostream, boost::noncopyable>("std_ostream", no_init);
       class_<wt, boost::noncopyable, bases<std::ostream> >("ostream", no_init)
-        .def(init<boost::python::object&, std::size_t>((
-          arg("python_file_obj"),
-          arg("buffer_size")=0)))
-      ;
+        .def(init<boost::python::object &, std::size_t>(
+          (arg("python_file_obj"), arg("buffer_size") = 0)));
     }
   };
-
 
   using namespace boost::python;
   BOOST_PYTHON_MODULE(dials_util_ext) {

--- a/util/boost_python/streambuf_test_ext.cpp
+++ b/util/boost_python/streambuf_test_ext.cpp
@@ -7,14 +7,14 @@
 namespace dials { namespace util { namespace {
 
   template <class StreamType>
-  boost::python::object append_status(StreamType const &s, std::string &result) {
+  boost::python::object append_status(StreamType const& s, std::string& result) {
     if (!s.good()) result += "[ ";
     if (s.bad()) result += "bad, ";
     if (s.fail()) result += "fail, ";
     if (s.eof()) result += "eof";
     if (!s.good()) result += " ]";
-    boost::python::object data_bytes(
-      boost::python::handle<>(PyBytes_FromStringAndSize(result.c_str(), result.size())));
+    boost::python::object data_bytes(boost::python::handle<>(
+      PyBytes_FromStringAndSize(result.c_str(), result.size())));
     return data_bytes;
   }
 
@@ -26,7 +26,7 @@ namespace dials { namespace util { namespace {
     std::string word, result;
 
     while (is >> word) {
-        result += word + ", ";
+      result += word + ", ";
     };
 
     return append_status(is, result);
@@ -37,15 +37,20 @@ namespace dials { namespace util { namespace {
     std::string word, result;
 
     is.seekg(6);
-    is >> word; result += word + ", "; // should
+    is >> word;
+    result += word + ", ";  // should
     is.seekg(6, std::ios_base::beg);
-    is >> word; result += word + ", "; // should
+    is >> word;
+    result += word + ", ";  // should
     is.seekg(-3, std::ios_base::cur);
-    is >> word; result += word + ", "; // uld
+    is >> word;
+    result += word + ", ";  // uld
     is.seekg(-11, std::ios_base::cur);
-    is >> word; result += word + ", "; // ding
+    is >> word;
+    result += word + ", ";  // ding
     is.seekg(-4, std::ios_base::end);
-    is >> word; result += word + ", "; // fun
+    is >> word;
+    result += word + ", ";  // fun
 
     return append_status(is, result);
   }
@@ -54,13 +59,15 @@ namespace dials { namespace util { namespace {
     streambuf::istream is(input);
     std::string word, result;
 
-    is >> word; result += word + ", ";
-    is >> word; result += word + ", ";
+    is >> word;
+    result += word + ", ";
+    is >> word;
+    result += word + ", ";
 
     return append_status(is, result);
   }
 
-  boost::python::object write_word_ostream(std::ostream &os) {
+  boost::python::object write_word_ostream(std::ostream& os) {
     std::string result;
 
     os << 2 << " times " << 1.6 << " equals " << 3.2;
@@ -69,7 +76,7 @@ namespace dials { namespace util { namespace {
     return append_status(os, result);
   }
 
-  boost::python::object write_and_seek_ostream(std::ostream &os) {
+  boost::python::object write_and_seek_ostream(std::ostream& os) {
     std::string result;
 
     os << 1000 << " timEs " << 5555 << " equalS " << 1000000;
@@ -96,9 +103,7 @@ namespace dials { namespace util { namespace {
     return write_and_seek_ostream(os);
   }
 
-  void
-  wrap_all()
-  {
+  void wrap_all() {
     using namespace boost::python;
     def("read_word", read_word);
     def("read_and_seek", read_and_seek);
@@ -109,9 +114,8 @@ namespace dials { namespace util { namespace {
     def("write_and_seek", write_and_seek_ostream);
   }
 
-}}} // namespace dials::util::<anonymous>
+}}}  // namespace dials::util::
 
-BOOST_PYTHON_MODULE(dials_util_streambuf_test_ext)
-{
+BOOST_PYTHON_MODULE(dials_util_streambuf_test_ext) {
   dials::util::wrap_all();
 }

--- a/util/boost_python/streambuf_test_ext.cpp
+++ b/util/boost_python/streambuf_test_ext.cpp
@@ -7,19 +7,21 @@
 namespace dials { namespace util { namespace {
 
   template <class StreamType>
-  std::string append_status(StreamType const &s, std::string &result) {
+  boost::python::object append_status(StreamType const &s, std::string &result) {
     if (!s.good()) result += "[ ";
     if (s.bad()) result += "bad, ";
     if (s.fail()) result += "fail, ";
     if (s.eof()) result += "eof";
     if (!s.good()) result += " ]";
-    return result;
+    boost::python::object data_bytes(
+      boost::python::handle<>(PyBytes_FromStringAndSize(result.c_str(), result.size())));
+    return data_bytes;
   }
 
   // Coding should be fun
   // 012345678901234567890
 
-  std::string read_word(streambuf& input) {
+  boost::python::object read_word(streambuf& input) {
     streambuf::istream is(input);
     std::string word, result;
 
@@ -30,7 +32,7 @@ namespace dials { namespace util { namespace {
     return append_status(is, result);
   }
 
-  std::string read_and_seek(streambuf& input) {
+  boost::python::object read_and_seek(streambuf& input) {
     streambuf::istream is(input);
     std::string word, result;
 
@@ -48,7 +50,7 @@ namespace dials { namespace util { namespace {
     return append_status(is, result);
   }
 
-  std::string partial_read(streambuf& input) {
+  boost::python::object partial_read(streambuf& input) {
     streambuf::istream is(input);
     std::string word, result;
 
@@ -58,7 +60,7 @@ namespace dials { namespace util { namespace {
     return append_status(is, result);
   }
 
-  std::string write_word_ostream(std::ostream &os) {
+  boost::python::object write_word_ostream(std::ostream &os) {
     std::string result;
 
     os << 2 << " times " << 1.6 << " equals " << 3.2;
@@ -66,7 +68,7 @@ namespace dials { namespace util { namespace {
     return append_status(os, result);
   }
 
-  std::string write_and_seek_ostream(std::ostream &os) {
+  boost::python::object write_and_seek_ostream(std::ostream &os) {
     std::string result;
 
     os << 1000 << " timEs " << 5555 << " equalS " << 1000000;
@@ -82,12 +84,12 @@ namespace dials { namespace util { namespace {
     return append_status(os, result);
   }
 
-  std::string write_word(streambuf& output) {
+  boost::python::object write_word(streambuf& output) {
     streambuf::ostream os(output);
     return write_word_ostream(os);
   }
 
-  std::string write_and_seek(streambuf& output) {
+  boost::python::object write_and_seek(streambuf& output) {
     streambuf::ostream os(output);
     return write_and_seek_ostream(os);
   }

--- a/util/boost_python/streambuf_test_ext.cpp
+++ b/util/boost_python/streambuf_test_ext.cpp
@@ -2,158 +2,107 @@
 #include <boost/python/def.hpp>
 
 #include <dials/util/python_streambuf.h>
-#include <boost/timer.hpp>
 #include <fstream>
 
 namespace dials { namespace util { namespace {
 
   template <class StreamType>
-  void append_status(StreamType const &s, std::string &result) {
+  std::string append_status(StreamType const &s, std::string &result) {
     if (!s.good()) result += "[ ";
     if (s.bad()) result += "bad, ";
     if (s.fail()) result += "fail, ";
     if (s.eof()) result += "eof";
     if (!s.good()) result += " ]";
+    return result;
   }
 
-  std::string actual_read_test(std::istream &is, std::string const &what) {
-    // Coding should be fun
-    // 012345678901234567890
+  // Coding should be fun
+  // 012345678901234567890
+
+  std::string read_word(streambuf& input) {
+    streambuf::istream is(input);
     std::string word, result;
-    if (what == "read") {
-      while (is >> word) {
+
+    while (is >> word) {
         result += word + ", ";
-      }
-    }
-    else if (what == "read and seek") {
-      is.seekg(6);
-      is >> word; result += word + ", "; // should
-      is.seekg(6, std::ios_base::beg);
-      is >> word; result += word + ", "; // should
-      is.seekg(-3, std::ios_base::cur);
-      is >> word; result += word + ", "; // uld
-      is.seekg(-11, std::ios_base::cur);
-      is >> word; result += word + ", "; // ding
-      is.seekg(-4, std::ios_base::end);
-      is >> word; result += word + ", "; // fun
-    }
-    else if (what == "partial read") {
-      is >> word; result += word + ", ";
-      is >> word; result += word + ", ";
-    }
-    append_status(is, result);
-    return result;
+    };
+
+    return append_status(is, result);
   }
 
-  std::string actual_write_test(std::ostream &os, std::string const &what) {
+  std::string read_and_seek(streambuf& input) {
+    streambuf::istream is(input);
+    std::string word, result;
+
+    is.seekg(6);
+    is >> word; result += word + ", "; // should
+    is.seekg(6, std::ios_base::beg);
+    is >> word; result += word + ", "; // should
+    is.seekg(-3, std::ios_base::cur);
+    is >> word; result += word + ", "; // uld
+    is.seekg(-11, std::ios_base::cur);
+    is >> word; result += word + ", "; // ding
+    is.seekg(-4, std::ios_base::end);
+    is >> word; result += word + ", "; // fun
+
+    return append_status(is, result);
+  }
+
+  std::string partial_read(streambuf& input) {
+    streambuf::istream is(input);
+    std::string word, result;
+
+    is >> word; result += word + ", ";
+    is >> word; result += word + ", ";
+
+    return append_status(is, result);
+  }
+
+  std::string write_word_ostream(std::ostream &os) {
     std::string result;
-    if (what == "write") {
-      os << 2 << " times " << 1.6 << " equals " << 3.2;
-    }
-    else if (what.find("write and seek") == 0) {
-      os << 1000 << " timEs " << 5555 << " equalS " << 1000000;
-      // 1000 timEs 5555 equalS 1700000
-      // 0123456789012345678901234567890
-      if (what.find("(cur)") != std::string::npos) {
-        os.seekp(-19, std::ios_base::cur);
-        os << 1000;
-        os.seekp(6, std::ios_base::cur);
-        os << "s";
-        os.seekp(-14, std::ios_base::cur);
-        os << "e";
-      }
-    }
-    append_status(os, result);
-    return result;
+
+    os << 2 << " times " << 1.6 << " equals " << 3.2;
+
+    return append_status(os, result);
   }
 
-  std::string test_read(streambuf& input,
-                        std::string const &what)
-  {
-    streambuf::istream is(input);
-    return actual_read_test(is, what);
+  std::string write_and_seek_ostream(std::ostream &os) {
+    std::string result;
+
+    os << 1000 << " timEs " << 5555 << " equalS " << 1000000;
+    // 1000 timEs 5555 equalS 1700000
+    // 0123456789012345678901234567890
+    os.seekp(-19, std::ios_base::cur);
+    os << 1000;
+    os.seekp(6, std::ios_base::cur);
+    os << "s";
+    os.seekp(-14, std::ios_base::cur);
+    os << "e";
+
+    return append_status(os, result);
   }
 
-  std::string test_write(streambuf& output,
-                         std::string const &what)
-  {
+  std::string write_word(streambuf& output) {
     streambuf::ostream os(output);
-    return actual_write_test(os, what);
+    return write_word_ostream(os);
   }
 
-  double work_for_time_read(std::istream &is) {
-    int h,k,l,foo;
-    double f,s;
-    double result = 0;
-    while (is >> h >> k >> l) {
-      if (h == 0 && k == 0 && l == 0) break;
-      is >> f >> s >> foo;
-      result += (h + k + l)*s*f;
-    }
-    return result;
-  }
-
-  void work_for_time_write(std::ostream &os) {
-    int i=1, j=1;
-    for (int n=0; n < 1000000; ++n) {
-      os << j << " ";
-      int j_ = (i + j) % 65536;
-      i = j;
-      j = j_;
-    }
-  }
-
-  void time_read(char const *path, streambuf& input) {
-    boost::timer t;
-    streambuf::istream is(input);
-    work_for_time_read(is);
-    double py_t = t.elapsed();
-    std::ifstream std_is(path);
-    t.restart();
-    work_for_time_read(std_is);
-    double py_cpp = t.elapsed();
-    std::cout << "- Reading -\nPython adaptor: " << py_t;
-    std::cout << "\nPure C++: " << py_cpp;
-    if (py_t > py_cpp) {
-      std::cout << "\noverhead: " << (py_t - py_cpp)/py_t*100 << " %";
-    }
-    std::cout << "\n\n";
-  }
-
-  void time_write(char const *path, streambuf& output) {
-    boost::timer t;
+  std::string write_and_seek(streambuf& output) {
     streambuf::ostream os(output);
-    work_for_time_write(os);
-    double py_t = t.elapsed();
-    std::ofstream std_os(path);
-    t.restart();
-    work_for_time_write(std_os);
-    double py_cpp = t.elapsed();
-    std::cout << "- Writing -\nPython adaptor: " << py_t;
-    std::cout << "\nPure C++: " << py_cpp;
-    if (py_t > py_cpp) {
-      std::cout << "\noverhead: " << (py_t - py_cpp)/py_t*100 << " %";
-    }
-    std::cout << "\n\n";
+    return write_and_seek_ostream(os);
   }
-
-  void
-  call_with_stderr_stdout_do_nothing(
-    std::ostream& err_stream,
-    std::ostream& out_stream)
-  {}
 
   void
   wrap_all()
   {
     using namespace boost::python;
-    def("test_read", test_read);
-    def("test_write", actual_write_test);
-    def("test_write", test_write);
-    def("time_read", time_read);
-    def("time_write", time_write);
-    def("call_with_stderr_stdout_do_nothing",
-         call_with_stderr_stdout_do_nothing);
+    def("read_word", read_word);
+    def("read_and_seek", read_and_seek);
+    def("partial_read", partial_read);
+    def("write_word", write_word);
+    def("write_word", write_word_ostream);
+    def("write_and_seek", write_and_seek);
+    def("write_and_seek", write_and_seek_ostream);
   }
 
 }}} // namespace dials::util::<anonymous>

--- a/util/boost_python/streambuf_test_ext.cpp
+++ b/util/boost_python/streambuf_test_ext.cpp
@@ -64,6 +64,7 @@ namespace dials { namespace util { namespace {
     std::string result;
 
     os << 2 << " times " << 1.6 << " equals " << 3.2;
+    os.flush();
 
     return append_status(os, result);
   }
@@ -80,6 +81,7 @@ namespace dials { namespace util { namespace {
     os << "s";
     os.seekp(-14, std::ios_base::cur);
     os << "e";
+    os.flush();
 
     return append_status(os, result);
   }

--- a/util/boost_python/streambuf_test_ext.cpp
+++ b/util/boost_python/streambuf_test_ext.cpp
@@ -1,0 +1,164 @@
+#include <boost/python/module.hpp>
+#include <boost/python/def.hpp>
+
+#include <dials/util/python_streambuf.h>
+#include <boost/timer.hpp>
+#include <fstream>
+
+namespace dials { namespace util { namespace {
+
+  template <class StreamType>
+  void append_status(StreamType const &s, std::string &result) {
+    if (!s.good()) result += "[ ";
+    if (s.bad()) result += "bad, ";
+    if (s.fail()) result += "fail, ";
+    if (s.eof()) result += "eof";
+    if (!s.good()) result += " ]";
+  }
+
+  std::string actual_read_test(std::istream &is, std::string const &what) {
+    // Coding should be fun
+    // 012345678901234567890
+    std::string word, result;
+    if (what == "read") {
+      while (is >> word) {
+        result += word + ", ";
+      }
+    }
+    else if (what == "read and seek") {
+      is.seekg(6);
+      is >> word; result += word + ", "; // should
+      is.seekg(6, std::ios_base::beg);
+      is >> word; result += word + ", "; // should
+      is.seekg(-3, std::ios_base::cur);
+      is >> word; result += word + ", "; // uld
+      is.seekg(-11, std::ios_base::cur);
+      is >> word; result += word + ", "; // ding
+      is.seekg(-4, std::ios_base::end);
+      is >> word; result += word + ", "; // fun
+    }
+    else if (what == "partial read") {
+      is >> word; result += word + ", ";
+      is >> word; result += word + ", ";
+    }
+    append_status(is, result);
+    return result;
+  }
+
+  std::string actual_write_test(std::ostream &os, std::string const &what) {
+    std::string result;
+    if (what == "write") {
+      os << 2 << " times " << 1.6 << " equals " << 3.2;
+    }
+    else if (what.find("write and seek") == 0) {
+      os << 1000 << " timEs " << 5555 << " equalS " << 1000000;
+      // 1000 timEs 5555 equalS 1700000
+      // 0123456789012345678901234567890
+      if (what.find("(cur)") != std::string::npos) {
+        os.seekp(-19, std::ios_base::cur);
+        os << 1000;
+        os.seekp(6, std::ios_base::cur);
+        os << "s";
+        os.seekp(-14, std::ios_base::cur);
+        os << "e";
+      }
+    }
+    append_status(os, result);
+    return result;
+  }
+
+  std::string test_read(streambuf& input,
+                        std::string const &what)
+  {
+    streambuf::istream is(input);
+    return actual_read_test(is, what);
+  }
+
+  std::string test_write(streambuf& output,
+                         std::string const &what)
+  {
+    streambuf::ostream os(output);
+    return actual_write_test(os, what);
+  }
+
+  double work_for_time_read(std::istream &is) {
+    int h,k,l,foo;
+    double f,s;
+    double result = 0;
+    while (is >> h >> k >> l) {
+      if (h == 0 && k == 0 && l == 0) break;
+      is >> f >> s >> foo;
+      result += (h + k + l)*s*f;
+    }
+    return result;
+  }
+
+  void work_for_time_write(std::ostream &os) {
+    int i=1, j=1;
+    for (int n=0; n < 1000000; ++n) {
+      os << j << " ";
+      int j_ = (i + j) % 65536;
+      i = j;
+      j = j_;
+    }
+  }
+
+  void time_read(char const *path, streambuf& input) {
+    boost::timer t;
+    streambuf::istream is(input);
+    work_for_time_read(is);
+    double py_t = t.elapsed();
+    std::ifstream std_is(path);
+    t.restart();
+    work_for_time_read(std_is);
+    double py_cpp = t.elapsed();
+    std::cout << "- Reading -\nPython adaptor: " << py_t;
+    std::cout << "\nPure C++: " << py_cpp;
+    if (py_t > py_cpp) {
+      std::cout << "\noverhead: " << (py_t - py_cpp)/py_t*100 << " %";
+    }
+    std::cout << "\n\n";
+  }
+
+  void time_write(char const *path, streambuf& output) {
+    boost::timer t;
+    streambuf::ostream os(output);
+    work_for_time_write(os);
+    double py_t = t.elapsed();
+    std::ofstream std_os(path);
+    t.restart();
+    work_for_time_write(std_os);
+    double py_cpp = t.elapsed();
+    std::cout << "- Writing -\nPython adaptor: " << py_t;
+    std::cout << "\nPure C++: " << py_cpp;
+    if (py_t > py_cpp) {
+      std::cout << "\noverhead: " << (py_t - py_cpp)/py_t*100 << " %";
+    }
+    std::cout << "\n\n";
+  }
+
+  void
+  call_with_stderr_stdout_do_nothing(
+    std::ostream& err_stream,
+    std::ostream& out_stream)
+  {}
+
+  void
+  wrap_all()
+  {
+    using namespace boost::python;
+    def("test_read", test_read);
+    def("test_write", actual_write_test);
+    def("test_write", test_write);
+    def("time_read", time_read);
+    def("time_write", time_write);
+    def("call_with_stderr_stdout_do_nothing",
+         call_with_stderr_stdout_do_nothing);
+  }
+
+}}} // namespace dials::util::<anonymous>
+
+BOOST_PYTHON_MODULE(dials_util_streambuf_test_ext)
+{
+  dials::util::wrap_all();
+}

--- a/util/ext.py
+++ b/util/ext.py
@@ -7,4 +7,6 @@ __all__ = (  # noqa: F405
     "add_dials_batches",
     "dials_u_to_mosflm",
     "scale_down_array",
+    "streambuf",
+    "ostream",
 )

--- a/util/python_streambuf.h
+++ b/util/python_streambuf.h
@@ -1,0 +1,489 @@
+#ifndef DIALS_UTIL_PYTHON_STREAMBUF_H
+#define DIALS_UTIL_PYTHON_STREAMBUF_H
+
+#include <boost/python/object.hpp>
+#include <boost/python/str.hpp>
+#include <boost/python/extract.hpp>
+
+#include <boost/optional.hpp>
+#include <boost/utility/typed_in_place_factory.hpp>
+
+#include <streambuf>
+#include <iostream>
+
+#if PY_MAJOR_VERSION >= 3
+#define IS_PY3K
+#endif
+
+namespace dials { namespace util {
+
+namespace bp = boost::python;
+
+/// A stream buffer getting data from and putting data into a Python file object
+/** The aims are as follow:
+
+    - Given a C++ function acting on a standard stream, e.g.
+
+      \code
+      void read_inputs(std::istream& input) {
+        ...
+        input >> something >> something_else;
+      }
+      \endcode
+
+      and given a piece of Python code which creates a file-like object,
+      to be able to pass this file object to that C++ function, e.g.
+
+      \code
+      import gzip
+      gzip_file_obj = gzip.GzipFile(...)
+      read_inputs(gzip_file_obj)
+      \endcode
+
+      and have the standard stream pull data from and put data into the Python
+      file object.
+
+    - When Python \c read_inputs() returns, the Python object is able to
+      continue reading or writing where the C++ code left off.
+
+    - Operations in C++ on mere files should be competitively fast compared
+      to the direct use of \c std::fstream.
+
+
+    \b Motivation
+
+      - the standard Python library offer of file-like objects (files,
+        compressed files and archives, network, ...) is far superior to the
+        offer of streams in the C++ standard library and Boost C++ libraries.
+
+      - i/o code involves a fair amount of text processing which is more
+        efficiently prototyped in Python but then one may need to rewrite
+        a time-critical part in C++, in as seamless a manner as possible.
+
+    \b Usage
+
+    This is 2-step:
+
+      - a trivial wrapper function
+
+        \code
+          using dials::util::streambuf;
+          void read_inputs_wrapper(streambuf& input)
+          {
+            streambuf::istream is(input);
+            read_inputs(is);
+          }
+
+          def("read_inputs", read_inputs_wrapper);
+        \endcode
+
+        which has to be written every time one wants a Python binding for
+        such a C++ function.
+
+      - the Python side
+
+        \code
+          from boost.python import streambuf
+          read_inputs(streambuf(python_file_obj=obj, buffer_size=1024))
+        \endcode
+
+        \c buffer_size is optional. See also: \c default_buffer_size
+
+  Note: references are to the C++ standard (the numbers between parentheses
+  at the end of references are margin markers).
+*/
+class streambuf : public std::basic_streambuf<char>
+{
+  private:
+    typedef std::basic_streambuf<char> base_t;
+
+  public:
+    /* The syntax
+        using base_t::char_type;
+       would be nicer but Visual Studio C++ 8 chokes on it
+    */
+    typedef base_t::char_type   char_type;
+    typedef base_t::int_type    int_type;
+    typedef base_t::pos_type    pos_type;
+    typedef base_t::off_type    off_type;
+    typedef base_t::traits_type traits_type;
+
+    // work around Visual C++ 7.1 problem
+    inline static int
+    traits_type_eof() { return traits_type::eof(); }
+
+    /// The default size of the read and write buffer.
+    /** They are respectively used to buffer data read from and data written to
+        the Python file object. It can be modified from Python.
+    */
+    static std::size_t default_buffer_size;
+
+    /// Construct from a Python file object
+    /** if buffer_size is 0 the current default_buffer_size is used.
+    */
+    streambuf(
+      bp::object& python_file_obj,
+      std::size_t buffer_size_=0)
+    :
+      py_read (getattr(python_file_obj, "read",  bp::object())),
+      py_write(getattr(python_file_obj, "write", bp::object())),
+      py_seek (getattr(python_file_obj, "seek",  bp::object())),
+      py_tell (getattr(python_file_obj, "tell",  bp::object())),
+      buffer_size(buffer_size_ != 0 ? buffer_size_ : default_buffer_size),
+      write_buffer(0),
+      pos_of_read_buffer_end_in_py_file(0),
+      pos_of_write_buffer_end_in_py_file(buffer_size),
+      farthest_pptr(0)
+    {
+      DIALS_ASSERT(buffer_size != 0);
+      /* Some Python file objects (e.g. sys.stdout and sys.stdin)
+         have non-functional seek and tell. If so, assign None to
+         py_tell and py_seek.
+       */
+      if (py_tell != bp::object()) {
+        try {
+          py_tell();
+        }
+        catch (bp::error_already_set&) {
+          py_tell = bp::object();
+          py_seek = bp::object();
+          /* Boost.Python does not do any Python exception handling whatsoever
+             So we need to catch it by hand like so.
+           */
+          PyErr_Clear();
+        }
+      }
+
+      if (py_write != bp::object()) {
+        // C-like string to make debugging easier
+        write_buffer = new char[buffer_size + 1];
+        write_buffer[buffer_size] = '\0';
+        setp(write_buffer, write_buffer + buffer_size);  // 27.5.2.4.5 (5)
+        farthest_pptr = pptr();
+      }
+      else {
+        // The first attempt at output will result in a call to overflow
+        setp(0, 0);
+      }
+
+      if (py_tell != bp::object()) {
+        off_type py_pos = bp::extract<off_type>(py_tell());
+        pos_of_read_buffer_end_in_py_file = py_pos;
+        pos_of_write_buffer_end_in_py_file = py_pos;
+      }
+    }
+
+    /// Mundane destructor freeing the allocated resources
+    virtual ~streambuf() {
+      if (write_buffer) delete[] write_buffer;
+    }
+
+    /// C.f. C++ standard section 27.5.2.4.3
+    /** It is essential to override this virtual function for the stream
+        member function readsome to work correctly (c.f. 27.6.1.3, alinea 30)
+     */
+    virtual std::streamsize showmanyc() {
+      int_type const failure = traits_type::eof();
+      int_type status = underflow();
+      if (status == failure) return -1;
+      return egptr() - gptr();
+    }
+
+    /// C.f. C++ standard section 27.5.2.4.3
+    virtual int_type underflow() {
+      int_type const failure = traits_type::eof();
+      if (py_read == bp::object()) {
+        throw std::invalid_argument(
+          "That Python file object has no 'read' attribute");
+      }
+      read_buffer = py_read(buffer_size);
+      char *read_buffer_data;
+      bp::ssize_t py_n_read;
+#ifdef IS_PY3K
+      if (PyBytes_AsStringAndSize(read_buffer.ptr(),
+                                   &read_buffer_data, &py_n_read) == -1) {
+#else
+      if (PyString_AsStringAndSize(read_buffer.ptr(),
+                                   &read_buffer_data, &py_n_read) == -1) {
+#endif
+        setg(0, 0, 0);
+        throw std::invalid_argument(
+          "The method 'read' of the Python file object "
+          "did not return a string.");
+      }
+      off_type n_read = (off_type)py_n_read;
+      pos_of_read_buffer_end_in_py_file += n_read;
+      setg(read_buffer_data, read_buffer_data, read_buffer_data + n_read);
+      // ^^^27.5.2.3.1 (4)
+      if (n_read == 0) return failure;
+      return traits_type::to_int_type(read_buffer_data[0]);
+    }
+
+    /// C.f. C++ standard section 27.5.2.4.5
+    virtual int_type overflow(int_type c=traits_type_eof()) {
+      if (py_write == bp::object()) {
+        throw std::invalid_argument(
+          "That Python file object has no 'write' attribute");
+      }
+      farthest_pptr = std::max(farthest_pptr, pptr());
+      off_type n_written = (off_type)(farthest_pptr - pbase());
+      bp::str chunk(pbase(), farthest_pptr);
+      py_write(chunk);
+      if (!traits_type::eq_int_type(c, traits_type::eof())) {
+        py_write(traits_type::to_char_type(c));
+        n_written++;
+      }
+      if (n_written) {
+        pos_of_write_buffer_end_in_py_file += n_written;
+        setp(pbase(), epptr());
+        // ^^^ 27.5.2.4.5 (5)
+        farthest_pptr = pptr();
+      }
+      return traits_type::eq_int_type(
+        c, traits_type::eof()) ? traits_type::not_eof(c) : c;
+    }
+
+    /// Update the python file to reflect the state of this stream buffer
+    /** Empty the write buffer into the Python file object and set the seek
+        position of the latter accordingly (C++ standard section 27.5.2.4.2).
+        If there is no write buffer or it is empty, but there is a non-empty
+        read buffer, set the Python file object seek position to the
+        seek position in that read buffer.
+    */
+    virtual int sync() {
+      int result = 0;
+      farthest_pptr = std::max(farthest_pptr, pptr());
+      if (farthest_pptr && farthest_pptr > pbase()) {
+        off_type delta = pptr() - farthest_pptr;
+        int_type status = overflow();
+        if (traits_type::eq_int_type(status, traits_type::eof())) result = -1;
+        if (py_seek != bp::object()) py_seek(delta, 1);
+      }
+      else if (gptr() && gptr() < egptr()) {
+        if (py_seek != bp::object()) py_seek(gptr() - egptr(), 1);
+      }
+      return result;
+    }
+
+    /// C.f. C++ standard section 27.5.2.4.2
+    /** This implementation is optimised to look whether the position is within
+        the buffers, so as to avoid calling Python seek or tell. It is
+        important for many applications that the overhead of calling into Python
+        is avoided as much as possible (e.g. parsers which may do a lot of
+        backtracking)
+    */
+    virtual
+    pos_type seekoff(off_type off, std::ios_base::seekdir way,
+                     std::ios_base::openmode which=  std::ios_base::in
+                                                   | std::ios_base::out)
+    {
+      /* In practice, "which" is either std::ios_base::in or out
+         since we end up here because either seekp or seekg was called
+         on the stream using this buffer. That simplifies the code
+         in a few places.
+      */
+      int const failure = off_type(-1);
+
+      if (py_seek == bp::object()) {
+        throw std::invalid_argument(
+          "That Python file object has no 'seek' attribute");
+      }
+
+      // we need the read buffer to contain something!
+      if (which == std::ios_base::in && !gptr()) {
+        if (traits_type::eq_int_type(underflow(), traits_type::eof())) {
+          return failure;
+        }
+      }
+
+      // compute the whence parameter for Python seek
+      int whence;
+      switch (way) {
+        case std::ios_base::beg:
+          whence = 0;
+          break;
+        case std::ios_base::cur:
+          whence = 1;
+          break;
+        case std::ios_base::end:
+          whence = 2;
+          break;
+        default:
+          return failure;
+      }
+
+      // Let's have a go
+      boost::optional<off_type> result = seekoff_without_calling_python(
+        off, way, which);
+      if (!result) {
+        // we need to call Python
+        if (which == std::ios_base::out) overflow();
+        if (way == std::ios_base::cur) {
+          if      (which == std::ios_base::in)  off -= egptr() - gptr();
+          else if (which == std::ios_base::out) off += pptr() - pbase();
+        }
+        py_seek(off, whence);
+        result = off_type(bp::extract<off_type>(py_tell()));
+        if (which == std::ios_base::in) underflow();
+      }
+      return *result;
+    }
+
+    /// C.f. C++ standard section 27.5.2.4.2
+    virtual
+    pos_type seekpos(pos_type sp,
+                     std::ios_base::openmode which=  std::ios_base::in
+                                                   | std::ios_base::out)
+    {
+      return streambuf::seekoff(sp, std::ios_base::beg, which);
+    }
+
+  private:
+    bp::object py_read, py_write, py_seek, py_tell;
+
+    std::size_t buffer_size;
+
+    /* This is actually a Python string and the actual read buffer is
+       its internal data, i.e. an array of characters. We use a Boost.Python
+       object so as to hold on it: as a result, the actual buffer can't
+       go away.
+    */
+    bp::object read_buffer;
+
+    /* A mere array of char's allocated on the heap at construction time and
+       de-allocated only at destruction time.
+    */
+    char *write_buffer;
+
+    off_type pos_of_read_buffer_end_in_py_file,
+             pos_of_write_buffer_end_in_py_file;
+
+    // the farthest place the buffer has been written into
+    char *farthest_pptr;
+
+
+    boost::optional<off_type> seekoff_without_calling_python(
+      off_type off,
+      std::ios_base::seekdir way,
+      std::ios_base::openmode which)
+    {
+      boost::optional<off_type> const failure;
+
+      // Buffer range and current position
+      off_type buf_begin, buf_end, buf_cur, upper_bound;
+      off_type pos_of_buffer_end_in_py_file;
+      if (which == std::ios_base::in) {
+        pos_of_buffer_end_in_py_file = pos_of_read_buffer_end_in_py_file;
+        buf_begin = reinterpret_cast<std::streamsize>(eback());
+        buf_cur = reinterpret_cast<std::streamsize>(gptr());
+        buf_end = reinterpret_cast<std::streamsize>(egptr());
+        upper_bound = buf_end;
+      }
+      else if (which == std::ios_base::out) {
+        pos_of_buffer_end_in_py_file = pos_of_write_buffer_end_in_py_file;
+        buf_begin = reinterpret_cast<std::streamsize>(pbase());
+        buf_cur = reinterpret_cast<std::streamsize>(pptr());
+        buf_end = reinterpret_cast<std::streamsize>(epptr());
+        farthest_pptr = std::max(farthest_pptr, pptr());
+        upper_bound = reinterpret_cast<std::streamsize>(farthest_pptr) + 1;
+      }
+      else {
+        DIALS_ASSERT(0);
+      }
+
+      // Sought position in "buffer coordinate"
+      off_type buf_sought;
+      if (way == std::ios_base::cur) {
+        buf_sought = buf_cur + off;
+      }
+      else if (way == std::ios_base::beg) {
+        buf_sought = buf_end + (off - pos_of_buffer_end_in_py_file);
+      }
+      else if (way == std::ios_base::end) {
+        return failure;
+      }
+      else {
+        DIALS_ASSERT(0);
+      }
+
+      // if the sought position is not in the buffer, give up
+      if (buf_sought < buf_begin || buf_sought >= upper_bound) return failure;
+
+      // we are in wonderland
+      if      (which == std::ios_base::in)  gbump(buf_sought - buf_cur);
+      else if (which == std::ios_base::out) pbump(buf_sought - buf_cur);
+      return pos_of_buffer_end_in_py_file + (buf_sought - buf_end);
+    }
+
+  public:
+
+    class istream : public std::istream
+    {
+      public:
+        istream(streambuf& buf) : std::istream(&buf)
+        {
+          exceptions(std::ios_base::badbit);
+        }
+
+        ~istream() { if (this->good()) this->sync(); }
+    };
+
+    class ostream : public std::ostream
+    {
+      public:
+        ostream(streambuf& buf) : std::ostream(&buf)
+        {
+          exceptions(std::ios_base::badbit);
+        }
+
+        ~ostream() { if (this->good()) this->flush(); }
+    };
+};
+
+/*Including the definition of default_buffer_size in more than
+  one object file appears to preclude linkage of the objects together.
+  Instead, define it only where it is needed in meta_ext.cpp.
+std::size_t streambuf::default_buffer_size = 1024;
+*/
+
+struct streambuf_capsule
+{
+  streambuf python_streambuf;
+
+  streambuf_capsule(
+    bp::object& python_file_obj,
+    std::size_t buffer_size=0)
+  :
+    python_streambuf(python_file_obj, buffer_size)
+  {}
+};
+
+struct ostream : private streambuf_capsule, streambuf::ostream
+{
+  ostream(
+    bp::object& python_file_obj,
+    std::size_t buffer_size=0)
+  :
+    streambuf_capsule(python_file_obj, buffer_size),
+    streambuf::ostream(python_streambuf)
+  {}
+
+  ~ostream()
+  {
+    try {
+      if (this->good()) this->flush();
+    }
+    catch (bp::error_already_set&) {
+      PyErr_Clear();
+      throw std::runtime_error(
+        "Problem closing python ostream.\n"
+        "  Known limitation: the error is unrecoverable. Sorry.\n"
+        "  Suggestion for programmer: add ostream.flush() before"
+        " returning.");
+    }
+  }
+};
+
+}} // dials::util
+
+#endif // GUARD

--- a/util/python_streambuf.h
+++ b/util/python_streambuf.h
@@ -8,6 +8,8 @@
 #include <boost/optional.hpp>
 #include <boost/utility/typed_in_place_factory.hpp>
 
+#include <dials/error.h>
+
 #include <streambuf>
 #include <iostream>
 

--- a/util/test_python_streambuf.py
+++ b/util/test_python_streambuf.py
@@ -9,8 +9,8 @@ from dials.util.ext import streambuf, ostream
 ext = boost.python.import_ext("dials_util_streambuf_test_ext")
 
 class io_test_case(object):
-    phrase = "Coding should be fun"
-    #         01234567890123456789
+    phrase = b"Coding should be fun"
+    #          01234567890123456789
 
     def run(self):
         m = streambuf.default_buffer_size
@@ -28,15 +28,15 @@ class io_test_case(object):
     def exercise_read(self):
         self.create_file_object(mode="rb")
         words = ext.read_word(streambuf(self.file_object))
-        assert words == "Coding, should, be, fun, [ fail, eof ]"
+        assert words == b"Coding, should, be, fun, [ fail, eof ]"
         self.file_object.close()
 
     def exercise_partial_read(self):
         self.create_file_object(mode="rb")
         words = ext.partial_read(streambuf(self.file_object))
-        assert words == "Coding, should, "
+        assert words == b"Coding, should, "
         trailing = self.file_object.read()
-        assert trailing == " be fun"
+        assert trailing == b" be fun"
         self.file_object.close()
 
     def exercise_read_failure(self):
@@ -49,15 +49,15 @@ class io_test_case(object):
     def exercise_write(self):
         self.create_file_object(mode="wb")
         report = ext.write_word(ostream(self.file_object))
-        assert report == ""
-        assert self.file_content() == "2 times 1.6 equals 3.2"
+        assert report == b""
+        assert self.file_content() == b"2 times 1.6 equals 3.2"
         self.file_object.close()
 
     def exercise_seek_and_read(self):
         self.create_file_object(mode="rb")
         instrumented_file = mock.Mock(spec=self.file_object, wraps=self.file_object)
         words = ext.read_and_seek(streambuf(instrumented_file))
-        assert words == "should, should, uld, ding, fun, [ eof ]"
+        assert words == b"should, should, uld, ding, fun, [ eof ]"
         n = streambuf.default_buffer_size
         soughts = instrumented_file.seek.call_args_list
         # stringent tests carefully crafted to make sure the seek-in-buffer
@@ -88,8 +88,8 @@ class io_test_case(object):
         self.create_file_object(mode="wb")
         instrumented_file = mock.Mock(spec=self.file_object, wraps=self.file_object)
         report = ext.write_and_seek(ostream(instrumented_file))
-        assert report == ""
-        expected = "1000 times 1000 equals 1000000"
+        assert report == b""
+        expected = b"1000 times 1000 equals 1000000"
         assert self.file_content() == expected
         assert self.file_object.tell() == 9
         if streambuf.default_buffer_size >= 30:
@@ -135,7 +135,8 @@ class mere_file_test_case(io_test_case):
 
     def file_content(self):
         self.file_object.flush()
-        result = open(self.file_object.name).read()
+        with open(self.file_object.name, "rb") as fh:
+            result = fh.read()
         return result
 
 

--- a/util/test_python_streambuf.py
+++ b/util/test_python_streambuf.py
@@ -1,0 +1,231 @@
+from __future__ import absolute_import, division, print_function
+
+import boost.python
+from boost.python import streambuf, ostream
+from six.moves import range
+ext = boost.python.import_ext("boost_adaptbx_python_streambuf_test_ext")
+import StringIO
+import cStringIO
+from libtbx.test_utils import Exception_expected
+from libtbx.option_parser import option_parser
+import libtbx.object_oriented_patterns as oop
+import os
+
+
+class file_object_debug_proxy(oop.proxy):
+
+  def __init__(self, *args, **kwds):
+    super(file_object_debug_proxy, self).__init__(*args, **kwds)
+    self.seek_call_log = []
+    self.write_call_log = []
+
+  def seek(self, off, mode):
+    self.seek_call_log.append((off, mode))
+    self.subject.seek(off, mode)
+
+  def write(self, s):
+    self.write_call_log.append(s)
+    self.subject.write(s)
+
+
+class io_test_case(object):
+  phrase = "Coding should be fun"
+  #         01234567890123456789
+
+  def run(self):
+    m = streambuf.default_buffer_size
+    for n in range(50, 0, -1):
+      streambuf.default_buffer_size = n
+      self.exercise_read_failure()
+      self.exercise_write_failure()
+      self.exercise_read()
+      self.exercise_write()
+      self.exercise_seek_and_read()
+      self.exercise_partial_read()
+      self.exercise_write_and_seek()
+    streambuf.default_buffer_size = m
+
+  def exercise_read(self):
+    self.create_file_object(mode='r')
+    words = ext.test_read(streambuf(self.file_object), "read")
+    assert words == "Coding, should, be, fun, [ fail, eof ]"
+    self.file_object.close()
+
+  def exercise_partial_read(self):
+    self.create_file_object(mode='r')
+    words = ext.test_read(streambuf(self.file_object), "partial read")
+    assert words == "Coding, should, "
+    trailing = self.file_object.read()
+    assert  trailing == " be fun"
+    self.file_object.close()
+
+  def exercise_read_failure(self):
+    self.create_file_object(mode='r')
+    self.file_object.close()
+    try:
+      ext.test_read(streambuf(self.file_object), "read")
+    except ValueError:
+      pass
+    else:
+      raise Exception_expected
+    self.file_object.close()
+
+  def exercise_write(self):
+    self.create_file_object(mode='w')
+    report = ext.test_write(ostream(self.file_object), "write")
+    assert report == ''
+    assert self.file_content() == "2 times 1.6 equals 3.2"
+    self.file_object.close()
+
+  def exercise_seek_and_read(self):
+    self.create_instrumented_file_object(mode='r')
+    words = ext.test_read(streambuf(self.file_object), "read and seek")
+    assert words == "should, should, uld, ding, fun, [ eof ]"
+    n = streambuf.default_buffer_size
+    soughts = self.file_object.seek_call_log
+    # stringent tests carefully crafted to make sure the seek-in-buffer
+    # optimisation works as expected
+    # C.f. the comment in the C++ function actual_write_test
+    assert soughts[-1] == (-4,2)
+    soughts = soughts[:-1]
+    if n >= 14:
+      assert soughts == []
+    else:
+      assert soughts[0] == (6,0)
+      soughts = soughts[1:]
+      if 8 <= n <= 13:
+        assert len(soughts) == 1 and self.only_seek_cur(soughts)
+      elif n == 7:
+        assert len(soughts) == 2 and self.only_seek_cur(soughts)
+      else:
+        assert soughts[0] == (6,0)
+        soughts = soughts[1:]
+        assert self.only_seek_cur(soughts)
+        if n == 4: assert len(soughts) == 1
+        else: assert len(soughts) == 2
+    self.file_object.close()
+
+  def exercise_write_and_seek(self):
+    self.create_instrumented_file_object(mode='w')
+    report = ext.test_write(ostream(self.file_object), "write and seek (cur)")
+    assert report == ''
+    expected = '1000 times 1000 equals 1000000'
+    assert self.file_content() == expected
+    assert self.file_object.tell() == 9
+    if streambuf.default_buffer_size >= 30:
+      assert self.file_object.write_call_log == [ expected ]
+    self.file_object.close()
+
+  def only_seek_cur(cls, seek_calls):
+    return [ whence for off, whence in seek_calls if whence != 1 ] == []
+
+  def create_instrumented_file_object(self, mode):
+    self.create_file_object(mode)
+    self.file_object = file_object_debug_proxy(self.file_object)
+
+
+class stringio_test_case(io_test_case):
+
+  stringio_type = StringIO.StringIO
+
+  def exercise_write_failure(self):
+    pass
+
+  def create_file_object(self, mode):
+    if mode == 'r':
+      self.file_object = self.stringio_type(self.phrase)
+    elif mode == 'w':
+      self.file_object = self.stringio_type()
+    else:
+      raise NotImplementedError("Internal error in the test code")
+
+  def file_content(self):
+    return self.file_object.getvalue()
+
+
+class cstringio_test_case(stringio_test_case):
+
+  stringio_type = cStringIO.StringIO
+
+  def exercise_write_failure(self):
+    self.create_file_object(mode='r')
+    try:
+      ext.test_write(ostream(self.file_object), "write")
+    except ValueError as err:
+      # That Python file object has no 'write' attribute
+      assert str(err).find("write") > -1
+    except RuntimeError as err:
+      # Redhat 8.0: basic_ios::clear(iostate) caused exception
+      assert str(err).find("clear") > -1
+    else:
+      raise Exception_expected
+
+
+class mere_file_test_case(io_test_case):
+
+  def exercise_write_failure(self):
+    import platform
+    if (platform.platform().find("redhat-8.0") >= 0):
+      return # avoid Abort
+    self.create_file_object(mode='r')
+    try:
+      ext.test_write(streambuf(self.file_object), "write")
+    except IOError as err:
+      pass
+    else:
+      raise Exception_expected
+    self.file_object.close()
+
+  def create_file_object(self, mode):
+    f = open("tmp_tst_python_streambuf", "w")
+    if mode.find('r') > -1:
+      f.write(self.phrase)
+    f.close()
+    self.file_object = open(f.name, mode)
+
+  def file_content(self):
+    i = self.file_object.tell()
+    self.file_object.flush()
+    result = open(self.file_object.name).read()
+    self.file_object.seek(i, 0)
+    return result
+
+
+def time_it(path, buffer_size):
+  if (buffer_size is None):
+    buffer_size = streambuf.default_buffer_size
+  print("Buffer is %i bytes" % buffer_size)
+  path = os.path.expanduser(path)
+  input = open(path, 'r')
+  inp_buf = streambuf(python_file_obj=input, buffer_size=buffer_size)
+  ext.time_read(input.name, inp_buf)
+  output = open("tmp_tst_python_streambuf", "w")
+  out_buf = streambuf(python_file_obj=output, buffer_size=buffer_size)
+  ext.time_write(output.name, out_buf)
+
+def run(args):
+  options = (option_parser()
+              .option(None, '--time_on_file',
+                      metavar="PATH",
+                      help="time reading and writing."
+                           "The file to read shall be a hkl file, i.e "
+                           "each line has a format like "
+                           "'int int int double double'. "
+                           "The end shall be marked by 0 0 0")
+              .option(None, '--buffer_size', type='int',
+                      metavar="INT")
+              ).process(args).options
+  for i_trial in range(3):
+    stringio_test_case().run()
+  for i_trial in range(3):
+    cstringio_test_case().run()
+  for i_trial in range(3):
+    mere_file_test_case().run()
+  if options.time_on_file:
+    time_it(options.time_on_file, options.buffer_size)
+
+  print('OK')
+
+if __name__ == '__main__':
+  import sys
+  run(sys.argv[1:])

--- a/util/test_python_streambuf.py
+++ b/util/test_python_streambuf.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 import boost.python
-from boost.python import streambuf, ostream
 from six.moves import range
-ext = boost.python.import_ext("boost_adaptbx_python_streambuf_test_ext")
+ext = boost.python.import_ext("dials_util_streambuf_test_ext")
 import StringIO
 import cStringIO
+from dials.util.ext import streambuf, ostream
 from libtbx.test_utils import Exception_expected
 from libtbx.option_parser import option_parser
 import libtbx.object_oriented_patterns as oop

--- a/util/test_python_streambuf.py
+++ b/util/test_python_streambuf.py
@@ -1,231 +1,199 @@
 from __future__ import absolute_import, division, print_function
 
 import boost.python
-from six.moves import range
-ext = boost.python.import_ext("dials_util_streambuf_test_ext")
+import pytest
 import StringIO
 import cStringIO
 from dials.util.ext import streambuf, ostream
 from libtbx.test_utils import Exception_expected
-from libtbx.option_parser import option_parser
 import libtbx.object_oriented_patterns as oop
-import os
 
+ext = boost.python.import_ext("dials_util_streambuf_test_ext")
 
 class file_object_debug_proxy(oop.proxy):
+    def __init__(self, *args, **kwds):
+        super(file_object_debug_proxy, self).__init__(*args, **kwds)
+        self.seek_call_log = []
+        self.write_call_log = []
 
-  def __init__(self, *args, **kwds):
-    super(file_object_debug_proxy, self).__init__(*args, **kwds)
-    self.seek_call_log = []
-    self.write_call_log = []
+    def seek(self, off, mode):
+        self.seek_call_log.append((off, mode))
+        self.subject.seek(off, mode)
 
-  def seek(self, off, mode):
-    self.seek_call_log.append((off, mode))
-    self.subject.seek(off, mode)
-
-  def write(self, s):
-    self.write_call_log.append(s)
-    self.subject.write(s)
+    def write(self, s):
+        self.write_call_log.append(s)
+        self.subject.write(s)
 
 
 class io_test_case(object):
-  phrase = "Coding should be fun"
-  #         01234567890123456789
+    phrase = "Coding should be fun"
+    #         01234567890123456789
 
-  def run(self):
-    m = streambuf.default_buffer_size
-    for n in range(50, 0, -1):
-      streambuf.default_buffer_size = n
-      self.exercise_read_failure()
-      self.exercise_write_failure()
-      self.exercise_read()
-      self.exercise_write()
-      self.exercise_seek_and_read()
-      self.exercise_partial_read()
-      self.exercise_write_and_seek()
-    streambuf.default_buffer_size = m
+    def run(self):
+        m = streambuf.default_buffer_size
+        for n in range(50, 0, -1):
+            streambuf.default_buffer_size = n
+            self.exercise_read_failure()
+            self.exercise_write_failure()
+            self.exercise_read()
+            self.exercise_write()
+            self.exercise_seek_and_read()
+            self.exercise_partial_read()
+            self.exercise_write_and_seek()
+        streambuf.default_buffer_size = m
 
-  def exercise_read(self):
-    self.create_file_object(mode='r')
-    words = ext.test_read(streambuf(self.file_object), "read")
-    assert words == "Coding, should, be, fun, [ fail, eof ]"
-    self.file_object.close()
+    def exercise_read(self):
+        self.create_file_object(mode="r")
+        words = ext.test_read(streambuf(self.file_object), "read")
+        assert words == "Coding, should, be, fun, [ fail, eof ]"
+        self.file_object.close()
 
-  def exercise_partial_read(self):
-    self.create_file_object(mode='r')
-    words = ext.test_read(streambuf(self.file_object), "partial read")
-    assert words == "Coding, should, "
-    trailing = self.file_object.read()
-    assert  trailing == " be fun"
-    self.file_object.close()
+    def exercise_partial_read(self):
+        self.create_file_object(mode="r")
+        words = ext.test_read(streambuf(self.file_object), "partial read")
+        assert words == "Coding, should, "
+        trailing = self.file_object.read()
+        assert trailing == " be fun"
+        self.file_object.close()
 
-  def exercise_read_failure(self):
-    self.create_file_object(mode='r')
-    self.file_object.close()
-    try:
-      ext.test_read(streambuf(self.file_object), "read")
-    except ValueError:
-      pass
-    else:
-      raise Exception_expected
-    self.file_object.close()
+    def exercise_read_failure(self):
+        self.create_file_object(mode="r")
+        self.file_object.close()
+        try:
+            ext.test_read(streambuf(self.file_object), "read")
+        except ValueError:
+            pass
+        else:
+            raise Exception_expected
+        self.file_object.close()
 
-  def exercise_write(self):
-    self.create_file_object(mode='w')
-    report = ext.test_write(ostream(self.file_object), "write")
-    assert report == ''
-    assert self.file_content() == "2 times 1.6 equals 3.2"
-    self.file_object.close()
+    def exercise_write(self):
+        self.create_file_object(mode="w")
+        report = ext.test_write(ostream(self.file_object), "write")
+        assert report == ""
+        assert self.file_content() == "2 times 1.6 equals 3.2"
+        self.file_object.close()
 
-  def exercise_seek_and_read(self):
-    self.create_instrumented_file_object(mode='r')
-    words = ext.test_read(streambuf(self.file_object), "read and seek")
-    assert words == "should, should, uld, ding, fun, [ eof ]"
-    n = streambuf.default_buffer_size
-    soughts = self.file_object.seek_call_log
-    # stringent tests carefully crafted to make sure the seek-in-buffer
-    # optimisation works as expected
-    # C.f. the comment in the C++ function actual_write_test
-    assert soughts[-1] == (-4,2)
-    soughts = soughts[:-1]
-    if n >= 14:
-      assert soughts == []
-    else:
-      assert soughts[0] == (6,0)
-      soughts = soughts[1:]
-      if 8 <= n <= 13:
-        assert len(soughts) == 1 and self.only_seek_cur(soughts)
-      elif n == 7:
-        assert len(soughts) == 2 and self.only_seek_cur(soughts)
-      else:
-        assert soughts[0] == (6,0)
-        soughts = soughts[1:]
-        assert self.only_seek_cur(soughts)
-        if n == 4: assert len(soughts) == 1
-        else: assert len(soughts) == 2
-    self.file_object.close()
+    def exercise_seek_and_read(self):
+        self.create_instrumented_file_object(mode="r")
+        words = ext.test_read(streambuf(self.file_object), "read and seek")
+        assert words == "should, should, uld, ding, fun, [ eof ]"
+        n = streambuf.default_buffer_size
+        soughts = self.file_object.seek_call_log
+        # stringent tests carefully crafted to make sure the seek-in-buffer
+        # optimisation works as expected
+        # C.f. the comment in the C++ function actual_write_test
+        assert soughts[-1] == (-4, 2)
+        soughts = soughts[:-1]
+        if n >= 14:
+            assert soughts == []
+        else:
+            assert soughts[0] == (6, 0)
+            soughts = soughts[1:]
+            if 8 <= n <= 13:
+                assert len(soughts) == 1 and self.only_seek_cur(soughts)
+            elif n == 7:
+                assert len(soughts) == 2 and self.only_seek_cur(soughts)
+            else:
+                assert soughts[0] == (6, 0)
+                soughts = soughts[1:]
+                assert self.only_seek_cur(soughts)
+                if n == 4:
+                    assert len(soughts) == 1
+                else:
+                    assert len(soughts) == 2
+        self.file_object.close()
 
-  def exercise_write_and_seek(self):
-    self.create_instrumented_file_object(mode='w')
-    report = ext.test_write(ostream(self.file_object), "write and seek (cur)")
-    assert report == ''
-    expected = '1000 times 1000 equals 1000000'
-    assert self.file_content() == expected
-    assert self.file_object.tell() == 9
-    if streambuf.default_buffer_size >= 30:
-      assert self.file_object.write_call_log == [ expected ]
-    self.file_object.close()
+    def exercise_write_and_seek(self):
+        self.create_instrumented_file_object(mode="w")
+        report = ext.test_write(ostream(self.file_object), "write and seek (cur)")
+        assert report == ""
+        expected = "1000 times 1000 equals 1000000"
+        assert self.file_content() == expected
+        assert self.file_object.tell() == 9
+        if streambuf.default_buffer_size >= 30:
+            assert self.file_object.write_call_log == [expected]
+        self.file_object.close()
 
-  def only_seek_cur(cls, seek_calls):
-    return [ whence for off, whence in seek_calls if whence != 1 ] == []
+    def only_seek_cur(cls, seek_calls):
+        return [whence for off, whence in seek_calls if whence != 1] == []
 
-  def create_instrumented_file_object(self, mode):
-    self.create_file_object(mode)
-    self.file_object = file_object_debug_proxy(self.file_object)
+    def create_instrumented_file_object(self, mode):
+        self.create_file_object(mode)
+        self.file_object = file_object_debug_proxy(self.file_object)
 
 
 class stringio_test_case(io_test_case):
 
-  stringio_type = StringIO.StringIO
+    stringio_type = StringIO.StringIO
 
-  def exercise_write_failure(self):
-    pass
+    def exercise_write_failure(self):
+        pass
 
-  def create_file_object(self, mode):
-    if mode == 'r':
-      self.file_object = self.stringio_type(self.phrase)
-    elif mode == 'w':
-      self.file_object = self.stringio_type()
-    else:
-      raise NotImplementedError("Internal error in the test code")
+    def create_file_object(self, mode):
+        if mode == "r":
+            self.file_object = self.stringio_type(self.phrase)
+        elif mode == "w":
+            self.file_object = self.stringio_type()
+        else:
+            raise NotImplementedError("Internal error in the test code")
 
-  def file_content(self):
-    return self.file_object.getvalue()
+    def file_content(self):
+        return self.file_object.getvalue()
 
 
 class cstringio_test_case(stringio_test_case):
 
-  stringio_type = cStringIO.StringIO
+    stringio_type = cStringIO.StringIO
 
-  def exercise_write_failure(self):
-    self.create_file_object(mode='r')
-    try:
-      ext.test_write(ostream(self.file_object), "write")
-    except ValueError as err:
-      # That Python file object has no 'write' attribute
-      assert str(err).find("write") > -1
-    except RuntimeError as err:
-      # Redhat 8.0: basic_ios::clear(iostate) caused exception
-      assert str(err).find("clear") > -1
-    else:
-      raise Exception_expected
+    def exercise_write_failure(self):
+        self.create_file_object(mode="r")
+        try:
+            ext.test_write(ostream(self.file_object), "write")
+        except ValueError as err:
+            # That Python file object has no 'write' attribute
+            assert str(err).find("write") > -1
+        except RuntimeError as err:
+            # Redhat 8.0: basic_ios::clear(iostate) caused exception
+            assert str(err).find("clear") > -1
+        else:
+            raise Exception_expected
 
 
 class mere_file_test_case(io_test_case):
+    def exercise_write_failure(self):
+        import platform
 
-  def exercise_write_failure(self):
-    import platform
-    if (platform.platform().find("redhat-8.0") >= 0):
-      return # avoid Abort
-    self.create_file_object(mode='r')
-    try:
-      ext.test_write(streambuf(self.file_object), "write")
-    except IOError as err:
-      pass
-    else:
-      raise Exception_expected
-    self.file_object.close()
+        if platform.platform().find("redhat-8.0") >= 0:
+            return  # avoid Abort
+        self.create_file_object(mode="r")
+        with pytest.raises(IOError):
+            ext.test_write(streambuf(self.file_object), "write")
+        self.file_object.close()
 
-  def create_file_object(self, mode):
-    f = open("tmp_tst_python_streambuf", "w")
-    if mode.find('r') > -1:
-      f.write(self.phrase)
-    f.close()
-    self.file_object = open(f.name, mode)
+    def create_file_object(self, mode):
+        f = open("tmp_tst_python_streambuf", "w")
+        if mode.find("r") > -1:
+            f.write(self.phrase)
+        f.close()
+        self.file_object = open(f.name, mode)
 
-  def file_content(self):
-    i = self.file_object.tell()
-    self.file_object.flush()
-    result = open(self.file_object.name).read()
-    self.file_object.seek(i, 0)
-    return result
+    def file_content(self):
+        i = self.file_object.tell()
+        self.file_object.flush()
+        result = open(self.file_object.name).read()
+        self.file_object.seek(i, 0)
+        return result
 
 
-def time_it(path, buffer_size):
-  if (buffer_size is None):
-    buffer_size = streambuf.default_buffer_size
-  print("Buffer is %i bytes" % buffer_size)
-  path = os.path.expanduser(path)
-  input = open(path, 'r')
-  inp_buf = streambuf(python_file_obj=input, buffer_size=buffer_size)
-  ext.time_read(input.name, inp_buf)
-  output = open("tmp_tst_python_streambuf", "w")
-  out_buf = streambuf(python_file_obj=output, buffer_size=buffer_size)
-  ext.time_write(output.name, out_buf)
-
-def run(args):
-  options = (option_parser()
-              .option(None, '--time_on_file',
-                      metavar="PATH",
-                      help="time reading and writing."
-                           "The file to read shall be a hkl file, i.e "
-                           "each line has a format like "
-                           "'int int int double double'. "
-                           "The end shall be marked by 0 0 0")
-              .option(None, '--buffer_size', type='int',
-                      metavar="INT")
-              ).process(args).options
-  for i_trial in range(3):
+def test_with_stringio():
     stringio_test_case().run()
-  for i_trial in range(3):
+
+
+def test_with_cstringio():
     cstringio_test_case().run()
-  for i_trial in range(3):
-    mere_file_test_case().run()
-  if options.time_on_file:
-    time_it(options.time_on_file, options.buffer_size)
 
-  print('OK')
 
-if __name__ == '__main__':
-  import sys
-  run(sys.argv[1:])
+def test_with_file(tmpdir):
+    with tmpdir.as_cwd():
+        mere_file_test_case().run()

--- a/util/test_python_streambuf.py
+++ b/util/test_python_streambuf.py
@@ -4,7 +4,6 @@ import boost.python
 import pytest
 import six
 from dials.util.ext import streambuf, ostream
-from libtbx.test_utils import Exception_expected
 import libtbx.object_oriented_patterns as oop
 
 ext = boost.python.import_ext("dials_util_streambuf_test_ext")
@@ -43,13 +42,13 @@ class io_test_case(object):
 
     def exercise_read(self):
         self.create_file_object(mode="rb")
-        words = ext.test_read(streambuf(self.file_object), "read")
+        words = ext.read_word(streambuf(self.file_object))
         assert words == "Coding, should, be, fun, [ fail, eof ]"
         self.file_object.close()
 
     def exercise_partial_read(self):
         self.create_file_object(mode="rb")
-        words = ext.test_read(streambuf(self.file_object), "partial read")
+        words = ext.partial_read(streambuf(self.file_object))
         assert words == "Coding, should, "
         trailing = self.file_object.read()
         assert trailing == " be fun"
@@ -58,24 +57,20 @@ class io_test_case(object):
     def exercise_read_failure(self):
         self.create_file_object(mode="rb")
         self.file_object.close()
-        try:
-            ext.test_read(streambuf(self.file_object), "read")
-        except ValueError:
-            pass
-        else:
-            raise Exception_expected
+        with pytest.raises(ValueError):
+            ext.read_word(streambuf(self.file_object))
         self.file_object.close()
 
     def exercise_write(self):
         self.create_file_object(mode="wb")
-        report = ext.test_write(ostream(self.file_object), "write")
+        report = ext.write_word(ostream(self.file_object))
         assert report == ""
         assert self.file_content() == "2 times 1.6 equals 3.2"
         self.file_object.close()
 
     def exercise_seek_and_read(self):
         self.create_instrumented_file_object(mode="rb")
-        words = ext.test_read(streambuf(self.file_object), "read and seek")
+        words = ext.read_and_seek(streambuf(self.file_object))
         assert words == "should, should, uld, ding, fun, [ eof ]"
         n = streambuf.default_buffer_size
         soughts = self.file_object.seek_call_log
@@ -105,7 +100,7 @@ class io_test_case(object):
 
     def exercise_write_and_seek(self):
         self.create_instrumented_file_object(mode="wb")
-        report = ext.test_write(ostream(self.file_object), "write and seek (cur)")
+        report = ext.write_and_seek(ostream(self.file_object))
         assert report == ""
         expected = "1000 times 1000 equals 1000000"
         assert self.file_content() == expected
@@ -144,7 +139,7 @@ class mere_file_test_case(io_test_case):
     def exercise_write_failure(self):
         self.create_file_object(mode="rb")
         with pytest.raises(IOError):
-            ext.test_write(streambuf(self.file_object), "write")
+            ext.write_word(streambuf(self.file_object))
         self.file_object.close()
 
     def create_file_object(self, mode):


### PR DESCRIPTION
The previous implementation held the reflection table up to 3 times in
memory during the output phase. This implementation passes the python
filehandle into C++ space and then writes the msgpack output directly
to the file. As a result memory consumption is significantly reduced.

Fixes #1112