### PR TITLE
Cache resolution masks per detector/panel

### DIFF
--- a/newsfragments/1170.bugfix
+++ b/newsfragments/1170.bugfix
@@ -1,0 +1,1 @@
+dials.find_spots_server no longer slows down 3x when using resolution filters

--- a/test/util/test_masking.py
+++ b/test/util/test_masking.py
@@ -156,9 +156,6 @@ def test_lru_equality_cache_id():
 
     fun = lru_equality_cache(maxsize=1)(_callappend)
 
-    # Now test cacheing of non-id-equal equality
-    callargs.clear()
-
     class EqTester(object):
         def __init__(self, a):
             self.a = a

--- a/util/masking.py
+++ b/util/masking.py
@@ -179,7 +179,6 @@ def _get_resolution_masker(beam, panel):
 
 def _apply_resolution_mask(mask, beam, panel, *args):
     _get_resolution_masker(beam, panel).apply(mask, *args)
-    print(_get_resolution_masker.cache_info())
 
 
 class MaskGenerator(object):


### PR DESCRIPTION
Because of implementation, generating a panel mask based on resolution is a relatively slow process, as it works by naively calculating the resolution for every pixel on a per-pixel basis. In normal spotfinding this object is reused with a local cache and so this isn't run into. With per-image-analysis spotfinding with find_spot_server this isn't the case, so we hit this expense for every call.

This patch adds a cache round the call to generate the masker, which means that although this expense is still paid, it's only paid the first time a particular (panel, beam) combination is used.

The cache is deliberately set small to avoid excessive memory usage; this will cause problems if repeatedly switching between N detectors but should be fine under the assumption that successive images through the per-image-analysis are mostly the same (panel, beam).

Fixes #1170, although not the root cause.