### PR TITLE
Make dials.export format=nxs pass NeXus validation

### DIFF
--- a/command_line/export.py
+++ b/command_line/export.py
@@ -154,6 +154,22 @@ phil_scope = parse(
       .type = path
       .help = "The output Nexus file"
 
+    instrument_name = Unknown
+      .type = str
+      .help = "Name of the instrument/beamline"
+
+    instrument_short_name = Unknown
+      .type = str
+      .help = "Short name for instrument/beamline, perhaps the acronym"
+
+    source_name = Unknown
+      .type = str
+      .help = "Name of the source/facility"
+
+    source_short_name = Unknown
+      .type = str
+      .help = "Short name for source, perhaps the acronym"
+
   }
 
   mmcif {
@@ -298,7 +314,7 @@ def export_nexus(params, experiments, reflections):
 
     from dials.util.nexus import dump
 
-    dump(experiments, reflections[0], params.nxs.hklout)
+    dump(experiments, reflections[0], params.nxs)
 
 
 def export_mmcif(params, experiments, reflections):

--- a/test/util/test_nexus.py
+++ b/test/util/test_nexus.py
@@ -6,6 +6,7 @@ def test_run(dials_regression, run_in_tmpdir):
     from dxtbx.model.experiment_list import ExperimentListFactory
     from dials.array_family import flex
     from os.path import join
+    from dials.command_line.export import phil_scope
 
     path = join(dials_regression, "nexus_test_data")
 
@@ -23,7 +24,9 @@ def test_run(dials_regression, run_in_tmpdir):
     del reflections1["background.mse"]
 
     # Dump the reflections
-    dump(experiments1, reflections1, "hklout.nxs")
+    params = phil_scope.extract()
+    params.nxs.hklout = "hklout.nxs"
+    dump(experiments1, reflections1, params.nxs)
 
     # Load them again
     experiments2, reflections2 = load("hklout.nxs")

--- a/test/util/test_nexus_multi_experiment.py
+++ b/test/util/test_nexus_multi_experiment.py
@@ -10,6 +10,7 @@ from dials.util.nexus.nx_mx import polarization_normal_to_stokes
 from dials.util.nexus.nx_mx import polarization_stokes_to_normal
 from dxtbx.model.experiment_list import ExperimentListFactory
 from scitbx import matrix
+from dials.command_line.export import phil_scope
 
 
 def test_polarization_conversion():
@@ -32,7 +33,9 @@ def test_polarization_conversion():
 
 def run_single(experiments1, filename):
     # Dump the file
-    dials.util.nexus.dump(experiments1, None, filename)
+    params = phil_scope.extract().nxs
+    params.hklout = filename
+    dials.util.nexus.dump(experiments1, None, params)
 
     # Load the file
     experiments2, reflections = dials.util.nexus.load(filename)

--- a/util/nexus/__init__.py
+++ b/util/nexus/__init__.py
@@ -13,8 +13,8 @@ def get_entry(filename, mode="a"):
     else:
         entry = handle.create_group("entry")
         entry.attrs["NX_class"] = "NXentry"
-    handle.attrs["file_name"] = filename
-    handle.attrs["file_time"] = strftime("%Y-%m-%dT%H:%M:%S")
+        handle.attrs["file_name"] = filename
+        handle.attrs["file_time"] = strftime("%Y-%m-%dT%H:%M:%S")
     return entry
 
 

--- a/util/nexus/__init__.py
+++ b/util/nexus/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import h5py
 from dials.util.nexus import nx_reflections, nx_mx
+from time import strftime
 
 
 def get_entry(filename, mode="a"):
@@ -12,6 +13,8 @@ def get_entry(filename, mode="a"):
     else:
         entry = handle.create_group("entry")
         entry.attrs["NX_class"] = "NXentry"
+    handle.attrs["file_name"] = filename
+    handle.attrs["file_time"] = strftime("%Y-%m-%dT%H:%M:%S")
     return entry
 
 
@@ -22,7 +25,8 @@ def load(filename):
     return exp, ref
 
 
-def dump(experiments, reflections, filename):
+def dump(experiments, reflections, params):
+    filename = params.hklout
     entry = get_entry(filename, "w")
-    experiments = nx_mx.dump(entry, experiments)
+    experiments = nx_mx.dump(entry, experiments, params)
     nx_reflections.dump(entry, reflections, experiments)

--- a/util/nexus/nx_reflections.py
+++ b/util/nexus/nx_reflections.py
@@ -25,7 +25,7 @@ def make_int(handle, name, data, description, units=None):
 
 
 def make_bool(handle, name, data, description, units=None):
-    return make_dataset(handle, name, "bool", data, description, units)
+    return make_dataset(handle, name, "int8", data, description, units)
 
 
 def make_float(handle, name, data, description, units=None):
@@ -94,6 +94,9 @@ def write(handle, key, data):
         make_float(handle, "predicted_px_x", col1, dsc1)
         make_float(handle, "predicted_px_y", col2, dsc2)
         make_float(handle, "predicted_frame", col3, dsc3)
+        handle["predicted_px_x"].attrs["units"] = ""
+        handle["predicted_px_y"].attrs["units"] = ""
+        handle["predicted_frame"].attrs["units"] = ""
     elif key == "xyzcal.mm":
         col1, col2, col3 = data.parts()
         dsc1 = "The predicted bragg peak fast millimeter location"
@@ -106,6 +109,7 @@ def write(handle, key, data):
         d = data.as_int()
         d.reshape(flex.grid((len(data)), 6))
         make_int(handle, "bounding_box", d, "The reflection bounding box")
+        handle["bounding_box"].attrs["units"] = ""
     elif key == "xyzobs.px.value":
         col1, col2, col3 = data.parts()
         dsc1 = "The observed centroid fast pixel value"
@@ -114,6 +118,9 @@ def write(handle, key, data):
         make_float(handle, "observed_px_x", col1, dsc1)
         make_float(handle, "observed_px_y", col2, dsc2)
         make_float(handle, "observed_frame", col3, dsc3)
+        handle["observed_px_x"].attrs["units"] = ""
+        handle["observed_px_y"].attrs["units"] = ""
+        handle["observed_frame"].attrs["units"] = ""
     elif key == "xyzobs.px.variance":
         col1, col2, col3 = data.parts()
         dsc1 = "The observed centroid fast pixel variance"
@@ -122,6 +129,9 @@ def write(handle, key, data):
         make_float(handle, "observed_px_x_var", col1, dsc1)
         make_float(handle, "observed_px_y_var", col2, dsc2)
         make_float(handle, "observed_frame_var", col3, dsc3)
+        handle["observed_px_x_var"].attrs["units"] = ""
+        handle["observed_px_y_var"].attrs["units"] = ""
+        handle["observed_frame_var"].attrs["units"] = ""
     elif key == "xyzobs.mm.value":
         col1, col2, col3 = data.parts()
         dsc1 = "The observed centroid fast pixel value"
@@ -328,6 +338,7 @@ def dump(entry, reflections, experiments):
     assert "reflections" not in entry
     refls = entry.create_group("reflections")
     refls.attrs["NX_class"] = "NXsubentry"
+    refls.attrs["description"] = ""
 
     # Create the definition
     definition = refls.create_dataset("definition", data="NXreflections")
@@ -347,13 +358,14 @@ def dump(entry, reflections, experiments):
             print(e.args[0])
 
     # FIXME Write the overlaps (for testing at the moment)
-    overlaps = [[] for i in range(len(reflections))]
-    overlaps[0] = [1, 2, 3]
-    overlaps[1] = [0, 4]
-    overlaps[2] = [0, 3]
-    overlaps[3] = [0, 2]
-    overlaps[4] = [1]
-    make_vlen_uint(refls, "overlaps", overlaps, "Reflection overlap list")
+    # Optional and doesn't pass validation, so disable
+    # overlaps = [[] for i in range(len(reflections))]
+    # overlaps[0] = [1, 2, 3]
+    # overlaps[1] = [0, 4]
+    # overlaps[2] = [0, 3]
+    # overlaps[3] = [0, 2]
+    # overlaps[4] = [1]
+    # make_vlen_uint(refls, "overlaps", overlaps, "Reflection overlap list")
 
 
 def load(entry):

--- a/util/nexus/nx_reflections.py
+++ b/util/nexus/nx_reflections.py
@@ -213,7 +213,7 @@ def read(handle, key):
     elif key == "partial_id":
         return flex.size_t(handle["reflection_id"][:].astype(int))
     elif key == "entering":
-        return flex.bool(handle["entering"][:])
+        return flex.bool(handle["entering"][:].astype(np.bool))
     elif key == "flags":
         return flex.size_t(handle["flags"][:].astype(int))
     elif key == "panel":


### PR DESCRIPTION
This pull request makes NeXus files generated by dials.export format=nxs (nearly) fully compliant with NXmx and NXreflections.  No further work is required here to make these files pass validation. 
 When these two pull requests over in NeXus-land are merged (this is work from last week's code camp), we'll be fully compliant:

nexusformat/definitions#744
nexusformat/cnxvalidate#26
