### PR TITLE
Replace **0.5 and **2 with flex.sqrt and flex.pow2

### DIFF
--- a/algorithms/integration/filtering.py
+++ b/algorithms/integration/filtering.py
@@ -196,7 +196,7 @@ class IceRingFilter:
         :return: True/False in powder ring
         """
         result = flex.bool(len(d), False)
-        d2 = 1.0 / d ** 2
+        d2 = 1.0 / flex.pow2(d)
         for ice_ring in self.ice_rings:
             result = result | (d2 >= ice_ring[0]) & (d2 <= ice_ring[1])
         return result

--- a/algorithms/integration/kapton_2019_correction.py
+++ b/algorithms/integration/kapton_2019_correction.py
@@ -622,7 +622,7 @@ class multi_kapton_correction(object):
                     # has already been corrected!
                 else:
                     refl_sele["intensity.sum.value"] *= k_corr
-                    refl_sele["intensity.sum.variance"] *= (k_corr) ** 2
+                    refl_sele["intensity.sum.variance"] *= flex.pow2(k_corr)
                 return refl_sele
 
             if len(refl_zero) > 0 and self.params.smart_sigmas:

--- a/algorithms/integration/kapton_correction.py
+++ b/algorithms/integration/kapton_correction.py
@@ -637,7 +637,7 @@ class multi_kapton_correction(object):
                     # has already been corrected!
                 else:
                     refl_sele["intensity.sum.value"] *= k_corr
-                    refl_sele["intensity.sum.variance"] *= (k_corr) ** 2
+                    refl_sele["intensity.sum.variance"] *= flex.pow2(k_corr)
                 return refl_sele
 
             if len(refl_zero) > 0 and self.params.smart_sigmas:

--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -71,7 +71,7 @@ def prepare_merged_reflection_table(experiments, reflection_table, d_min=None):
     )
     merged_reflections = flex.reflection_table()
     merged_reflections["intensity"] = merged.data()
-    merged_reflections["variance"] = merged.sigmas() ** 2
+    merged_reflections["variance"] = flex.pow2(merged.sigmas())
     merged_reflections["miller_index"] = merged.indices()
     return merged_reflections
 
@@ -183,7 +183,7 @@ def merge_and_truncate(params, experiments, reflections):
     if params.assess_space_group:
         merged_reflections = flex.reflection_table()
         merged_reflections["intensity"] = merged.data()
-        merged_reflections["variance"] = merged.sigmas() ** 2
+        merged_reflections["variance"] = flex.pow2(merged.sigmas())
         merged_reflections["miller_index"] = merged.indices()
         logger.info("Running systematic absences check")
         run_systematic_absences_checks(experiments, merged_reflections)

--- a/algorithms/profile_model/gaussian_rs/calculator.py
+++ b/algorithms/profile_model/gaussian_rs/calculator.py
@@ -84,7 +84,7 @@ class ComputeEsdBeamDivergence(object):
 
             if flex.sum(values) > 1:
                 variance.append(
-                    flex.sum(values * (angles ** 2)) / (flex.sum(values) - 1)
+                    flex.sum(values * flex.pow2(angles)) / (flex.sum(values) - 1)
                 )
 
         # Return a list of variances
@@ -720,12 +720,12 @@ class ScanVaryingProfileModelCalculator(object):
 
         # Smooth the parameters
         kernel = gaussian_kernel(51)
-        sigma_b_sq_new = convolve(sigma_b ** 2, kernel)
-        sigma_m_sq_new = convolve(sigma_m ** 2, kernel)
+        sigma_b_sq_new = convolve(flex.pow2(sigma_b), kernel)
+        sigma_m_sq_new = convolve(flex.pow2(sigma_m), kernel)
 
         # Print the output - mean as is scan varying
-        mean_sigma_b = math.sqrt(sum(sigma_b ** 2) / len(sigma_b))
-        mean_sigma_m = math.sqrt(sum(sigma_m ** 2) / len(sigma_m))
+        mean_sigma_b = math.sqrt(sum(flex.pow2(sigma_b)) / len(sigma_b))
+        mean_sigma_m = math.sqrt(sum(flex.pow2(sigma_m)) / len(sigma_m))
 
         # Save the smoothed parameters
         self._sigma_b = flex.sqrt(flex.double(sigma_b_sq_new))

--- a/algorithms/refinement/two_theta_refiner.py
+++ b/algorithms/refinement/two_theta_refiner.py
@@ -159,7 +159,7 @@ class TwoThetaTarget(Target):
         reflections["2theta_resid"] = (
             reflections["2theta_cal.rad"] - reflections["2theta_obs.rad"]
         )
-        reflections["2theta_resid2"] = reflections["2theta_resid"] ** 2
+        reflections["2theta_resid2"] = flex.pow2(reflections["2theta_resid"])
 
         # set used_in_refinement flag to all those that had predictions
         mask = reflections.get_flags(reflections.flags.predicted)
@@ -256,7 +256,7 @@ class TwoThetaPredictionParameterisation(PredictionParameterisation):
 
             # 2theta = 2 * arcsin( |r0| / (2 * |s0| ) )
             sintheta = 0.5 * r0len * wl
-            fac = 1.0 / flex.sqrt(flex.double(len(wl), 1.0) - sintheta ** 2)
+            fac = 1.0 / flex.sqrt(flex.double(len(wl), 1.0) - flex.pow2(sintheta))
             val = fac * wl * dr0len
 
             d2theta_dp.append(val)

--- a/algorithms/scaling/Ih_table.py
+++ b/algorithms/scaling/Ih_table.py
@@ -540,7 +540,7 @@ Not all rows of h_index_matrix appear to be filled in IhTableBlock setup."""
     def calc_Ih(self):
         """Calculate the current best estimate for Ih for each reflection group."""
         scale_factors = self.Ih_table["inverse_scale_factor"]
-        gsq = (scale_factors ** 2) * self.Ih_table["weights"]
+        gsq = flex.pow2(scale_factors) * self.Ih_table["weights"]
         sumgsq = gsq * self.h_index_matrix
         gI = (scale_factors * self.Ih_table["intensity"]) * self.Ih_table["weights"]
         sumgI = gI * self.h_index_matrix
