### PR TITLE
Fix shoebox memory usage check

### DIFF
--- a/algorithms/integration/parallel_integrator.py
+++ b/algorithms/integration/parallel_integrator.py
@@ -296,9 +296,9 @@ def assert_enough_memory(required_memory, max_memory_usage):
     include increasing the percentage of memory allowed for shoeboxes or
     decreasing the block size. This could also be caused by a highly mosaic
     crystal model - is your crystal really this mosaic?
-      Total system memory: %g GB
-      Limit image memory: %g GB
-      Required image memory: %g GB
+      Total system memory: %.1f GB
+      Limit image memory: %.1f GB
+      Required image memory: %.1f GB
     """
             % (total_memory / 1e9, limit_memory / 1e9, required_memory / 1e9)
         )

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -478,9 +478,9 @@ class Task(object):
         percentage of memory allowed for shoeboxes or decreasing the block size.
         The average shoebox size is %d × %d pixels × %d images - is your crystal
         really this mosaic?
-        Total system memory: %g GB
-        Shoebox memory limit: %g GB
-        Required shoebox memory: %g GB
+        Total system memory: %.1f GB
+        Shoebox memory limit: %.1f GB
+        Required shoebox memory: %.1f GB
     """
                 % (
                     xsize,
@@ -813,9 +813,9 @@ class Manager(object):
         percentage of memory allowed for shoeboxes or decreasing the block size.
         The average shoebox size is %d × %d pixels × %d images - is your crystal
         really this mosaic?
-            Total system memory: %g GB
-            Shoebox memory limit: %g GB
-            Required shoebox memory: %g GB
+            Total system memory: %.1f GB
+            Shoebox memory limit: %.1f GB
+            Required shoebox memory: %.1f GB
         """
                     % (
                         xsize,

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -65,9 +65,9 @@ def _average_bbox_size(reflections):
     sel = flex.random_selection(len(bbox), min(len(bbox), 1000))
     subset_bbox = bbox.select(sel)
     xmin, xmax, ymin, ymax, zmin, zmax = subset_bbox.parts()
-    xsize = flex.mean(xmax - xmin)
-    ysize = flex.mean(ymax - ymin)
-    zsize = flex.mean(zmax - zmin)
+    xsize = flex.mean(flex.double(xmax - xmin))
+    ysize = flex.mean(flex.double(ymax - ymin))
+    zsize = flex.mean(flex.double(zmax - zmin))
     return xsize, ysize, zsize
 
 

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -65,9 +65,9 @@ def _average_bbox_size(reflections):
     sel = flex.random_selection(len(bbox), min(len(bbox), 1000))
     subset_bbox = bbox.select(sel)
     xmin, xmax, ymin, ymax, zmin, zmax = subset_bbox.parts()
-    xsize = flex.mean(flex.double(xmax - xmin))
-    ysize = flex.mean(flex.double(ymax - ymin))
-    zsize = flex.mean(flex.double(zmax - zmin))
+    xsize = flex.mean((xmax - xmin).as_double())
+    ysize = flex.mean((ymax - ymin).as_double())
+    zsize = flex.mean((zmax - zmin).as_double())
     return xsize, ysize, zsize
 
 

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -479,7 +479,7 @@ class Task(object):
         The average shoebox size is %d × %d pixels × %d images - is your crystal
         really this mosaic?
         Total system memory: %g GB
-        Limit shoebox memory: %g GB
+        Shoebox memory limit: %g GB
         Required shoebox memory: %g GB
     """
                 % (
@@ -814,8 +814,8 @@ class Manager(object):
         The average shoebox size is %d × %d pixels × %d images - is your crystal
         really this mosaic?
             Total system memory: %g GB
-            Limit shoebox memory: %g GB
-            Maximum shoebox memory: %g GB
+            Shoebox memory limit: %g GB
+            Required shoebox memory: %g GB
         """
                     % (
                         xsize,

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -58,15 +58,16 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-def _average_shoebox_size(reflections):
-    """Calculate the average shoebox size for debugging"""
+def _average_bbox_size(reflections):
+    """Calculate the average bbox size for debugging"""
 
-    shoebox = reflections["shoebox"]
-    sel = flex.random_selection(len(shoebox), min(len(shoebox), 1000))
-    subset_sb = shoebox.select(sel)
-    xsize = flex.mean(flex.double([s.xsize() for s in subset_sb]))
-    ysize = flex.mean(flex.double([s.ysize() for s in subset_sb]))
-    zsize = flex.mean(flex.double([s.zsize() for s in subset_sb]))
+    bbox = reflections["bbox"]
+    sel = flex.random_selection(len(bbox), min(len(bbox), 1000))
+    subset_bbox = bbox.select(sel)
+    xmin, xmax, ymin, ymax, zmin, zmax = subset_bbox.parts()
+    xsize = flex.mean(xmax - xmin)
+    ysize = flex.mean(ymax - ymin)
+    zsize = flex.mean(zmax - zmin)
     return xsize, ysize, zsize
 
 
@@ -467,7 +468,7 @@ class Task(object):
         ), "maximum memory usage must be <= 1"
         limit_memory = total_memory * self.params.block.max_memory_usage
         if sbox_memory > limit_memory:
-            xsize, ysize, zsize = _average_shoebox_size(self.reflections)
+            xsize, ysize, zsize = _average_bbox_size(self.reflections)
             raise RuntimeError(
                 """
     There was a problem allocating memory for shoeboxes. Possible solutions
@@ -801,7 +802,8 @@ class Manager(object):
             limit_memory = total_memory * self.params.block.max_memory_usage
             njobs = int(math.floor(limit_memory / max_memory))
             if njobs < 1:
-                xsize, ysize, zsize = _average_shoebox_size(self.reflections)
+
+                xsize, ysize, zsize = _average_bbox_size(self.reflections)
                 raise RuntimeError(
                     """
         No enough memory to run integration jobs. Possible solutions
@@ -813,7 +815,14 @@ class Manager(object):
             Limit shoebox memory: %g GB
             Max shoebox memory: %g GB
         """
-                    % (total_memory / 1e9, limit_memory / 1e9, max_memory / 1e9)
+                    % (
+                        xsize,
+                        ysize,
+                        zsize,
+                        total_memory / 1e9,
+                        limit_memory / 1e9,
+                        max_memory / 1e9,
+                    )
                 )
             else:
                 self.params.mp.nproc = min(self.params.mp.nproc, njobs)

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 from __future__ import absolute_import, division, print_function
 
 import itertools
@@ -470,12 +472,12 @@ class Task(object):
         if sbox_memory > limit_memory:
             xsize, ysize, zsize = _average_bbox_size(self.reflections)
             raise RuntimeError(
-                """
-    There was a problem allocating memory for shoeboxes. Possible solutions
-    include increasing the percentage of memory allowed for shoeboxes or
-    decreasing the block size. This could also be caused by a highly mosaic
-    crystal model. The average shoebox size is %d * %d * %d pixels - is your
-    crystal really this mosaic?
+                u"""
+        There was a problem allocating memory for shoeboxes.  This could be caused
+        by a highly mosaic crystal model.  Possible solutions include increasing the
+        percentage of memory allowed for shoeboxes or decreasing the block size.
+        The average shoebox size is %d × %d pixels × %d images - is your crystal
+        really this mosaic?
         Total system memory: %g GB
         Limit shoebox memory: %g GB
         Required shoebox memory: %g GB
@@ -805,15 +807,15 @@ class Manager(object):
 
                 xsize, ysize, zsize = _average_bbox_size(self.reflections)
                 raise RuntimeError(
-                    """
-        No enough memory to run integration jobs. Possible solutions
-        include increasing the percentage of memory allowed for shoeboxes or
-        decreasing the block size. This could be caused by a highly mosaic
-        crystal model.  The average shoebox size is %d * %d * %d pixels - is
-        your crystal really this mosaic?
+                    u"""
+        Not enough memory to run integration jobs.  This could be caused by a
+        highly mosaic crystal model.  Possible solutions include increasing the
+        percentage of memory allowed for shoeboxes or decreasing the block size.
+        The average shoebox size is %d × %d pixels × %d images - is your crystal
+        really this mosaic?
             Total system memory: %g GB
             Limit shoebox memory: %g GB
-            Max shoebox memory: %g GB
+            Maximum shoebox memory: %g GB
         """
                     % (
                         xsize,

--- a/algorithms/integration/test_processor.py
+++ b/algorithms/integration/test_processor.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import, division, print_function
+
+import math
+
+from dials.array_family import flex
+from dials_algorithms_integration_integrator_ext import JobList
+from dials.algorithms.profile_model.gaussian_rs import Model
+from dxtbx.model.experiment_list import ExperimentListFactory
+import dials.algorithms.integration.processor
+import mock
+import pytest
+
+
+def test_shoebox_memory_is_a_reasonable_guesstimate(dials_data):
+    path = dials_data("centroid_test_data").join("experiments.json").strpath
+
+    exlist = ExperimentListFactory.from_json_file(path)[0]
+    exlist.profile = Model(
+        None,
+        n_sigma=3,
+        sigma_b=0.024 * math.pi / 180.0,
+        sigma_m=0.044 * math.pi / 180.0,
+    )
+
+    rlist = flex.reflection_table.from_predictions(exlist)
+    rlist["id"] = flex.int(len(rlist), 0)
+    rlist["bbox"] = flex.int6(rlist.size(), (0, 1, 0, 1, 0, 1))
+
+    jobs = JobList()
+    jobs.add((0, 1), (0, 9), 9)
+    for flatten in (True, False):
+        assumed_memory_usage = list(jobs.shoebox_memory(rlist, flatten))
+        assert len(assumed_memory_usage) == 1
+        assert assumed_memory_usage[0] == pytest.approx(23952, abs=3000)
+
+
+@mock.patch("dials.algorithms.integration.processor.flex.max")
+@mock.patch("dials.algorithms.integration.processor.psutil.virtual_memory")
+def test_runtime_error_raised_when_not_enough_memory(mock_psutil_vm, mock_flex_max):
+    mock_flex_max.return_value = 750001
+    mock_psutil_vm.return_value.total = 1000000
+
+    phil_mock = mock.Mock()
+    phil_mock.mp.method = "multiprocessing"
+    phil_mock.mp.nproc = 4
+    phil_mock.block.max_memory_usage = 0.75
+
+    reflections = {"bbox": flex.int6(1000, (0, 1, 0, 1, 0, 1))}
+    manager = dials.algorithms.integration.processor.Manager(
+        None, reflections, phil_mock
+    )
+    manager.jobs = mock.Mock(autospec=JobList)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        manager.compute_processors()
+    assert "Not enough memory to run integration jobs." in exc_info.value.args[0]
+    mock_flex_max.assert_called_once_with(manager.jobs.shoebox_memory.return_value)
+
+    # Reduce memory usage by 1 byte, should then pass
+    mock_flex_max.return_value = 750000
+    manager.compute_processors()
+    mock_flex_max.assert_called_with(manager.jobs.shoebox_memory.return_value)

--- a/test/command_line/test_integrate.py
+++ b/test/command_line/test_integrate.py
@@ -7,6 +7,7 @@ import shutil
 
 from dxtbx.serialize import load
 from dials.array_family import flex
+from dials.algorithms.integration.processor import _average_bbox_size
 import procrunner
 
 
@@ -395,3 +396,10 @@ def test_integrate_with_kapton(dials_regression, tmpdir):
     assert results[0]["zero"][1] - results[1]["zero"][1] < 0.0001
     assert False not in [results[0]["low"][i] > results[1]["low"][i] for i in (0, 1)]
     assert False not in [results[0]["high"][i] > results[1]["high"][i] for i in (0, 1)]
+
+
+def test_average_bbox_size():
+    """Test behaviour of function for obtaining average bbox size."""
+    reflections = flex.reflection_table()
+    reflections["bbox"] = flex.int6(*(flex.int(10, i) for i in range(6)))
+    assert _average_bbox_size(reflections) == (1, 1, 1)


### PR DESCRIPTION
Sometimes `dials.algorithms.integration.processor._average_shoebox_size` can be called on a reflection table that has no shoeboxes.  In fact, this is the usual case when `dials.algorithms.integration.processor.Manager.compute_processors` is called during a `dials.integrate` process because the predicted reflections have bboxes but don't yet have shoeboxes.

When the multiplicity is so high that the required shoebox memory exceeds the memory limit, `dials.integrate` should raise a nice `RuntimeError` with a meaningful message.  This code path was broken and is fixed by this PR.

fixes #1111

Co-Authored-By: Markus Gerstel <markus.gerstel@diamond.ac.uk>