### PR TITLE
Use first 360 degrees of data for dials.symmetry. Fixes #1000

### DIFF
--- a/algorithms/symmetry/cosym/_generate_test_data.py
+++ b/algorithms/symmetry/cosym/_generate_test_data.py
@@ -5,7 +5,7 @@ from cctbx.sgtbx.subgroups import subgroups
 import scitbx.matrix
 import scitbx.random
 
-from dxtbx.model import Crystal, Experiment, ExperimentList
+from dxtbx.model import Crystal, Experiment, ExperimentList, Scan
 from dials.array_family import flex
 
 
@@ -45,7 +45,8 @@ def generate_experiments_reflections(
         ).transpose()
         expts.append(
             Experiment(
-                crystal=Crystal(B, space_group=dataset.space_group(), reciprocal=True)
+                crystal=Crystal(B, space_group=dataset.space_group(), reciprocal=True),
+                scan=Scan(image_range=(0, 180), oscillation=(0.0, 1.0)),
             )
         )
         refl = flex.reflection_table()

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import copy
 import json
 import logging
+import math
 import random
 import sys
 from dials.util import tabulate
@@ -224,6 +225,39 @@ def eliminate_sys_absent(experiments, reflections):
     return reflections
 
 
+def get_subset_for_symmetry(params, experiments, reflection_tables):
+    """Select an image range for symmetry analysis, or just select
+    the first 360 degrees of data."""
+    refls_for_sym = []
+    if params.exclude_images:
+        experiments = exclude_image_ranges_from_scans(
+            reflection_tables, experiments, params.exclude_images
+        )
+        for refl, exp in zip(reflection_tables, experiments):
+            sel = get_selection_for_valid_image_ranges(refl, exp)
+            refls_for_sym.append(refl.select(sel))
+    else:
+        # use first 360 degrees if <360 deg i.e. first measured data.
+        for expt, refl in zip(experiments, reflection_tables):
+            scanwidth = abs(
+                expt.scan.get_oscillation_range()[1]
+                - expt.scan.get_oscillation_range()[0]
+            )
+            if scanwidth <= 360:
+                refls_for_sym.append(refl)
+            else:
+                positive = expt.scan.get_oscillation()[1] > 0
+                phis = refl["xyzobs.mm.value"].parts()[2] * 180.0 / math.pi
+                if positive:
+                    max_allowed_phi = min(phis) + 360.0
+                    sel = phis < max_allowed_phi
+                else:
+                    min_allowed_phi = max(phis) - 360.0
+                    sel = phis > min_allowed_phi
+                refls_for_sym.append(refl.select(sel))
+    return refls_for_sym
+
+
 def symmetry(experiments, reflection_tables, params=None):
     """
     Run symmetry analysis
@@ -237,20 +271,6 @@ def symmetry(experiments, reflection_tables, params=None):
     if params is None:
         params = phil_scope.extract()
     refls_for_sym = []
-
-    def get_refl_for_sym(params, experiments, reflection_tables):
-        """Optionally apply exclude images"""
-        refls_for_sym = []
-        if params.exclude_images:
-            experiments = exclude_image_ranges_from_scans(
-                reflection_tables, experiments, params.exclude_images
-            )
-            for refl, exp in zip(reflection_tables, experiments):
-                sel = get_selection_for_valid_image_ranges(refl, exp)
-                refls_for_sym.append(refl.select(sel))
-        else:
-            refls_for_sym = reflection_tables
-        return refls_for_sym
 
     if params.laue_group is Auto:
         logger.info("=" * 80)
@@ -276,7 +296,7 @@ def symmetry(experiments, reflection_tables, params=None):
             experiments, reflection_tables, cb_ops
         )
 
-        refls_for_sym = get_refl_for_sym(params, experiments, reflection_tables)
+        refls_for_sym = get_subset_for_symmetry(params, experiments, reflection_tables)
 
         datasets = filtered_arrays_from_experiments_reflections(
             experiments,
@@ -365,7 +385,9 @@ Using space group I 2 2 2, space group I 21 21 21 is equally likely.\n"""
             logger.info("No absences to check for this laue group\n")
         else:
             if not refls_for_sym:
-                refls_for_sym = get_refl_for_sym(params, experiments, reflection_tables)
+                refls_for_sym = get_subset_for_symmetry(
+                    params, experiments, reflection_tables
+                )
 
             if (params.d_min is Auto) and (result is not None):
                 d_min = result.intensities.resolution_range()[1]

--- a/test/command_line/test_symmetry.py
+++ b/test/command_line/test_symmetry.py
@@ -278,7 +278,7 @@ def test_get_subset_for_symmetry_image_range():
     """Test that first 360 degrees are selected from each sweep with an exclude
     images command."""
     params, expts, tables = _make_input_for_exclude_tests(exclude_images=True)
-    refls = get_subset_for_symmetry(params, expts, tables)
+    refls = get_subset_for_symmetry(expts, tables, params.exclude_images)
     assert refls[0]["i"] == 0
     assert refls[1]["i"] == 0
 
@@ -286,7 +286,7 @@ def test_get_subset_for_symmetry_image_range():
 def test_get_subset_for_symmetry_first_360():
     """Test that first 360 degrees are selected from each sweep"""
     params, expts, tables = _make_input_for_exclude_tests(exclude_images=False)
-    refls = get_subset_for_symmetry(params, expts, tables)
+    refls = get_subset_for_symmetry(expts, tables, params.exclude_images)
     assert refls[0]["i"] == 0
     assert refls[1]["i"] == 0
 


### PR DESCRIPTION
Use first 360 degrees by default (if not explicitly using the exclude_images option).
Add tests for the helper function.