@@ -701,6 +701,6 @@ def _reflection_table_to_iobs(table, unit_cell, space_group):
         miller_set, data=table["intensity"] / table["inverse_scale_factor"]
     )
     i_obs.set_observation_type_xray_intensity()
-    i_obs.set_sigmas((table["variance"] ** 0.5) / table["inverse_scale_factor"])
+    i_obs.set_sigmas(flex.sqrt(table["variance"]) / table["inverse_scale_factor"])
     i_obs.set_info(miller.array_info(source="DIALS", source_type="reflection_tables"))
     return i_obs

--- a/algorithms/scaling/combine_intensities.py
+++ b/algorithms/scaling/combine_intensities.py
@@ -173,7 +173,7 @@ class SingleDatasetIntensityCombiner(object):
             )
             i_obs.set_observation_type_xray_intensity()
             i_obs.set_sigmas(
-                (Var ** 0.5)
+                flex.sqrt(Var)
                 * self.dataset["prescaling_correction"]
                 / self.dataset["inverse_scale_factor"]
             )
@@ -229,7 +229,7 @@ def _calculate_suitable_combined_intensities(scaler, max_key):
     if max_key == 1:
         if "partiality" in reflections:
             intensity = Isum * suitable_conv * inv_p
-            variance = Vsum * (suitable_conv * inv_p) ** 2
+            variance = Vsum * flex.pow2(suitable_conv * inv_p)
         else:
             intensity = Isum * suitable_conv
             variance = Vsum * suitable_conv * suitable_conv
@@ -347,7 +347,7 @@ class MultiDatasetIntensityCombiner(object):
             for dataset in self.datasets:
                 Int, Var = _get_Is_from_Imidval(dataset, Imid)
                 Int *= dataset["prescaling_correction"]
-                sigma = (Var ** 0.5) * dataset["prescaling_correction"]
+                sigma = flex.sqrt(Var) * dataset["prescaling_correction"]
                 combined_intensities.extend(Int)
                 combined_sigmas.extend(sigma)
                 combined_scales.extend(dataset["inverse_scale_factor"])
@@ -393,8 +393,8 @@ def _get_Is_from_Imidval(reflections, Imid):
     elif Imid == 1:  # special value to trigger sum
         if "partiality" in reflections:
             Int = reflections["intensity.sum.value"] / reflections["partiality"]
-            Var = reflections["intensity.sum.variance"] / (
-                reflections["partiality"] ** 2
+            Var = reflections["intensity.sum.variance"] / flex.pow2(
+                reflections["partiality"]
             )
         else:
             Int = reflections["intensity.sum.value"]
@@ -406,7 +406,7 @@ def _get_Is_from_Imidval(reflections, Imid):
                 reflections["intensity.sum.value"] / reflections["partiality"],
                 reflections["intensity.prf.variance"],
                 reflections["intensity.sum.variance"]
-                / (reflections["partiality"] ** 2),
+                / flex.pow2(reflections["partiality"]),
                 Imid,
             )
         else:

--- a/algorithms/scaling/error_model/error_model.py
+++ b/algorithms/scaling/error_model/error_model.py
@@ -70,7 +70,8 @@ def get_error_parameters_to_refine(model, scope):
 def calc_sigmaprime(x, Ih_table):
     """Calculate the error from the model."""
     sigmaprime = (
-        x[0] * ((Ih_table.variances) + ((x[1] * Ih_table.intensities) ** 2)) ** 0.5
+        x[0]
+        * flex.sqrt((Ih_table.variances) + flex.pow2((x[1] * Ih_table.intensities)))
     ) / Ih_table.inverse_scale_factors
     return sigmaprime
 
@@ -80,7 +81,7 @@ def calc_deltahl(Ih_table, n_h, sigmaprime):
     I_hl = Ih_table.intensities
     g_hl = Ih_table.inverse_scale_factors
     I_h = Ih_table.Ih_values
-    prefactor = ((n_h - flex.double(n_h.size(), 1.0)) / n_h) ** 0.5
+    prefactor = flex.sqrt((n_h - flex.double(n_h.size(), 1.0)) / n_h)
     delta_hl = prefactor * ((I_hl / g_hl) - I_h) / sigmaprime
     return delta_hl
 
@@ -318,10 +319,10 @@ class ErrorModelBinner(object):
 
     def calculate_bin_variances(self):
         """Calculate the variance of each bin."""
-        sum_deltasq = (self.delta_hl ** 2) * self.summation_matrix
-        sum_delta_sq = (self.delta_hl * self.summation_matrix) ** 2
+        sum_deltasq = flex.pow2(self.delta_hl) * self.summation_matrix
+        sum_delta_sq = flex.pow2(self.delta_hl * self.summation_matrix)
         bin_vars = (sum_deltasq / self.binning_info["refl_per_bin"]) - (
-            sum_delta_sq / (self.binning_info["refl_per_bin"] ** 2)
+            sum_delta_sq / flex.pow2(self.binning_info["refl_per_bin"])
         )
         self.binning_info["bin_variances"] = bin_vars
         return bin_vars
@@ -438,7 +439,7 @@ class BasicErrorModel(object):
     def update_variances(self, variances, intensities):
         """Use the error model parameter to calculate new values for the variances."""
         new_variance = (self.parameters[0] ** 2) * (
-            variances + ((self.parameters[1] * intensities) ** 2)
+            variances + flex.pow2(self.parameters[1] * intensities)
         )
         return new_variance
 

--- a/algorithms/scaling/error_model/error_model.py
+++ b/algorithms/scaling/error_model/error_model.py
@@ -70,8 +70,7 @@ def get_error_parameters_to_refine(model, scope):
 def calc_sigmaprime(x, Ih_table):
     """Calculate the error from the model."""
     sigmaprime = (
-        x[0]
-        * flex.sqrt((Ih_table.variances) + flex.pow2((x[1] * Ih_table.intensities)))
+        x[0] * flex.sqrt(Ih_table.variances + flex.pow2(x[1] * Ih_table.intensities))
     ) / Ih_table.inverse_scale_factors
     return sigmaprime
 

