### PR TITLE
Fix indexing from known orientation with multi-lattice

### DIFF
--- a/algorithms/indexing/known_orientation.py
+++ b/algorithms/indexing/known_orientation.py
@@ -13,22 +13,22 @@ class IndexerKnownOrientation(Indexer):
 
     def find_lattices(self):
         experiments = ExperimentList()
-        for cm in self.known_orientations:
+        for cm, expt in zip(self.known_orientations, self.experiments):
             # indexer expects crystals to be in primitive setting
             space_group = cm.get_space_group()
             cb_op_to_primitive = (
                 space_group.info().change_of_basis_op_to_primitive_setting()
             )
             cm = cm.change_basis(cb_op_to_primitive)
-            for expt in self.experiments:
-                experiments.append(
-                    Experiment(
-                        imageset=expt.imageset,
-                        beam=expt.beam,
-                        detector=expt.detector,
-                        goniometer=expt.goniometer,
-                        scan=expt.scan,
-                        crystal=cm,
-                    )
+            experiments.append(
+                Experiment(
+                    imageset=expt.imageset,
+                    beam=expt.beam,
+                    detector=expt.detector,
+                    goniometer=expt.goniometer,
+                    scan=expt.scan,
+                    crystal=cm,
+                    identifier=expt.identifier,
                 )
+            )
         return experiments

--- a/algorithms/indexing/test_index.py
+++ b/algorithms/indexing/test_index.py
@@ -780,6 +780,23 @@ def test_refinement_failure_on_max_lattices_a15(dials_regression, tmpdir):
     )
     assert len(experiments_list) == 2
 
+    # now try to reindex with existing model
+    result = procrunner.run(
+        [
+            "dials.index",
+            tmpdir.join("indexed.expt").strpath,
+            os.path.join(data_dir, "lpe4-2-a15_strong.pickle"),
+            "max_lattices=2",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("indexed.refl").check() and tmpdir.join("indexed.expt").check()
+    experiments_list = load.experiment_list(
+        tmpdir.join("indexed.expt").strpath, check_format=False
+    )
+    assert len(experiments_list) == 2
+
 
 def test_stills_indexer_multi_lattice_bug_MosaicSauter2014(dials_regression, tmpdir):
     """ Problem: In stills_indexer, before calling the refine function, the experiment list contains a list of


### PR DESCRIPTION
As pointed out in #1096 , the current code is broken (and looks like it may never have worked) for max_lattices > 1, possibly because it has only been used before on single lattice case where it does work.

I think this simple fix is all that's needed. A test has been added, which passes with the change, alongside the original case in #1096