### PR TITLE
Implement shared scaling models and dose_decay scaling model.

### DIFF
--- a/algorithms/scaling/model/components/scale_components.py
+++ b/algorithms/scaling/model/components/scale_components.py
@@ -316,11 +316,8 @@ class LinearDoseDecay(ScaleComponentBase):
 
     For the dose dependent, the form is I = I0 exp(-ln(2) D/ Hd).
     Parameterise this as linear function of rotation with an overall factor
-    to refine.
-    Including an overall B-factor for nonisomorphism i.e. exp(B0 / 2d^2),
-    gives a scale factor :
-    T(r) = exp(Cr/d + B0/2d^2) - i.e. a two parameter model with the overall
-    'dose' proportional factor C and B0.
+    to refine. T(r) = exp(Cr/d - i.e. a one parameter model with the overall
+    'dose' proportional factor C.
     """
 
     null_parameter_value = 0.0

--- a/algorithms/scaling/model/components/scale_components.py
+++ b/algorithms/scaling/model/components/scale_components.py
@@ -387,6 +387,36 @@ class LinearDoseDecay(ScaleComponentBase):
         return scales
 
 
+class QuadraticDoseDecay(LinearDoseDecay):
+    """
+    A model component for a decay that depends quadratically on dose
+
+    For the dose dependent, the form is I = I0 exp(-C D/ d^2).
+    Parameterise this as linear function of rotation with an overall factor
+    to refine. T(r) = exp(Cr/d^2) - i.e. a one parameter model with the overall
+    'dose' proportional factor C.
+    """
+
+    def calculate_scales_and_derivatives(self, block_id=0):
+        """Calculate and return inverse scales and derivatives for a given block."""
+        scales = flex.exp(
+            self._parameters[0] * self._x[block_id] / (self._d_values[block_id] ** 2)
+        )
+        derivatives = sparse.matrix(self._n_refl[block_id], 1)
+        for i in range(self._n_refl[block_id]):
+            derivatives[i, 0] = scales[i] * (
+                self._x[block_id][i] / (self._d_values[block_id][i] ** 2)
+            )
+        return scales, derivatives
+
+    def calculate_scales(self, block_id=0):
+        """Calculate and return inverse scales for a given block."""
+        scales = flex.exp(
+            self._parameters[0] * self._x[block_id] / (self._d_values[block_id] ** 2)
+        )
+        return scales
+
+
 class SHScaleComponent(ScaleComponentBase):
     """
     A model component for a spherical harmonic absorption correction.

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -17,7 +17,10 @@ from dials.algorithms.scaling.plots import (
     error_model_variance_plot,
     error_regression_plot,
 )
-from dials.algorithms.scaling.model.model import plot_scaling_models
+from dials.algorithms.scaling.model.model import (
+    plot_scaling_models,
+    make_combined_plots,
+)
 from dials.report.analysis import (
     reflection_tables_to_batch_dependent_properties,
     make_merging_statistics_summary,
@@ -237,6 +240,9 @@ class ScalingModelObserver(Observer):
     def make_plots(self):
         """Generate scaling model component plot data."""
         d = OrderedDict()
+        combined_plots = make_combined_plots(self.data)
+        if combined_plots:
+            d.update(combined_plots)
         for key in sorted(self.data.keys()):
             scaling_model_plots = plot_scaling_models(self.data[key])
             for plot in scaling_model_plots.values():

--- a/algorithms/scaling/parameter_handler.py
+++ b/algorithms/scaling/parameter_handler.py
@@ -49,7 +49,7 @@ class ScalingParameterManagerGenerator(ParameterManagerGenerator):
 
     """Class to generate parameter manager for scaling."""
 
-    def __init__(self, data_managers, mode):
+    def __init__(self, data_managers, target, mode, shared=None):
         super(ScalingParameterManagerGenerator, self).__init__(
-            data_managers, scaling_active_parameter_manager, mode
+            data_managers, scaling_active_parameter_manager, target, mode, shared
         )

--- a/algorithms/scaling/plots.py
+++ b/algorithms/scaling/plots.py
@@ -12,29 +12,41 @@ from scitbx import math as scitbxmath
 from scitbx.math import distributions
 
 
-def _get_smooth_plotting_data_from_model(physical_model, component="scale"):
+def _get_smooth_plotting_data_from_model(model, component="scale"):
     """Return a tuple of phis, parameters, parameter esds,
     sample positions for plotting and sample scale values."""
-    configdict = physical_model.configdict
-    valid_osc = configdict["valid_osc_range"]
-    sample_values = flex.double(
-        np.linspace(
-            valid_osc[0],
-            valid_osc[1],
-            int((valid_osc[1] - valid_osc[0]) / 0.1) + 1,
-            endpoint=True,
+    valid_osc = model.configdict["valid_osc_range"]
+    if model.id_ == "physical":
+        sample_values = flex.double(
+            np.linspace(
+                valid_osc[0],
+                valid_osc[1],
+                int((valid_osc[1] - valid_osc[0]) / 0.1) + 1,
+                endpoint=True,
+            )
+        )  # Make a grid of
+        # points with 10 points per degree.
+    elif model.id_ == "dose_decay":
+        sample_values = flex.double(
+            np.linspace(
+                0.0,
+                abs(valid_osc[1] - valid_osc[0]),
+                int((abs(valid_osc[1] - valid_osc[0])) / 0.1) + 1,
+                endpoint=True,
+            )
         )
-    )  # Make a grid of
-    # points with 10 points per degree.
     if component == "scale":
-        if "scale" in configdict["corrections"]:
-            scale_SF = physical_model.components["scale"]
-            norm_vals = sample_values / physical_model.configdict["scale_rot_interval"]
+        if "scale" in model.configdict["corrections"]:
+            scale_SF = model.components["scale"]
+            norm_vals = sample_values / model.configdict["scale_rot_interval"]
             scale_SF.data = {"x": norm_vals}
             scale_SF.update_reflection_data()
             s = scale_SF.calculate_scales()
+            offset = valid_osc[0]
+            if model.id_ == "dose_decay":
+                offset = 0
             smoother_phis = [
-                (i * configdict["scale_rot_interval"]) + valid_osc[0]
+                (i * model.configdict["scale_rot_interval"]) + offset
                 for i in scale_SF.smoother.positions()
             ]
         return (
@@ -45,14 +57,14 @@ def _get_smooth_plotting_data_from_model(physical_model, component="scale"):
             s,
         )
     if component == "decay":
-        if "decay" in configdict["corrections"]:
-            decay_SF = physical_model.components["decay"]
-            norm_vals = sample_values / physical_model.configdict["decay_rot_interval"]
+        if "decay" in model.configdict["corrections"]:
+            decay_SF = model.components["decay"]
+            norm_vals = sample_values / model.configdict["decay_rot_interval"]
             decay_SF.data = {"x": norm_vals, "d": flex.double(norm_vals.size(), 1.0)}
             decay_SF.update_reflection_data()
             s = decay_SF.calculate_scales()
             smoother_phis = [
-                (i * configdict["decay_rot_interval"]) + valid_osc[0]
+                (i * model.configdict["decay_rot_interval"]) + valid_osc[0]
                 for i in decay_SF._smoother.positions()
             ]
         return (
@@ -76,6 +88,29 @@ gi = Ci * Ri * Si
 """
 
 
+def plot_relative_Bs(relative_Bs):
+    """Make scatter plot of relative Bs for dose-decay"""
+    d = {
+        "dose_relative_Bs": {
+            "data": [
+                {
+                    "x": list(range(0, len(relative_Bs))),
+                    "y": relative_Bs,
+                    "type": "scatter",
+                    "name": "Relative B-factor per dataset",
+                    "mode": "markers",
+                }
+            ],
+            "layout": {
+                "title": "Relative B-factor per dataset",
+                "xaxis": {"anchor": "y", "title": "Sweep id"},
+                "yaxis": {"anchor": "x", "title": "Relative B (Angstrom^2)"},
+            },
+        }
+    }
+    return d
+
+
 def plot_dose_decay(dose_decay_model):
     """Plot the decay and scale corrections for the dose-decay model."""
     d = {
@@ -83,11 +118,7 @@ def plot_dose_decay(dose_decay_model):
             "data": [],
             "layout": {
                 "title": "Dose-decay model corrections",
-                "xaxis": {
-                    "domain": [0, 1],
-                    "anchor": "y",
-                    "title": "rotation angle (degrees)",
-                },
+                "xaxis": {"domain": [0, 1], "anchor": "y", "title": "phi (degrees)",},
                 "yaxis": {
                     "domain": [0, 0.45],
                     "anchor": "x",
@@ -109,7 +140,7 @@ def plot_dose_decay(dose_decay_model):
 
     if "decay" in dose_decay_model.components:
         data = _add_decay_model_scales_to_data(
-            dose_decay_model, data, yaxis="y", resolution=3.0
+            dose_decay_model, data, yaxis="y", resolution=3.0,
         )
 
     d["dose_decay"]["data"] = data
@@ -156,15 +187,25 @@ def _add_decay_model_scales_to_data(model, data, yaxis="y", resolution=3.0):
     configdict = model.configdict
     valid_osc = configdict["valid_osc_range"]
 
-    sample_values = flex.double(
-        np.linspace(
-            valid_osc[0],
-            valid_osc[1],
-            int((valid_osc[1] - valid_osc[0]) / 0.1) + 1,
-            endpoint=True,
+    if model.id_ == "physical":
+        sample_values = flex.double(
+            np.linspace(
+                valid_osc[0],
+                valid_osc[1],
+                int((valid_osc[1] - valid_osc[0]) / 0.1) + 1,
+                endpoint=True,
+            )
+        )  # Make a grid of
+        # points with 10 points per degree.
+    elif model.id_ == "dose_decay":
+        sample_values = flex.double(
+            np.linspace(
+                0.0,
+                abs(valid_osc[1] - valid_osc[0]),
+                int((abs(valid_osc[1] - valid_osc[0])) / 0.1) + 1,
+                endpoint=True,
+            )
         )
-    )  # Make a grid of
-    # points with 10 points per degree.
     d = flex.double(sample_values.size(), resolution)
 
     if "decay" in model.components:

--- a/algorithms/scaling/plots.py
+++ b/algorithms/scaling/plots.py
@@ -76,6 +76,115 @@ gi = Ci * Ri * Si
 """
 
 
+def plot_dose_decay(dose_decay_model):
+    """Plot the decay and scale corrections for the dose-decay model."""
+    d = {
+        "dose_decay": {
+            "data": [],
+            "layout": {
+                "title": "Dose-decay model corrections",
+                "xaxis": {
+                    "domain": [0, 1],
+                    "anchor": "y",
+                    "title": "rotation angle (degrees)",
+                },
+                "yaxis": {
+                    "domain": [0, 0.45],
+                    "anchor": "x",
+                    "title": "Decay correction <br>scale factor",
+                },
+                "yaxis2": {
+                    "domain": [0.50, 0.95],
+                    "anchor": "x",
+                    "title": "Scale correction <br>scale factor",
+                },
+            },
+        }
+    }
+
+    data = []
+
+    if "scale" in dose_decay_model.components:
+        data = _add_smooth_scales_to_data(dose_decay_model, data, yaxis="y2")
+
+    if "decay" in dose_decay_model.components:
+        data = _add_decay_model_scales_to_data(
+            dose_decay_model, data, yaxis="y", resolution=3.0
+        )
+
+    d["dose_decay"]["data"] = data
+
+    return d
+
+
+def _add_smooth_scales_to_data(physical_model, data, yaxis="y2"):
+    (
+        smoother_phis,
+        parameters,
+        parameter_esds,
+        sample_values,
+        sample_scales,
+    ) = _get_smooth_plotting_data_from_model(physical_model, component="scale")
+
+    data.append(
+        {
+            "x": list(sample_values),
+            "y": list(sample_scales),
+            "type": "line",
+            "name": "smoothly-varying <br>scale correction",
+            "xaxis": "x",
+            "yaxis": yaxis,
+        }
+    )
+    data.append(
+        {
+            "x": list(smoother_phis),
+            "y": list(parameters),
+            "type": "scatter",
+            "mode": "markers",
+            "name": "smoothly-varying <br>scale parameters",
+            "xaxis": "x",
+            "yaxis": yaxis,
+        }
+    )
+    if parameter_esds:
+        data[-1]["error_y"] = {"type": "data", "array": list(parameter_esds)}
+    return data
+
+
+def _add_decay_model_scales_to_data(model, data, yaxis="y", resolution=3.0):
+    configdict = model.configdict
+    valid_osc = configdict["valid_osc_range"]
+
+    sample_values = flex.double(
+        np.linspace(
+            valid_osc[0],
+            valid_osc[1],
+            int((valid_osc[1] - valid_osc[0]) / 0.1) + 1,
+            endpoint=True,
+        )
+    )  # Make a grid of
+    # points with 10 points per degree.
+    d = flex.double(sample_values.size(), resolution)
+
+    if "decay" in model.components:
+        decay_SF = model.components["decay"]
+        decay_SF.data = {"x": sample_values, "d": d}
+        decay_SF.update_reflection_data()
+        s = decay_SF.calculate_scales()
+    data.append(
+        {
+            "x": list(sample_values),
+            "y": list(s),
+            "type": "line",
+            "name": "Decay scale factor <br>at %s Angstrom" % resolution,
+            "xaxis": "x",
+            "yaxis": yaxis,
+        }
+    )
+    return data
+
+
 def plot_smooth_scales(physical_model):
     """Plot smooth scale factors for the physical model."""
 
@@ -90,14 +199,19 @@ def plot_smooth_scales(physical_model):
                     "title": "rotation angle (degrees)",
                 },
                 "yaxis": {
-                    "domain": [0, 0.45],
+                    "domain": [0.0, 0.30],
                     "anchor": "x",
-                    "title": "relative B-factor",
+                    "title": "scale factor",
                 },
                 "yaxis2": {
-                    "domain": [0.5, 0.95],
+                    "domain": [0.35, 0.65],
                     "anchor": "x",
-                    "title": "inverse <br> scale factor",
+                    "title": "relative <br> B-factor",
+                },
+                "yaxis3": {
+                    "domain": [0.70, 1.0],
+                    "anchor": "x",
+                    "title": "scale factor",
                 },
             },
             "help": smooth_help_msg,
@@ -107,38 +221,7 @@ def plot_smooth_scales(physical_model):
     data = []
 
     if "scale" in physical_model.components:
-        (
-            smoother_phis,
-            parameters,
-            parameter_esds,
-            sample_values,
-            sample_scales,
-        ) = _get_smooth_plotting_data_from_model(physical_model, component="scale")
-
-        data.append(
-            {
-                "x": list(sample_values),
-                "y": list(sample_scales),
-                "type": "line",
-                "name": "smoothly-varying <br>scale correction",
-                "xaxis": "x",
-                "yaxis": "y2",
-            }
-        )
-        data.append(
-            {
-                "x": list(smoother_phis),
-                "y": list(parameters),
-                "type": "scatter",
-                "mode": "markers",
-                "name": "smoothly-varying <br>scale parameters",
-                "xaxis": "x",
-                "yaxis": "y2",
-            }
-        )
-        if parameter_esds:
-            data[-1]["error_y"] = {"type": "data", "array": list(parameter_esds)}
-
+        data = _add_smooth_scales_to_data(physical_model, data, yaxis="y3")
     if "decay" in physical_model.components:
         (
             smoother_phis,
@@ -155,7 +238,7 @@ def plot_smooth_scales(physical_model):
                 "type": "line",
                 "name": "smoothly-varying <br>B-factor correction",
                 "xaxis": "x",
-                "yaxis": "y",
+                "yaxis": "y2",
             }
         )
         data.append(
@@ -166,11 +249,15 @@ def plot_smooth_scales(physical_model):
                 "mode": "markers",
                 "name": "smoothly-varying <br>B-factor parameters",
                 "xaxis": "x",
-                "yaxis": "y",
+                "yaxis": "y2",
             }
         )
         if parameter_esds:
             data[-1]["error_y"] = {"type": "data", "array": list(parameter_esds)}