--- a/algorithms/scaling/error_model/error_model_target.py
+++ b/algorithms/scaling/error_model/error_model_target.py
@@ -10,12 +10,13 @@ def calculate_regression_x_y(Ih_table):
     """Calculate regression data points."""
     n = Ih_table.group_multiplicities() - 1.0
     group_variances = (
-        (Ih_table.intensities - (Ih_table.inverse_scale_factors * Ih_table.Ih_values))
-        ** 2
+        flex.pow2(
+            Ih_table.intensities - (Ih_table.inverse_scale_factors * Ih_table.Ih_values)
+        )
         * Ih_table.h_index_matrix
     ) / n
     sigmasq_obs = group_variances * Ih_table.h_expand_matrix
-    isq = Ih_table.intensities ** 2
+    isq = flex.pow2(Ih_table.intensities)
     y = sigmasq_obs / isq
     x = Ih_table.variances / isq
     return x, y
@@ -116,7 +117,9 @@ class ErrorModelTargetA(ErrorModelTarget):
     def calculate_residuals(self, apm):
         """Return the residual vector"""
         x = apm.x
-        R = (self.error_model.sortedy - (x[1] * self.error_model.sortedx) - x[0]) ** 2
+        R = flex.pow2(
+            self.error_model.sortedy - (x[1] * self.error_model.sortedx) - x[0]
+        )
         return R
 
     def calculate_gradients(self, apm):
