### PR TITLE
Unit cell tool

### DIFF
--- a/command_line/image_viewer.py
+++ b/command_line/image_viewer.py
@@ -116,6 +116,10 @@ calibrate_unit_cell{
   space_group = None
     .type=str
     .help = "Specify spacegroup for the unit cell"
+  show_hkl = None
+    .type = ints(size=3)
+    .multiple=True
+    .help = "Limit display of rings to these Miller indices"
 }
 
 include scope dials.util.options.format_phil_scope

--- a/command_line/image_viewer.py
+++ b/command_line/image_viewer.py
@@ -105,15 +105,15 @@ calibrate_pdb{
     .type=float
     .help = "Limiting resolution to calculate powder rings"
 }
-calibrate_unitcell{
-  unitcell = None
+calibrate_unit_cell{
+  unit_cell = None
     .type=unit_cell
     .help = "Specify unit cell for powder rings."
     .help = "Option is mutually exclusive with calibrate silver, pdb and powder arcs options."
   d_min = 20.
     .type=float
     .help = "Limiting resolution to calculate powder rings"
-  spacegroup = None
+  space_group = None
     .type=str
     .help = "Specify spacegroup for the unit cell"
 }

--- a/command_line/image_viewer.py
+++ b/command_line/image_viewer.py
@@ -84,7 +84,39 @@ mask = None
   .type = path
   .help = path to mask pickle file
 
-include scope rstbx.phil.phil_preferences.iotbx_defs_viewer_detail
+powder_arcs{
+  show = False
+    .type=bool
+    .help = "show powder arcs calculated from PDB file."
+  code = None
+    .type=str
+    .help = "PDB code (4 characters) for file; fetch it from the Internet."
+}
+calibrate_silver = False
+    .type=bool
+    .help = "Open special GUI for distance/metrology from silver behenate."
+calibrate_pdb{
+  code = None
+    .type=str
+    .help = "Open pdb code (over Internet) to get unit cell & symmetry for powder rings."
+    .help = "Most useful for calibrating low-Q rings on far detector."
+    .help = "Option is mutually exclusive with calibrate silver, unit cell and powder arcs options."
+  d_min = 20.
+    .type=float
+    .help = "Limiting resolution to calculate powder rings"
+}
+calibrate_unitcell{
+  unitcell = None
+    .type=unit_cell
+    .help = "Specify unit cell for powder rings."
+    .help = "Option is mutually exclusive with calibrate silver, pdb and powder arcs options."
+  d_min = 20.
+    .type=float
+    .help = "Limiting resolution to calculate powder rings"
+  spacegroup = None
+    .type=str
+    .help = "Specify spacegroup for the unit cell"
+}
 
 include scope dials.util.options.format_phil_scope
 

--- a/newsfragments/1192.feature
+++ b/newsfragments/1192.feature
@@ -1,0 +1,1 @@
+dials.image_viewer: for the unit cell tool, rename parameters for consistency and add a new show_hkl option to filter displayed powder rings to select only those of interest.

--- a/util/image_viewer/slip_viewer/uc_frame.py
+++ b/util/image_viewer/slip_viewer/uc_frame.py
@@ -45,13 +45,15 @@ class UCSettingsPanel(wx.Panel):
         self._wavelength = beam.get_wavelength()
 
         # Unit cell controls.
-        if self.phil_params.calibrate_unitcell.unitcell is not None:
-            self._cell = list(self.phil_params.calibrate_unitcell.unitcell.parameters())
+        if self.phil_params.calibrate_unit_cell.unit_cell is not None:
+            self._cell = list(
+                self.phil_params.calibrate_unit_cell.unit_cell.parameters()
+            )
         else:
             self._cell = [4.18, 4.72, 58.38, 89.44, 89.63, 75.85]
 
-        if self.phil_params.calibrate_unitcell.spacegroup is not None:
-            self._spacegroup = self.phil_params.calibrate_unitcell.spacegroup
+        if self.phil_params.calibrate_unit_cell.space_group is not None:
+            self._spacegroup = self.phil_params.calibrate_unit_cell.space_group
         else:
             self._spacegroup = "P1"
 
@@ -224,8 +226,8 @@ class UCSettingsPanel(wx.Panel):
         sizer.Add(box)
 
         # d_min control
-        if self.phil_params.calibrate_unitcell.d_min is not None:
-            self.d_min = self.phil_params.calibrate_unitcell.d_min
+        if self.phil_params.calibrate_unit_cell.d_min is not None:
+            self.d_min = self.phil_params.calibrate_unit_cell.d_min
         else:
             self.d_min = 3.5
         box = wx.BoxSizer(wx.HORIZONTAL)

--- a/util/image_viewer/slip_viewer/uc_frame.py
+++ b/util/image_viewer/slip_viewer/uc_frame.py
@@ -57,6 +57,8 @@ class UCSettingsPanel(wx.Panel):
         else:
             self._spacegroup = "P1"
 
+        self._show_hkl = self.phil_params.calibrate_unit_cell.show_hkl
+
         self._cell_control_names = [
             "uc_a_ctrl",
             "uc_b_ctrl",
@@ -365,6 +367,13 @@ class UCSettingsPanel(wx.Panel):
         except Exception as e:
             frame.update_statusbar(str(e))
             return
+
+        if self._show_hkl:
+            hkl_list = hkl_list.common_set(
+                cctbx.miller.set(
+                    crystal_symmetry=uc, indices=self._show_hkl, anomalous_flag=False
+                )
+            )
 
         frame.update_statusbar(
             "%d %d %d %d %d %d, " % tuple(self._cell)


### PR DESCRIPTION
Here are a couple of changes to the unit cell tool of `dials.image_viewer`.

First, I renamed parameters here to be more consistent with other DIALS programs: `spacegroup` → `space_group` and `unitcell` → `unit_cell`. I suspect this tool is not used much here (whereas it may get much more use in `cctbx.image_viewer`). Therefore I don't think this change affects many users' existing work patterns.

The second change introduces a new parameter, `show_hkl`. This can be used to filter the displayed rings to show only those corresponding to Miller indices in the supplied list. This is helpful because datasheets for diffraction standards usually list only the strongly diffracting rings: https://www.emsdiasum.com/microscopy/technical/datasheet/80044.aspx

With this change only the desired rings are displayed
```
dials.image_viewer imported.expt \
  calibrate_unit_cell.unit_cell=4.094,4.094,4.094,90,90,90 \
  calibrate_unit_cell.d_min=0.81 \
  show_hkl=1,1,1 show_hkl=2,0,0 show_hkl=2,2,0 \
  show_hkl=3,1,1 show_hkl=2,2,2 show_hkl=4,0,0 \
  show_hkl=3,3,1 show_hkl=4,2,0 show_hkl=4,2,2
```
![Screenshot from 2020-03-11 15-34-27](https://user-images.githubusercontent.com/11502083/76435647-2c302200-63af-11ea-8e86-427b2b95b07f.png)

which is considerably easier to interpret than viewing all rings up to the specified resolution limit
```
dials.image_viewer imported.expt \
  calibrate_unit_cell.unit_cell=4.094,4.094,4.094,90,90,90 \
  calibrate_unit_cell.d_min=0.81
```
![Screenshot from 2020-03-11 15-34-31](https://user-images.githubusercontent.com/11502083/76435772-5b469380-63af-11ea-819c-9b4027f9c9cf.png)
