### PR TITLE
Fix counting output

### DIFF
--- a/algorithms/spot_finding/per_image_analysis.py
+++ b/algorithms/spot_finding/per_image_analysis.py
@@ -13,6 +13,7 @@ from scitbx import matrix
 
 Slot = collections.namedtuple("Slot", "d_min d_max")
 _stats_field_names = [
+    "image",
     "d_min_distl_method_1",
     "d_min_distl_method_2",
     "estimated_d_min",
@@ -611,6 +612,7 @@ def stats_for_reflection_table(
         noisiness_method_2 = -1.0
 
     return StatsSingleImage(
+        image=0,
         n_spots_total=n_spots_total,
         n_spots_no_ice=n_spots_no_ice,
         n_spots_4A=n_spot_4A,
@@ -656,7 +658,8 @@ def stats_per_image(experiment, reflections, resolution_analysis=True):
         d_min_distl_method_2.append(stats.d_min_distl_method_2)
         noisiness_method_2.append(stats.noisiness_method_2)
 
-    return StatsMultiImage(
+    smi = StatsMultiImage(
+        image=list(range(start + 1, end + 1)),
         n_spots_total=n_spots_total,
         n_spots_no_ice=n_spots_no_ice,
         n_spots_4A=n_spots_4A,
@@ -667,6 +670,7 @@ def stats_per_image(experiment, reflections, resolution_analysis=True):
         d_min_distl_method_2=d_min_distl_method_2,
         noisiness_method_2=noisiness_method_2,
     )
+    return smi
 
 
 def plot_stats(stats, filename="per_image_analysis.png"):

--- a/util/ascii_art.py
+++ b/util/ascii_art.py
@@ -30,13 +30,20 @@ def flex_histogram(z, char="*", width=60, height=10):
     min_z = flex.min(z)
     max_z = flex.max(z)
 
+    shift = 0
+    if min_z < 0:
+        min_z += 1
+        max_z += 1
+        z += 1
+        shift = 1
+
     epsilon = flex.double(n % 2 for n in range(len(z)))
     epsilon = (epsilon / 2) - 0.25
     z += epsilon
 
     # image numbers to display on x-axis label
-    xmin = int(round(min_z + 1e-16))
-    xmax = int(round(max_z))
+    xmin = int(round(min_z + 1e-16)) - shift
+    xmax = int(round(max_z + 1e-16)) - shift
 
     # estimate the total number of images
     image_count = xmax - xmin + 1

--- a/util/ascii_art.py
+++ b/util/ascii_art.py
@@ -24,9 +24,6 @@ def flex_histogram(z, char="*", width=60, height=10):
     assert isinstance(char, six.string_types)
     assert len(char) == 1
 
-    # with open('list.json', 'w') as fh:
-    #   json.dump(sorted(list(z)), fh)
-
     min_z = flex.min(z)
     max_z = flex.max(z)
 
@@ -42,8 +39,8 @@ def flex_histogram(z, char="*", width=60, height=10):
     z += epsilon
 
     # image numbers to display on x-axis label
-    xmin = int(round(min_z + 1e-16)) - shift
-    xmax = int(round(max_z + 1e-16)) - shift
+    xmin = int(round(min_z + 0.25)) - shift
+    xmax = int(round(max_z + 0.25)) - shift
 
     # estimate the total number of images
     image_count = xmax - xmin + 1


### PR DESCRIPTION
For #1153

In the ascii-art graph need to recognise weirdness if we are counting from 0 - the output indices should be shifted (am implicitly assuming we are at worst having image 0 not image -1 ... etc.)

For the per-image analysis need to pass around the image numbers as well as
there it had been assumed that we would be running from 1... always