### PR TITLE
DIALS 2.1.4

### DIFF
--- a/libtbx_config
+++ b/libtbx_config
@@ -2,7 +2,7 @@
     "modules_required_for_build": ["boost", "scitbx", "cctbx", "dxtbx", "rstbx"],
     "modules_required_for_use": ["boost_adaptbx", "iotbx", "mmtbx"],
     "optional_modules": ["crys3d", "gltbx", "xfel"],
-    "conda_required": ["dials-dependencies>=0.8.0"],
+    "conda_required": [],
     "python_required": [
         "dials-data>=2.0.38",
         "Jinja2",

--- a/util/SConscript
+++ b/util/SConscript
@@ -12,4 +12,5 @@ env.SharedLibrary(target="#/lib/dials_util_ext", source=sources, LIBS=env["LIBS"
 env.SharedLibrary(
     target="#/lib/dials_util_streambuf_test_ext",
     source="boost_python/streambuf_test_ext.cpp",
+    LIBS=env["LIBS"],
 )

--- a/util/image_viewer/slip_viewer/tile_generation.py
+++ b/util/image_viewer/slip_viewer/tile_generation.py
@@ -67,8 +67,9 @@ def _get_flex_image_multipanel(
     assert len(panels) == len(raw_data), (len(panels), len(raw_data))
 
     # Determine next multiple of eight of the largest panel size.
+    data_max_focus = None
     for data in raw_data:
-        if "data_max_focus" not in locals():
+        if data_max_focus is None:
             data_max_focus = data.focus()
         else:
             data_max_focus = (
@@ -84,12 +85,13 @@ def _get_flex_image_multipanel(
     # dxtbx records a separated trusted_range for each panel,
     # generic_flex_image supports only accepts a single common value for
     # the saturation.
+    saturation = None
     for panel in panels:
-        if "saturation" not in locals():
+        if saturation is None:
             saturation = panel.get_trusted_range()[1]
         else:
             assert approx_equal(saturation, panel.get_trusted_range()[1])
-    assert "saturation" in locals() and saturation is not None
+    assert saturation is not None
 
     # Create rawdata and my_flex_image before populating it.
     rawdata = flex.double(flex.grid(len(panels) * data_padded[0], data_padded[1]))


### PR DESCRIPTION
* `dials.image_viewer`: performance improvements
* beamline CIF definition updates (mainly for DLS I19 data)
* xia2 now records dials absorption correction information in CIF files
* xia2 respects specified space group, not just the point group (xia2/xia2#420)
* `xia2.overload`: Fix bug on Python 3
* `xia2.report`: Fix bug in pychef plotting