@@ -144,7 +147,7 @@ class ErrorModelTargetB(ErrorModelTarget):
         bin_vars = self.error_model.binner.bin_variances
         R = (
             (
-                (flex.double(bin_vars.size(), 0.5) - bin_vars) ** 2
+                flex.pow2(flex.double(bin_vars.size(), 0.5) - bin_vars)
                 + (1.0 / bin_vars)
                 - flex.double(bin_vars.size(), 1.25)
             )
@@ -166,9 +169,9 @@ class ErrorModelTargetB(ErrorModelTarget):
         bin_counts = self.error_model.binner.binning_info["refl_per_bin"]
         dsig_dc = (
             b
-            * (I_hl ** 2)
+            * flex.pow2(I_hl)
             * (a ** 2)
-            / (self.error_model.binner.sigmaprime * (g_hl ** 2))
+            / (self.error_model.binner.sigmaprime * flex.pow2(g_hl))
         )
         ddelta_dsigma = (
             -1.0 * self.error_model.binner.delta_hl / self.error_model.binner.sigmaprime
@@ -177,13 +180,13 @@ class ErrorModelTargetB(ErrorModelTarget):
         dphi_by_dvar = -2.0 * (
             flex.double(bin_vars.size(), 0.5)
             - bin_vars
-            + (1.0 / (2.0 * (bin_vars ** 2)))
+            + (1.0 / (2.0 * flex.pow2(bin_vars)))
         )
         term1 = 2.0 * self.error_model.binner.delta_hl * deriv * sum_matrix
         term2a = self.error_model.binner.delta_hl * sum_matrix
         term2b = deriv * sum_matrix
         grad = dphi_by_dvar * (
-            (term1 / bin_counts) - (2.0 * term2a * term2b / (bin_counts ** 2))
+            (term1 / bin_counts) - (2.0 * term2a * term2b / flex.pow2(bin_counts))
         )
         gradients = flex.double([flex.sum(grad * weights) / flex.sum(weights)])
         return gradients

--- a/algorithms/scaling/model/components/smooth_scale_components.py
+++ b/algorithms/scaling/model/components/smooth_scale_components.py
@@ -328,7 +328,7 @@ class SmoothBScaleComponent1D(SmoothScaleComponent1D):
 
     def calculate_scales(self, block_id=0):
         s = super(SmoothBScaleComponent1D, self).calculate_scales(block_id)
-        return flex.exp(s / (2.0 * (self._d_values[block_id] ** 2)))
+        return flex.exp(s / (2.0 * flex.pow2(self._d_values[block_id])))
 
     def calculate_restraints(self):
         residual = self.parameter_restraints * (self._parameters * self._parameters)

--- a/algorithms/scaling/model/model.py
+++ b/algorithms/scaling/model/model.py
@@ -581,9 +581,9 @@ class ArrayScalingModel(ScalingModelBase):
         norm_time = xyz[2] * self.configdict["time_norm_fac"]
         if "decay" in self.components:
             d = reflection_table["d"]
-            norm_res = ((1.0 / (d ** 2)) - self.configdict["resmin"]) / self.configdict[
-                "res_bin_width"
-            ]
+            norm_res = (
+                (1.0 / flex.pow2(d)) - self.configdict["resmin"]
+            ) / self.configdict["res_bin_width"]
             self.components["decay"].data = {"x": norm_res, "y": norm_time}
         if "absorption" in self.components:
             norm_x_abs = (xyz[0] - self.configdict["xmin"]) / self.configdict[

--- a/algorithms/scaling/outlier_rejection.py
+++ b/algorithms/scaling/outlier_rejection.py
@@ -227,14 +227,13 @@ Targeted outlier rejection requires a target Ih_table with nblocks = 1"""
             Ih_table.intensities
             - (Ih_table.inverse_scale_factors * Ih_table.Ih_table["target_Ih_value"])
         ) / (
-            (
+            flex.sqrt(
                 Ih_table.variances
                 + (
-                    (Ih_table.inverse_scale_factors ** 2)
+                    flex.pow2(Ih_table.inverse_scale_factors)
                     * Ih_table.Ih_table["target_Ih_sigmasq"]
                 )
             )
-            ** 0.5
         )
         outliers_sel = flex.abs(norm_dev) > self._zmax
         outliers_isel = nz_sel.iselection().select(outliers_sel)
@@ -268,7 +267,7 @@ class SimpleNormDevOutlierRejection(OutlierRejectionBase):
 
         assert w.all_gt(0)  # guard against division by zero
         norm_dev = (intensity - (g * wgIsum / wg2sum)) / (
-            ((1.0 / w) + ((g / wg2sum) ** 2)) ** 0.5
+            flex.sqrt((1.0 / w) + flex.pow2(g / wg2sum))
         )
         norm_dev.set_selected(zero_sel, 1000)  # to trigger rejection
         outliers_sel = flex.abs(norm_dev) > self._zmax
@@ -364,7 +363,7 @@ class NormDevOutlierRejection(OutlierRejectionBase):
 
         assert w_sel.all_gt(0)  # guard against division by zero
         norm_dev = (I_sel - (g_sel * wgIsum_others_sel / wg2sum_others_sel)) / (
-            ((1.0 / w_sel) + (g_sel ** 2 / wg2sum_others_sel)) ** 0.5
+            flex.sqrt((1.0 / w_sel) + (flex.pow2(g_sel) / wg2sum_others_sel))
         )
         norm_dev.set_selected(zero_sel, 1000)  # to trigger rejection
         z_score = flex.abs(norm_dev)

--- a/algorithms/scaling/plots.py
+++ b/algorithms/scaling/plots.py
@@ -737,7 +737,7 @@ def plot_array_decay_plot(array_model):
 
     tickvals = flex.double(range(n_y_bins + 1))
     resmin = (tickvals * configdict["res_bin_width"]) + configdict["resmin"]
-    d = 1.0 / ((tickvals * configdict["res_bin_width"]) + resmin) ** 0.5
+    d = 1.0 / flex.sqrt((tickvals * configdict["res_bin_width"]) + resmin)
     ticktext = ["%.3f" % i for i in d]
 
     return {

--- a/algorithms/scaling/reflection_selection.py
+++ b/algorithms/scaling/reflection_selection.py
@@ -85,7 +85,7 @@ def _build_class_matrix(reflections, class_matrix, offset=0):
 
 def _select_groups_on_Isigma_cutoff(Ih_table, cutoff=2.0):
     """Select groups with multiplicity>1, Isigma>cutoff"""
-    I_over_sigma = Ih_table.intensities / (Ih_table.variances ** 0.5)
+    I_over_sigma = Ih_table.intensities / flex.sqrt(Ih_table.variances)
     sumIsigm = I_over_sigma * Ih_table.h_index_matrix
     n = Ih_table.group_multiplicities()
     avg_Isigma = sumIsigm / n
@@ -319,7 +319,7 @@ def _loop_over_class_matrix(
 
 
 def _determine_Isigma_selection(reflection_table, params):
-    Ioversigma = reflection_table["intensity"] / (reflection_table["variance"] ** 0.5)
+    Ioversigma = reflection_table["intensity"] / flex.sqrt(reflection_table["variance"])
     Isiglow, Isighigh = params.reflection_selection.Isigma_range
     selection = Ioversigma > Isiglow
     if Isighigh != 0.0:

--- a/algorithms/scaling/scaler.py
+++ b/algorithms/scaling/scaler.py
@@ -235,7 +235,7 @@ class ScalerBase(Subject):
                 scaler.var_cov_matrix.non_zeroes > 0
             ):  # parameters errors have been determined
                 fractional_error = (
-                    scaler.reflection_table["inverse_scale_factor_variance"] ** 0.5
+                    flex.sqrt(scaler.reflection_table["inverse_scale_factor_variance"])
                     / scaler.reflection_table["inverse_scale_factor"]
                 )
                 variance_scaling = (

--- a/algorithms/scaling/scaling_library.py
+++ b/algorithms/scaling/scaling_library.py
@@ -369,7 +369,7 @@ will not be used for calculating merging statistics""",
     )
     i_obs.set_observation_type_xray_intensity()
     i_obs.set_sigmas(
-        (joint_table["intensity.scale.variance"] ** 0.5)
+        flex.sqrt(joint_table["intensity.scale.variance"])
         / joint_table["inverse_scale_factor"]
     )
     i_obs.set_info(miller.array_info(source="DIALS", source_type="reflection_tables"))
@@ -454,29 +454,37 @@ def create_datastructures_for_target_mtz(experiments, mtz_file):
     if "I" in col_dict:  # nice and simple
         r_t["miller_index"] = ind
         r_t["intensity"] = col_dict["I"].extract_values().as_double()
-        r_t["variance"] = col_dict["SIGI"].extract_values().as_double() ** 2
+        r_t["variance"] = flex.pow2(col_dict["SIGI"].extract_values().as_double())
     elif "IMEAN" in col_dict:  # nice and simple
         r_t["miller_index"] = ind
         r_t["intensity"] = col_dict["IMEAN"].extract_values().as_double()
-        r_t["variance"] = col_dict["SIGIMEAN"].extract_values().as_double() ** 2
+        r_t["variance"] = flex.pow2(col_dict["SIGIMEAN"].extract_values().as_double())
     elif "I(+)" in col_dict:  # need to combine I+ and I- together into target Ih
         if col_dict["I(+)"].n_valid_values() == 0:  # use I(-)
             r_t["miller_index"] = ind
             r_t["intensity"] = col_dict["I(-)"].extract_values().as_double()
-            r_t["variance"] = col_dict["SIGI(-)"].extract_values().as_double() ** 2
+            r_t["variance"] = flex.pow2(
+                col_dict["SIGI(-)"].extract_values().as_double()
+            )
         elif col_dict["I(-)"].n_valid_values() == 0:  # use I(+)
             r_t["miller_index"] = ind
             r_t["intensity"] = col_dict["I(+)"].extract_values().as_double()
-            r_t["variance"] = col_dict["SIGI(+)"].extract_values().as_double() ** 2
+            r_t["variance"] = flex.pow2(
+                col_dict["SIGI(+)"].extract_values().as_double()
+            )
         else:  # Combine both - add together then use Ih table to calculate I and sigma
             r_tplus = flex.reflection_table()
             r_tminus = flex.reflection_table()
             r_tplus["miller_index"] = ind
             r_tplus["intensity"] = col_dict["I(+)"].extract_values().as_double()
-            r_tplus["variance"] = col_dict["SIGI(+)"].extract_values().as_double() ** 2
+            r_tplus["variance"] = flex.pow2(
+                col_dict["SIGI(+)"].extract_values().as_double()
+            )
             r_tminus["miller_index"] = ind
             r_tminus["intensity"] = col_dict["I(-)"].extract_values().as_double()
-            r_tminus["variance"] = col_dict["SIGI(-)"].extract_values().as_double() ** 2
+            r_tminus["variance"] = flex.pow2(
+                col_dict["SIGI(-)"].extract_values().as_double()
+            )
             r_tplus.extend(r_tminus)
             r_tplus.set_flags(
                 flex.bool(r_tplus.size(), False), r_tplus.flags.bad_for_scaling

--- a/algorithms/scaling/target_function.py
+++ b/algorithms/scaling/target_function.py
@@ -35,7 +35,7 @@ class ScalingTarget(object):
         R = flex.double([])
         n = 0
         for block in Ih_table.blocked_data_list:
-            R.extend((self.calculate_residuals(block) ** 2) * block.weights)
+            R.extend(flex.pow2(self.calculate_residuals(block)) * block.weights)
             n += block.size
         if self.param_restraints:
             restraints = ScalingRestraintsCalculator.calculate_restraints(apm)
@@ -60,7 +60,7 @@ class ScalingTarget(object):
     @staticmethod
     def calculate_gradients(Ih_table):
         """Return a gradient vector on length len(self.apm.x)."""
-        gsq = Ih_table.inverse_scale_factors ** 2 * Ih_table.weights
+        gsq = flex.pow2(Ih_table.inverse_scale_factors) * Ih_table.weights
         sumgsq = gsq * Ih_table.h_index_matrix
         prefactor = (
             -2.0
@@ -87,7 +87,7 @@ class ScalingTarget(object):
     @staticmethod
     def calculate_jacobian(Ih_table):
         """Calculate the jacobian matrix, size Ih_table.size by len(self.apm.x)."""
-        gsq = Ih_table.inverse_scale_factors ** 2 * Ih_table.weights
+        gsq = flex.pow2(Ih_table.inverse_scale_factors) * Ih_table.weights
         sumgsq = gsq * Ih_table.h_index_matrix
         dIh = (
             Ih_table.intensities
@@ -110,7 +110,7 @@ class ScalingTarget(object):
         resids = cls.calculate_residuals(Ih_table)
         gradients = cls.calculate_gradients(Ih_table)
         weights = Ih_table.weights
-        functional = flex.sum(resids ** 2 * weights)
+        functional = flex.sum(flex.pow2(resids) * weights)
         del Ih_table.derivatives
         return functional, gradients
 

--- a/algorithms/scaling/test_basis_function.py
+++ b/algorithms/scaling/test_basis_function.py
@@ -60,7 +60,7 @@ def test_RefinerCalculator(small_reflection_table):
     # Now test that the inverse scale factor is correctly calculated.
     calculated_sfs = s
     assert list(calculated_sfs) == pytest.approx(
-        list(new_S * flex.exp(new_B / (2.0 * (decay.d_values[0] ** 2))))
+        list(new_S * flex.exp(new_B / (2.0 * flex.pow2(decay.d_values[0]))))
     )
 
     # Now check that the derivative matrix is correctly calculated.

--- a/algorithms/scaling/test_combine_intensities.py
+++ b/algorithms/scaling/test_combine_intensities.py
@@ -179,14 +179,14 @@ def test_combine_intensities(test_exp_P1):
     assert list(variance[0:5]) == pytest.approx(
         list(
             reflections["intensity.sum.variance"][0:5]
-            * reflections["prescaling_correction"][0:5] ** 2
+            * flex.pow2(reflections["prescaling_correction"][0:5])
         ),
         rel=2e-2,
     )
     assert list(variance[20:25]) == pytest.approx(
         list(
             reflections["intensity.prf.variance"][20:25]
-            * reflections["prescaling_correction"][20:25] ** 2
+            * flex.pow2(reflections["prescaling_correction"][20:25])
         ),
         rel=2e-2,
     )
@@ -200,7 +200,7 @@ def test_combine_intensities(test_exp_P1):
     assert list(variance) == pytest.approx(
         list(
             reflections["intensity.prf.variance"]
-            * reflections["prescaling_correction"] ** 2
+            * flex.pow2(reflections["prescaling_correction"])
         ),
         rel=2e-2,
     )
@@ -214,7 +214,7 @@ def test_combine_intensities(test_exp_P1):
     assert list(variance) == pytest.approx(
         list(
             reflections["intensity.sum.variance"]
-            * reflections["prescaling_correction"] ** 2
+            * flex.pow2(reflections["prescaling_correction"])
         ),
         rel=2e-2,
     )

--- a/algorithms/scaling/test_error_model.py
+++ b/algorithms/scaling/test_error_model.py
@@ -202,7 +202,7 @@ def test_errormodel(large_reflection_table, test_sg):
     sigmaprime = calc_sigmaprime([x0, x1], error_model.filtered_Ih_table)
     cal_sigpr = list(
         x0
-        * ((block.variances + ((x1 * block.intensities) ** 2)) ** 0.5)
+        * flex.sqrt(block.variances + flex.pow2(x1 * block.intensities))
         / block.inverse_scale_factors
     )
     assert list(sigmaprime) == pytest.approx(cal_sigpr[4:7] + cal_sigpr[-2:])
@@ -243,9 +243,9 @@ def test_error_model_target(large_reflection_table, test_sg):
     target.predict(parameterisation)
     # Test residual calculation
     residuals = target.calculate_residuals(parameterisation)
-    assert (
-        residuals
-        == (flex.double(2, 1.0) - error_model.binner.binning_info["bin_variances"]) ** 2
+    assert residuals == (
+        flex.double(2, 1.0)
+        - flex.pow2(error_model.binner.binning_info["bin_variances"])
     )
 
     # Test gradient calculation against finite differences.

--- a/algorithms/scaling/test_observers.py
+++ b/algorithms/scaling/test_observers.py
@@ -264,7 +264,7 @@ def example_array(reflections):
         anomalous_flag=False,
     )
     ma = miller.array(ms, data=reflections["intensity"])
-    ma.set_sigmas(reflections["variance"] ** 0.5)
+    ma.set_sigmas(flex.sqrt(reflections["variance"]))
     return ma
 
 

--- a/algorithms/scaling/test_scaling_library.py
+++ b/algorithms/scaling/test_scaling_library.py
@@ -297,7 +297,7 @@ def test_choose_scaling_intensities(test_reflections):
         test_refl["intensity.sum.value"] / test_refl["partiality"]
     )
     assert list(new_rt["variance"]) == pytest.approx(
-        list(test_refl["intensity.sum.variance"] / (test_refl["partiality"] ** 2))
+        list(test_refl["intensity.sum.variance"] / flex.pow2(test_refl["partiality"]))
     )
     # If bad choice, currently return the prf values.
     intstr = "bad"

--- a/algorithms/scaling/test_target_function.py
+++ b/algorithms/scaling/test_target_function.py
@@ -294,7 +294,9 @@ def test_target_fixedIh():
     assert J[1, 0] == pytest.approx(-22.0)
     assert J[2, 0] == pytest.approx(-33.0)
 
-    expected_rmsd = (flex.sum(expected_residuals ** 2) / len(expected_residuals)) ** 0.5
+    expected_rmsd = (
+        flex.sum(flex.pow2(expected_residuals)) / len(expected_residuals)
+    ) ** 0.5
     assert target._rmsds is None
     target.param_restraints = False  # don't try to use apm to get restraints
     assert target.rmsds(mock_Ih_table(), [])
@@ -411,11 +413,11 @@ def calculate_gradient_fd(target, scaler, apm):
         new_x[i] -= 0.5 * delta
         apm.set_param_vals(new_x)
         scaler.update_for_minimisation(apm, 0)
-        R_low = (target.calculate_residuals(Ih_table) ** 2) * Ih_table.weights
+        R_low = flex.pow2(target.calculate_residuals(Ih_table)) * Ih_table.weights
         new_x[i] += delta
         apm.set_param_vals(new_x)
         scaler.update_for_minimisation(apm, 0)
-        R_upper = (target.calculate_residuals(Ih_table) ** 2) * Ih_table.weights
+        R_upper = flex.pow2(target.calculate_residuals(Ih_table)) * Ih_table.weights
         new_x[i] -= 0.5 * delta
         apm.set_param_vals(new_x)
         scaler.update_for_minimisation(apm, 0)

--- a/algorithms/scaling/weighting.py
+++ b/algorithms/scaling/weighting.py
@@ -57,7 +57,7 @@ class GemanMcClureWeights(WeightingBase):
             self.Ih_table.intensities
             - (self.Ih_table.inverse_scale_factors * self.Ih_table.Ih_values)
         ) / (self.Ih_table.inverse_scale_factors * self.Ih_table.Ih_values)
-        self.Ih_table.weights = 1.0 / ((1.0 + (e_i ** 2)) ** 2)
+        self.Ih_table.weights = 1.0 / flex.pow2(1.0 + flex.pow2(e_i))
 
 
 class CauchyWeights(WeightingBase):
@@ -72,7 +72,7 @@ class CauchyWeights(WeightingBase):
             self.Ih_table.intensities
             - (self.Ih_table.inverse_scale_factors * self.Ih_table.Ih_values)
         ) / (self.Ih_table.inverse_scale_factors * self.Ih_table.Ih_values)
-        self.Ih_table.weights = 1.0 / (1.0 + ((e_i / self.c) ** 2))
+        self.Ih_table.weights = 1.0 / (1.0 + flex.pow2(e_i / self.c))
 
 
 class HuberWeights(WeightingBase):
@@ -87,7 +87,7 @@ class HuberWeights(WeightingBase):
             self.Ih_table.intensities
             - (self.Ih_table.inverse_scale_factors * self.Ih_table.Ih_values)
         ) / (self.Ih_table.inverse_scale_factors * self.Ih_table.Ih_values)
-        abs_ei = (e_i ** 2) ** 0.5
+        abs_ei = flex.abs(e_i)
         self.Ih_table.weights = flex.double(self.Ih_table.size, 1.0)
         sel = abs_ei > self.c
         sel_abs_ei = abs_ei.select(sel)

--- a/algorithms/statistics/cc_half_algorithm.py
+++ b/algorithms/statistics/cc_half_algorithm.py
@@ -92,7 +92,7 @@ class CCHalfFromMTZ(object):
         table = flex.reflection_table()
         table["miller_index"] = intensities.indices()
         table["intensity"] = intensities.data()
-        table["variance"] = intensities.sigmas() ** 2
+        table["variance"] = flex.pow2(intensities.sigmas())
 
         # Create unit cell list
         zeroed_batches = batches.data() - flex.min(batches.data())

--- a/algorithms/statistics/delta_cchalf.py
+++ b/algorithms/statistics/delta_cchalf.py
@@ -209,7 +209,7 @@ class PerGroupCChalfStatistics(object):
             intensities = self.reflection_table["intensity"].select(sel)
             n = intensities.size()
             sum_x = flex.sum(intensities)
-            sum_x2 = flex.sum(intensities ** 2)
+            sum_x2 = flex.sum(flex.pow2(intensities))
             self.reflection_sums[h] = ReflectionSum(sum_x, sum_x2, n)
 
         # Compute some numbers

--- a/algorithms/symmetry/absences/screw_axes.py
+++ b/algorithms/symmetry/absences/screw_axes.py
@@ -86,7 +86,7 @@ class ScrewAxis(Subject):
         miller_idx = refl["miller_index"].select(sel)
         self.miller_axis_vals = miller_idx.as_vec3_double().parts()[self.axis_idx]
         self.intensities = refl["intensity"].select(sel)
-        self.sigmas = refl["variance"].select(sel) ** 0.5
+        self.sigmas = flex.sqrt(refl["variance"].select(sel))
         self.i_over_sigma = self.intensities / self.sigmas
 
         if self.equivalent_axes:
@@ -94,7 +94,7 @@ class ScrewAxis(Subject):
                 sel = a.select_axial_reflections(refl["miller_index"])
                 miller_idx = refl["miller_index"].select(sel)
                 intensities = refl["intensity"].select(sel)
-                sigmas = refl["variance"].select(sel) ** 0.5
+                sigmas = flex.sqrt(refl["variance"].select(sel))
                 self.i_over_sigma.extend(intensities / sigmas)
                 self.miller_axis_vals.extend(
                     miller_idx.as_vec3_double().parts()[a.axis_idx]

--- a/algorithms/symmetry/absences/test_screw_axes.py
+++ b/algorithms/symmetry/absences/test_screw_axes.py
@@ -19,7 +19,7 @@ def make_test_data_LCY_21c():
     s = [8.64, 0.80, 28.70, 1.87, 248.14, 1.30, 637.42, 1.57, 4.49, 2.05]
     s += [50.27, 3.37, 520.39, 4.84, 24.14]
     r["miller_index"] = flex.miller_index([(0, 0, j) for j in miller_ax_vals])
-    r["variance"] = flex.double(s) ** 2
+    r["variance"] = flex.pow2(flex.double(s))
     r["intensity"] = flex.double(i)
     return r
 
@@ -38,7 +38,7 @@ def make_test_data_thermo_61c():
     s += [0.188, 0.192, 0.144, 0.38, 0.149, 0.146, 0.158, 0.17, 0.185, 1.288]
     s += [0.127, 0.088, 0.086, 0.059, 0.092, 0.975]
     r["miller_index"] = flex.miller_index([(0, 0, j) for j in miller_ax_vals])
-    r["variance"] = flex.double(s) ** 2
+    r["variance"] = flex.pow2(flex.double(s))
     r["intensity"] = flex.double(i)
     return r
 
@@ -68,7 +68,7 @@ def make_test_data_thaumatin_41c():
     s += [1.411, 0.861, 2.561, 1.481, 1.162, 0.918, 3.367, 0.93, 1.03, 0.875]
     s += [1.0, 0.925, 0.918, 0.983, 1.631, 0.821, 1.35]
     r["miller_index"] = flex.miller_index([(0, 0, j) for j in miller_ax_vals])
-    r["variance"] = flex.double(s) ** 2
+    r["variance"] = flex.pow2(flex.double(s))
     r["intensity"] = flex.double(i)
     return r
 

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -445,7 +445,7 @@ class _(object):
         )
         i_obs = cctbx.miller.array(miller_set, data=intensities)
         i_obs.set_observation_type_xray_intensity()
-        i_obs.set_sigmas(cctbx.array_family.flex.sqrt(variances))
+        i_obs.set_sigmas(variances ** 0.5)
         i_obs.set_info(
             cctbx.miller.array_info(source="DIALS", source_type="reflection_tables")
         )
@@ -620,9 +620,7 @@ class _(object):
         x1, y1, z1 = s2["xyzcal.px"].parts()
         x2, y2, z2 = o2["xyzcal.px"].parts()
         distance = cctbx.array_family.flex.sqrt(
-            cctbx.array_family.flex.pow2(x1 - x2)
-            + cctbx.array_family.flex.pow2(y1 - y2)
-            + cctbx.array_family.flex.pow2(z1 - z2)
+            (x1 - x2) ** 2 + (y1 - y2) ** 2 + (z1 - z2) ** 2
         )
         mask = distance < 2
         logger.info(" %d reflections matched" % len(o2))
@@ -739,9 +737,7 @@ class _(object):
         x1, y1, z1 = s2["xyzcal.px"].parts()
         x2, y2, z2 = o2["xyzcal.px"].parts()
         distance = cctbx.array_family.flex.sqrt(
-            cctbx.array_family.flex.pow2(x1 - x2)
-            + cctbx.array_family.flex.pow2(y1 - y2)
-            + cctbx.array_family.flex.pow2(z1 - z2)
+            (x1 - x2) ** 2 + (y1 - y2) ** 2 + (z1 - z2) ** 2
         )
         mask = distance < 2
         logger.info(" %d reflections matched" % len(o2))

--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -445,7 +445,7 @@ class _(object):
         )
         i_obs = cctbx.miller.array(miller_set, data=intensities)
         i_obs.set_observation_type_xray_intensity()
