### PR TITLE
Update partiality filtering in dials.export and dials.merge

### DIFF
--- a/command_line/export.py
+++ b/command_line/export.py
@@ -88,13 +88,13 @@ phil_scope = parse(
 
   mtz {
 
-    combine_partials = True
+    combine_partials = False
       .type = bool
       .help = "Combine partials that have the same partial id into one
         reflection, with an updated partiality given by the sum of the
         individual partialities."
 
-    partiality_threshold=0.99
+    partiality_threshold=0.4
       .type = float
       .help = "All reflections with partiality values above the partiality
         threshold will be retained. This is done after any combination of

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -88,7 +88,7 @@ phil_scope = parse(
 
   mtz {
 
-    combine_partials = False
+    combine_partials = True
       .type = bool
       .help = "Combine partials that have the same partial id into one
         reflection, with an updated partiality given by the sum of the

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -42,7 +42,7 @@ combine_partials = True
     .help = "Combine partials that have the same partial id into one
         reflection, with an updated partiality given by the sum of the
         individual partialities."
-partiality_threshold=0.99
+partiality_threshold=0.95
     .type = float
     .help = "All reflections with partiality values above the partiality
         threshold will be retained. This is done after any combination of

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -42,7 +42,7 @@ combine_partials = True
     .help = "Combine partials that have the same partial id into one
         reflection, with an updated partiality given by the sum of the
         individual partialities."
-partiality_threshold=0.95
+partiality_threshold=0.4
     .type = float
     .help = "All reflections with partiality values above the partiality
         threshold will be retained. This is done after any combination of

--- a/newsfragments/1184.misc
+++ b/newsfragments/1184.misc
@@ -1,0 +1,1 @@
+Set partiality threshold in export and merge to be consistent with dials.scale (0.4)

--- a/test/command_line/test_compute_delta_cchalf.py
+++ b/test/command_line/test_compute_delta_cchalf.py
@@ -45,7 +45,7 @@ def test_compute_delta_cchalf_scaled_data_mtz(dials_data, tmpdir):
     expts = location.join("scaled_20_25.expt").strpath
 
     # First export the data
-    command = ["dials.export", refls, expts]
+    command = ["dials.export", refls, expts, "partiality_threshold=0.99"]
     result = procrunner.run(command, working_directory=tmpdir)
     assert not result.returncode and not result.stderr
     assert tmpdir.join("scaled.mtz").check()


### PR DESCRIPTION
After thinking about this, I don't believe we're doing the right thing in dials export. We currently combine partials and only export if the partiality is 0.99 or greater, effectively filtering out all partials. This data/information can then not be used by other programs such as Aimless, and given that Aimless is able to deal with partials, this data should be kept. Also if partials are combined (how, because they have different scales?), then things like the ROT value become meaningless. Changing to these defaults would then mean a more consistent set of reflections are fed in to dials.scale and Aimless (by default dials.scale is considering all reflections with partiality above 0.4). Similar changes should be implemented in xia2.

For dials.merge, it makes sense to combine partials to get the best estimate of the full intensity, however we should probably not be quite as strict with the partiality cutoff, perhaps 0.95 or 0.9 is more suitable?