### PR TITLE
Stills process fixes

### DIFF
--- a/test/command_line/test_stills_process.py
+++ b/test/command_line/test_stills_process.py
@@ -118,6 +118,7 @@ def test_sacla_h5(dials_regression, run_in_tmpdir, use_mpi, in_memory=False):
           centroid_definition = com
         }
       }
+      output.composite_output = True
       """
             % geometry_path
         )
@@ -131,15 +132,12 @@ def test_sacla_h5(dials_regression, run_in_tmpdir, use_mpi, in_memory=False):
     result = easy_run.fully_buffered(command).raise_if_errors()
     result.show_stdout()
 
-    for result_filename, n_refls in zip(
-        [
-            "idx-run266702-0-subset_00000_integrated.refl",
-            "idx-run266702-0-subset_00001_integrated.refl",
-            "idx-run266702-0-subset_00003_integrated.refl",
-        ],
+    result_filename = "idx-0000_integrated.refl"
+    table = flex.reflection_table.from_file(result_filename)
+    for expt_id, n_refls in enumerate(
         [list(range(205, 225)), list(range(565, 580)), list(range(475, 500))],
     ):  # large ranges to handle platform-specific differences
-        table = flex.reflection_table.from_file(result_filename)
-        assert len(table) in n_refls, (result_filename, len(table))
-        assert "id" in table
-        assert (table["id"] == 0).count(False) == 0
+        subset = table.select(table["id"] == expt_id)
+        assert len(subset) in n_refls, (result_filename, expt_id, len(table))
+    assert "id" in table
+    assert set(table["id"]) == set((0, 1, 2))


### PR DESCRIPTION
- Fix experiment.identifier issues for composite mode.
- Composite mode was untested, so change one of the test_stills_process tests to test composite_mode
- For py3, use BytesIO instead of StringIO (for the legacy tar file output)
