### PR TITLE
Override sigma b multiplier

### DIFF
--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -438,7 +438,7 @@ def _initialize_rotation(experiments, params, reflections):
     # Compute some reflection properties
     reflections.compute_zeta_multi(experiments)
     reflections.compute_d(experiments)
-    reflections.compute_bbox(experiments)
+    reflections.compute_bbox(experiments, sigma_b_multiplier=1.0)
 
     # Filter the reflections by zeta
     mask = flex.abs(reflections["zeta"]) < params.filter.min_zeta
@@ -1325,7 +1325,7 @@ class Integrator3DThreaded(object):
         # Compute some reflection properties
         self.reflections.compute_zeta_multi(self.experiments)
         self.reflections.compute_d(self.experiments)
-        self.reflections.compute_bbox(self.experiments)
+        self.reflections.compute_bbox(self.experiments, sigma_b_multiplier=1.0)
 
         # Filter the reflections by zeta
         mask = (

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -468,7 +468,9 @@ def _initialize_stills(experiments, params, reflections):
 
     # Compute some reflection properties
     reflections.compute_d(experiments)
-    reflections.compute_bbox(experiments)
+    reflections.compute_bbox(
+        experiments, sigma_b_multiplier=params.profile.sigma_b_multiplier
+    )
 
     # Check the bounding boxes are all 1 frame in width
     z0, z1 = reflections["bbox"].parts()[4:6]

--- a/newsfragments/1195.feature
+++ b/newsfragments/1195.feature
@@ -1,1 +1,1 @@
-Changed the background box size multiplier to be a parameter - setting to small values significantly reduces memory requirements.
+In dials.integrate: changed the background box size multiplier to be a parameter (sigma_b_multiplier) - setting to small values significantly reduces memory requirements.

--- a/newsfragments/1195.feature
+++ b/newsfragments/1195.feature
@@ -1,0 +1,1 @@
+Changed the background box size multiplier default from 2 x to 1 x - massively reducing memory use. 

--- a/newsfragments/1195.feature
+++ b/newsfragments/1195.feature
@@ -1,1 +1,1 @@
-Changed the background box size multiplier default from 2 x to 1 x - massively reducing memory use. 
+Changed the background box size multiplier to be a parameter - setting to small values significantly reduces memory requirements.


### PR DESCRIPTION
Default is 2.0, which makes for large bounding boxes for background calculations - leaving this in place for still data. This pull request changes the default for rotation data to 1.0, which should substantially reduce the memory footprint but may have an impact on data quality. 

N.B. there is is no equivalent for sigma_m.

Will significantly help fixing https://github.com/dials/dials/issues/659