+
+        data = _add_decay_model_scales_to_data(
+            physical_model, data, yaxis="y", resolution=3.0
+        )
     d["smooth_scale_model"]["data"].extend(data)
     return d
 

--- a/algorithms/scaling/scaling_refiner.py
+++ b/algorithms/scaling/scaling_refiner.py
@@ -232,7 +232,7 @@ class ScalingSimpleLBFGS(ScalingRefinery, SimpleLBFGS):
         gi = []
         for block_id, block in enumerate(work_blocks):
             self._scaler.update_for_minimisation(self._parameters, block_id)
-            fb, gb = self._target.compute_functional_gradients(block)
+            fb, gb = self._parameters.compute_functional_gradients(block)
             f.append(fb)
             gi.append(gb)
         """task_results = easy_mp.parallel_map(
@@ -249,7 +249,7 @@ class ScalingSimpleLBFGS(ScalingRefinery, SimpleLBFGS):
         for i in range(1, len(gi)):
             g += gi[i]
 
-        restraints = self._target.compute_restraints_functional_gradients(
+        restraints = self._parameters.compute_restraints_functional_gradients(
             self._parameters
         )
 
@@ -280,7 +280,7 @@ class ScalingLstbxBuildUpMixin(ScalingRefinery):
         if objective_only:
             for block_id, block in enumerate(work_blocks):
                 self._scaler.update_for_minimisation(self._parameters, block_id)
-                residuals, weights = self._target.compute_residuals(block)
+                residuals, weights = self._parameters.compute_residuals(block)
                 self.add_residuals(residuals, weights)
         else:
             self._jacobian = None
@@ -291,7 +291,7 @@ class ScalingLstbxBuildUpMixin(ScalingRefinery):
                     residuals,
                     jacobian,
                     weights,
-                ) = self._target.compute_residuals_and_gradients(block)
+                ) = self._parameters.compute_residuals_and_gradients(block)
                 self.add_equations(residuals, jacobian, weights)
             """task_results = easy_mp.pool_map(
                 fixed_func=self._target.compute_residuals_and_gradients,
@@ -301,7 +301,7 @@ class ScalingLstbxBuildUpMixin(ScalingRefinery):
             for result in task_results:
                 self.add_equations(result[0], result[1], result[2])"""
 
-        restraints = self._target.compute_restraints_residuals_and_gradients(
+        restraints = self._parameters.compute_restraints_residuals_and_gradients(
             self._parameters
         )
         if restraints:

--- a/algorithms/scaling/test_basis_function.py
+++ b/algorithms/scaling/test_basis_function.py
@@ -11,6 +11,8 @@ from dials.algorithms.scaling.model.components.scale_components import (
 from dials.algorithms.scaling.basis_functions import RefinerCalculator
 from dials.algorithms.scaling.parameter_handler import scaling_active_parameter_manager
 
+# from dials.algorithms.scaling.target_function import ScalingTarget
+
 
 @pytest.fixture
 def small_reflection_table():
@@ -40,7 +42,7 @@ def test_RefinerCalculator(small_reflection_table):
         "abs": SingleScaleFactor(flex.double([1.0])),
     }  # Create empty components.
     components["scale"].data = {"id": rt["id"]}
-    components["decay"].data = {"d": rt["d"], "id": rt["id"]}
+    components["decay"].data = {"d": rt["d"]}
     components["abs"].data = {"id": rt["id"]}
     for component in components.values():
         component.update_reflection_data()  # Add some data to components.

--- a/algorithms/scaling/test_model.py
+++ b/algorithms/scaling/test_model.py
@@ -448,6 +448,7 @@ def test_DoseDecayModel(test_reflections, mock_exp):
         "corrections": ["scale", "decay", "relative_B"],
         "s_norm_fac": 1.0,
         "scale_rot_interval": 2.0,
+        "resolution_dependence": "quadratic",
     }
 
     parameters_dict = {

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -492,6 +492,27 @@ def test_scale_and_filter_image_group_mode(dials_data, tmpdir):
     assert analysis_results["termination_reason"] == "max_percent_removed"
 
 
+def test_scale_dose_decay_model(dials_data, tmpdir):
+    """Test the scale and filter command line program."""
+    location = dials_data("multi_crystal_proteinase_k")
+    command = [
+        "dials.scale",
+        "d_min=2.0",
+        "model=dose_decay",
+    ]
+    for i in [1, 2, 3, 4, 5, 7, 10]:
+        command.append(location.join("experiments_" + str(i) + ".json").strpath)
+        command.append(location.join("reflections_" + str(i) + ".pickle").strpath)
+
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("scaled.refl").check()
+    assert tmpdir.join("scaled.expt").check()
+    assert tmpdir.join("scaling.html").check()
+    expts = load.experiment_list(tmpdir.join("scaled.expt").strpath, check_format=False)
+    assert expts[0].scaling_model.id_ == "dose_decay"
+
+
 def test_scale_and_filter_dataset_mode(dials_data, tmpdir):
     """Test the scale and filter command line program."""
     location = dials_data("multi_crystal_proteinase_k")

--- a/algorithms/scaling/test_scale_components.py
+++ b/algorithms/scaling/test_scale_components.py
@@ -76,8 +76,8 @@ def test_SingleBScaleFactor():
     assert list(BSF.parameters) == [0.0]
     rt = flex.reflection_table()
     rt["d"] = flex.double([1.0, 1.0])
-    rt["id"] = flex.int([0, 0])
-    BSF.data = {"d": rt["d"], "id": rt["id"]}
+    # rt["id"] = flex.int([0, 0])
+    BSF.data = {"d": rt["d"]}
     BSF.update_reflection_data()
     assert BSF.n_refl == [2]
     assert list(BSF.d_values[0]) == [1.0, 1.0]

--- a/algorithms/scaling/test_scaler.py
+++ b/algorithms/scaling/test_scaler.py
@@ -19,6 +19,7 @@ from dials.algorithms.scaling.scaler import (
     NullScaler,
 )
 from dials.algorithms.scaling.parameter_handler import ScalingParameterManagerGenerator
+from dials.algorithms.scaling.target_function import ScalingTarget
 
 
 def side_effect_update_var(variances, intensities):
@@ -577,6 +578,7 @@ def test_SingleScaler_update_for_minimisation():
     single_scaler = SingleScaler(p, exp[0], r)
     pmg = ScalingParameterManagerGenerator(
         single_scaler.active_scalers,
+        ScalingTarget(),
         single_scaler.params.scaling_refinery.refinement_order,
     )
     single_scaler.components["scale"].parameters /= 2.0
@@ -725,7 +727,9 @@ def test_multiscaler_update_for_minimisation():
 
     multiscaler = MultiScaler([singlescaler1, singlescaler2])
     pmg = ScalingParameterManagerGenerator(
-        multiscaler.active_scalers, multiscaler.params.scaling_refinery.refinement_order
+        multiscaler.active_scalers,
+        ScalingTarget,
+        multiscaler.params.scaling_refinery.refinement_order,
     )
     multiscaler.single_scalers[0].components["scale"].parameters /= 2.0
     multiscaler.single_scalers[1].components["scale"].parameters *= 1.5

--- a/algorithms/scaling/test_target_function.py
+++ b/algorithms/scaling/test_target_function.py
@@ -321,7 +321,10 @@ def test_target_gradient_calculation_finite_difference(
     model.components["scale"].update_reflection_data()
     model.components["decay"].update_reflection_data()
     apm = multi_active_parameter_manager(
-        [model.components], [["scale", "decay"]], scaling_active_parameter_manager
+        ScalingTarget(),
+        [model.components],
+        [["scale", "decay"]],
+        scaling_active_parameter_manager,
     )
     model.components["scale"].inverse_scales = flex.double([2.0, 1.0, 2.0])
     model.components["decay"].inverse_scales = flex.double([1.0, 1.0, 0.4])
@@ -368,7 +371,10 @@ def test_target_jacobian_calculation_finite_difference(
     model.configure_components(large_reflection_table, single_exp, physical_param)
     model.components["scale"].update_reflection_data()
     apm = multi_active_parameter_manager(
-        [model.components], [["scale"]], scaling_active_parameter_manager
+        ScalingTarget(),
+        [model.components],
+        [["scale"]],
+        scaling_active_parameter_manager,
     )
     Ih_table = IhTable([large_reflection_table], single_exp.crystal.get_space_group())
 

--- a/libtbx_refresh.py
+++ b/libtbx_refresh.py
@@ -12,6 +12,7 @@ libtbx.pkg_utils.define_entry_points(
             "physical = dials.algorithms.scaling.model.model:PhysicalScalingModel",
             "KB = dials.algorithms.scaling.model.model:KBScalingModel",
             "array = dials.algorithms.scaling.model.model:ArrayScalingModel",
+            "dose_decay = dials.algorithms.scaling.model.model:DoseDecay",
         ],
         "dials.index.basis_vector_search": [
             "fft1d = dials.algorithms.indexing.basis_vector_search:FFT1D",

--- a/newsfragments/1183.newsfragment
+++ b/newsfragments/1183.newsfragment
@@ -1,0 +1,1 @@
+New scaling model, model=dose_decay, implementing a shared exponential decay component for multicrystal experiments


### PR DESCRIPTION
I don't expect anyone to have a look over the details of this as it's a fair amount of code, but here is a summary of what this is, and happy to receive feedback on the general ideas. I reckon it would be good to get this merged before the branch for 2.2

This work introduces a new scaling model, called dose-decay, which uses an exponentially decaying correction that is linearly dependent on dose :
i.e. decay correction proportional to _exp_(c D / d<sup>&beta;</sup>),
where D is `dose' i.e. image number, c is a proportionality constant which is the free parameter to be refined. This is in addition to a smoothly varying scale correction and overall B-factor per sweep.

It is unclear what the right value of &beta; is;
suggestions are that &beta;=1: https://doi.org/10.1107/S0907444910007262
but some recent experimental studies suggest a value of close to 2: https://doi.org/10.1107/S2052252519008777
so this is set as 2 (`resolution_dependence=quadratic`) for now.

This is ongoing research, targeted towards multi-crystal processing. By default, the decay model component is shared across crystals, i.e. the assumption is that all crystals receive the same dose history (not unreasonable for small crystals immersed in the beam in my opinion). Therefore this PR also implements sharing of model components, which can be used in future e.g. to share absorption surfaces for small molecule work.

Testing on a few datasets so far seems to suggest that this does not give any worse a result than allowing free refinement of smoothly-varying B-factors and may be beneficial for some datasets/analyses/future developments.