### PR TITLE
DIALS 2.1.5

### DIFF
--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -477,11 +477,11 @@ class Task(object):
         if sbox_memory > limit_memory:
             xsize, ysize, zsize = _average_bbox_size(self.reflections)
             raise RuntimeError(
-                u"""
+                """
         There was a problem allocating memory for shoeboxes.  This could be caused
         by a highly mosaic crystal model.  Possible solutions include increasing the
         percentage of memory allowed for shoeboxes or decreasing the block size.
-        The average shoebox size is %d × %d pixels × %d images - is your crystal
+        The average shoebox size is %d x %d pixels x %d images - is your crystal
         really this mosaic?
         Total system memory: %.1f GB
         Shoebox memory limit: %.1f GB
@@ -812,11 +812,11 @@ class Manager(object):
 
                 xsize, ysize, zsize = _average_bbox_size(self.reflections)
                 raise RuntimeError(
-                    u"""
+                    """
         Not enough memory to run integration jobs.  This could be caused by a
         highly mosaic crystal model.  Possible solutions include increasing the
         percentage of memory allowed for shoeboxes or decreasing the block size.
-        The average shoebox size is %d × %d pixels × %d images - is your crystal
+        The average shoebox size is %d x %d pixels x %d images - is your crystal
         really this mosaic?
             Total system memory: %.1f GB
             Shoebox memory limit: %.1f GB

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -14,6 +14,7 @@ from dials.util import log
 from dials.array_family import flex
 from dxtbx.model.experiment_list import ExperimentListFactory
 from dxtbx.model.experiment_list import ExperimentList
+from dxtbx.model.experiment_list import Experiment
 from libtbx.utils import Abort, Sorry
 
 logger = logging.getLogger("dials.command_line.stills_process")
@@ -238,17 +239,27 @@ def do_import(filename, load_models=True):
 
     from dxtbx.imageset import ImageSetFactory
 
+    all_experiments = ExperimentList()
     for experiment in experiments:
-        if load_models:
-            experiment.load_models()
+        # Convert from ImageSequence to ImageSet, if needed
         imageset = ImageSetFactory.imageset_from_anyset(experiment.imageset)
-        imageset.set_scan(None)
-        imageset.set_goniometer(None)
-        experiment.imageset = imageset
-        experiment.scan = None
-        experiment.goniometer = None
+        for i in range(len(imageset)):
+            # Preserve original models if they were available (in the case of an image file
+            # they will not be, but in the case of a previously processed experiment list,
+            # then they may be available
+            expt = Experiment(
+                imageset=imageset[i : i + 1],
+                detector=experiment.detector,
+                beam=experiment.beam,
+                scan=experiment.scan,
+                goniometer=experiment.goniometer,
+                crystal=experiment.crystal,
+            )
+            if load_models:
+                expt.load_models()
+            all_experiments.append(expt)
 
-    return experiments
+    return all_experiments
 
 
 class Script(object):


### PR DESCRIPTION
* Fix out-of-memory exception text
* `dials.image_viewer` now works for images imported with `multi_panel=True`
* `dials.stills_process` now supports imagesets of length > 1 (e.g. grid scans)
* `xia2`: silence a `DeprecationWarning` when running on CCP4 7.1