### PR TITLE
Calculate french-wilson plot using miller array methods. For #1169

### DIFF
--- a/report/plots.py
+++ b/report/plots.py
@@ -12,6 +12,7 @@ from cctbx import uctbx
 from scitbx.array_family import flex
 from scitbx.math import distributions
 from mmtbx.scaling.absolute_scaling import scattering_information, expected_intensity
+from mmtbx.scaling.matthews import matthews_rupp
 from scipy.optimize import least_squares
 
 
@@ -213,6 +214,8 @@ class IntensityStatisticsPlots(ResolutionPlotterMixin):
         self.multiplicities = merged.redundancies().complete_array(new_data_value=0)
         intensities.setup_binner_d_star_sq_step(auto_binning=True)
         self.wilson_plot_result = intensities.wilson_plot(use_binning=True)
+        mr = matthews_rupp(intensities.crystal_symmetry())
+        self.n_residues = mr.n_residues
         if not self._xanalysis and run_xtriage_analysis:
             # imports needed here or won't work, unsure why.
             from mmtbx.scaling.xtriage import xtriage_analyses
@@ -299,9 +302,8 @@ class IntensityStatisticsPlots(ResolutionPlotterMixin):
             )
         if not observed:
             return {}
-        # XXX unsure on n_residues, using same as xia2 CctbxFrenchWilson.py
         expected = expected_intensity(
-            scattering_information(n_residues=200),
+            scattering_information(n_residues=self.n_residues),
             dstarsq,
             b_wilson=self._xanalysis.iso_b_wilson,
             p_scale=self._xanalysis.wilson_scaling.iso_p_scale,

--- a/report/test_plots.py
+++ b/report/test_plots.py
@@ -83,6 +83,7 @@ def test_IntensityStatisticsPlots(iobs):
     wilson_scaling.mean_I_obs_data = [1.0, 2.0]
     wilson_scaling.mean_I_obs_theory = [1.0, 2.0]
     wilson_scaling.mean_I_normalisation = [1.0, 2.0]
+    wilson_scaling.iso_p_scale = 1.0
     # mock the twin results
     twin_results = mock.Mock()
     twin_results.nz_test.z = [1.0, 2.0]
@@ -98,6 +99,7 @@ def test_IntensityStatisticsPlots(iobs):
     xtriage_analyses = mock.Mock()
     xtriage_analyses.wilson_scaling = wilson_scaling
     xtriage_analyses.twin_results = twin_results
+    xtriage_analyses.iso_b_wilson = 2.0
 
     plotter = IntensityStatisticsPlots(
         iobs, n_resolution_bins=n_bins, xtriage_analyses=xtriage_analyses


### PR DESCRIPTION
Uses cctbx miller array methods to calculate the French-Wilson plot, and mmtbx code to generate the expected distribution, avoiding anisotropic scaling.

Seems to give reasonable looking plots (dials-report.html scaling results -> analysis by resolution)
Beta-lactamase:
![newplot (11)](https://user-images.githubusercontent.com/30625594/76773671-c40c8200-679a-11ea-8ed1-9d0670f2a5af.png)
Thermolysin:
![newplot (12)](https://user-images.githubusercontent.com/30625594/76773732-dd153300-679a-11ea-8ca0-3a2a11bff00b.png)
Thaumatin:
![newplot (13)](https://user-images.githubusercontent.com/30625594/76773842-05049680-679b-11ea-9d47-6b0a11a59b88.png)