-        i_obs.set_sigmas(variances ** 0.5)
+        i_obs.set_sigmas(cctbx.array_family.flex.sqrt(variances))
         i_obs.set_info(
             cctbx.miller.array_info(source="DIALS", source_type="reflection_tables")
         )
@@ -620,7 +620,9 @@ class _(object):
         x1, y1, z1 = s2["xyzcal.px"].parts()
         x2, y2, z2 = o2["xyzcal.px"].parts()
         distance = cctbx.array_family.flex.sqrt(
-            (x1 - x2) ** 2 + (y1 - y2) ** 2 + (z1 - z2) ** 2
+            cctbx.array_family.flex.pow2(x1 - x2)
+            + cctbx.array_family.flex.pow2(y1 - y2)
+            + cctbx.array_family.flex.pow2(z1 - z2)
         )
         mask = distance < 2
         logger.info(" %d reflections matched" % len(o2))
@@ -737,7 +739,9 @@ class _(object):
         x1, y1, z1 = s2["xyzcal.px"].parts()
         x2, y2, z2 = o2["xyzcal.px"].parts()
         distance = cctbx.array_family.flex.sqrt(
-            (x1 - x2) ** 2 + (y1 - y2) ** 2 + (z1 - z2) ** 2
+            cctbx.array_family.flex.pow2(x1 - x2)
+            + cctbx.array_family.flex.pow2(y1 - y2)
+            + cctbx.array_family.flex.pow2(z1 - z2)
         )
         mask = distance < 2
         logger.info(" %d reflections matched" % len(o2))

