### PR TITLE
Print image template

### DIFF
--- a/command_line/show.py
+++ b/command_line/show.py
@@ -258,6 +258,9 @@ def show_experiments(experiments, show_scan_varying=False):
             text.append("Format class: %s" % format_class.__name__)
         if expt.identifier != "":
             text.append("Experiment identifier: %s" % expt.identifier)
+        template = expt.imageset.get_template()
+        if template:
+            text.append("Image template: %s" % template)
         text.append(str(expt.detector))
         text.append(
             "Max resolution (at corners): %f"

--- a/command_line/show.py
+++ b/command_line/show.py
@@ -258,7 +258,10 @@ def show_experiments(experiments, show_scan_varying=False):
             text.append("Format class: %s" % format_class.__name__)
         if expt.identifier != "":
             text.append("Experiment identifier: %s" % expt.identifier)
-        template = expt.imageset.get_template()
+        try:
+            template = expt.imageset.get_template()
+        except AttributeError:
+            template = None
         if template:
             text.append("Image template: %s" % template)
         text.append(str(expt.detector))


### PR DESCRIPTION
Make it easier to match experiments to imagesets in a multi-imageset
context (such as after cosym/scaling). Related to #1132