--- a/command_line/import_xds.py
+++ b/command_line/import_xds.py
@@ -130,9 +130,9 @@ class IntegrateHKLImporter(object):
         table["xyzcal.px"] = xyzcal
         table["xyzobs.px.value"] = xyzobs
         table["intensity.cor.value"] = iobs
-        table["intensity.cor.variance"] = sigma ** 2
+        table["intensity.cor.variance"] = flex.pow2(sigma)
         table["intensity.prf.value"] = iobs * peak / rlp
-        table["intensity.prf.variance"] = (sigma * peak / rlp) ** 2
+        table["intensity.prf.variance"] = flex.pow2(sigma * peak / rlp)
         table["lp"] = 1.0 / rlp
         table["d"] = flex.double(uc.d(h) for h in hkl)
         Command.end("Created table with {} reflections".format(len(table)))

--- a/command_line/spot_resolution_shells.py
+++ b/command_line/spot_resolution_shells.py
@@ -29,7 +29,7 @@ def spot_resolution_shells(experiments, reflections, params):
     reflections.centroid_px_to_mm(experiments)
     reflections.map_centroids_to_reciprocal_space(experiments)
     two_theta_array = reflections["rlp"].norms()
-    h0 = flex.weighted_histogram(two_theta_array ** 2, n_slots=params.shells)
+    h0 = flex.weighted_histogram(flex.pow2(two_theta_array), n_slots=params.shells)
     n = h0.slots()
     d = 1.0 / flex.sqrt(h0.slot_centers())
 

--- a/report/plots.py
+++ b/report/plots.py
@@ -885,10 +885,10 @@ class AnomalousPlotter(ResolutionPlotterMixin):
                     dano2 = arr2.anomalous_differences().data()
                     if dano1.size() > 0:
                         rmsd_11 = (
-                            flex.sum((dano1 - dano2) ** 2) / (2.0 * dano1.size())
+                            flex.sum(flex.pow2(dano1 - dano2)) / (2.0 * dano1.size())
                         ) ** 0.5
                         rmsd_1min1 = (
-                            flex.sum((dano1 + dano2) ** 2) / (2.0 * dano1.size())
+                            flex.sum(flex.pow2(dano1 + dano2)) / (2.0 * dano1.size())
                         ) ** 0.5
                         correl_ratios.append(rmsd_1min1 / rmsd_11)
                     else:

--- a/test/array_family/test_reflection_table.py
+++ b/test/array_family/test_reflection_table.py
@@ -1368,7 +1368,7 @@ def test_as_miller_array():
 
     iobs = table.as_miller_array(experiment, intensity="1")
     assert list(iobs.data()) == list(table["intensity.1.value"])
-    assert list(iobs.sigmas()) == list(table["intensity.1.variance"] ** 0.5)
+    assert list(iobs.sigmas()) == list(flex.sqrt(table["intensity.1.variance"]))
 
     with pytest.raises(Sorry):
         _ = table.as_miller_array(experiment, intensity="2")

--- a/util/export_mmcif.py
+++ b/util/export_mmcif.py
@@ -13,6 +13,7 @@ from cctbx import miller
 from cctbx import crystal as cctbxcrystal
 from iotbx.merging_statistics import dataset_statistics
 from libtbx import Auto
+from scitbx.array_family import flex
 
 logger = logging.getLogger(__name__)
 RAD2DEG = 180.0 / math.pi
@@ -244,20 +245,20 @@ class MMCIFOutputFile(object):
         variables_present = []
         if "scale" in self.params.intensity:
             reflections["scales"] = 1.0 / reflections["inverse_scale_factor"]
-            reflections["intensity.scale.sigma"] = (
-                reflections["intensity.scale.variance"] ** 0.5
+            reflections["intensity.scale.sigma"] = flex.sqrt(
+                reflections["intensity.scale.variance"]
             )
             variables_present.extend(
                 ["scales", "intensity.scale.value", "intensity.scale.sigma"]
             )
         if "sum" in self.params.intensity:
-            reflections["intensity.sum.sigma"] = (
-                reflections["intensity.sum.variance"] ** 0.5
+            reflections["intensity.sum.sigma"] = flex.sqrt(
+                reflections["intensity.sum.variance"]
             )
             variables_present.extend(["intensity.sum.value", "intensity.sum.sigma"])
         if "profile" in self.params.intensity:
-            reflections["intensity.prf.sigma"] = (
-                reflections["intensity.prf.variance"] ** 0.5
+            reflections["intensity.prf.sigma"] = flex.sqrt(
+                reflections["intensity.prf.variance"]
             )
             variables_present.extend(["intensity.prf.value", "intensity.prf.sigma"])
 

--- a/util/filter_reflections.py
+++ b/util/filter_reflections.py
@@ -644,8 +644,8 @@ class ScaleIntensityReducer(FilterForExportAlgorithm):
         reflection_table["intensity.scale.value"] /= reflection_table[
             "inverse_scale_factor"
         ]
-        reflection_table["intensity.scale.variance"] /= (
-            reflection_table["inverse_scale_factor"] ** 2
+        reflection_table["intensity.scale.variance"] /= flex.pow2(
+            reflection_table["inverse_scale_factor"]
         )
         return reflection_table
 


### PR DESCRIPTION
Using flex.sqrt and flex.pow2 is faster:

```
$ cat tst.py 
import time
from scitbx.array_family import flex

a = flex.random_double(100000)

t0 = time.time()
for i in range(1000):
    a ** 0.5
t1 = time.time()

for i in range(1000):
    flex.sqrt(a)
t2 = time.time()

for i in range(1000):
    a ** 2
t3 = time.time()

for i in range(1000):
    flex.pow2(a)
t4 = time.time()

print(t1 - t0)
print(t2 - t1)
print(t3 - t2)
print(t4 - t3)

$ dials.python tst.py 
3.79648709297
0.110934972763
3.71216607094
0.0598487854004
```

Mostly touches scaling code, although also some changes elsewhere.