### PR TITLE
No trusted range for spotfinding

### DIFF
--- a/newsfragments/1156.removal
+++ b/newsfragments/1156.removal
@@ -1,0 +1,1 @@
+``dials.find_spots``: Deprecate ``spotfinder.filter.use_trusted_range=`` parameter

--- a/util/masking.py
+++ b/util/masking.py
@@ -218,7 +218,7 @@ class MaskGenerator(object):
                 warnings.warn(
                     "Checking for hot pixels using the trusted_range is"
                     " deprecated. https://github.com/dials/dials/issues/1156",
-                    DeprecationWarning,
+                    FutureWarning,
                 )
                 trusted_mask = None
                 low, high = panel.get_trusted_range()

--- a/util/masking.py
+++ b/util/masking.py
@@ -214,6 +214,9 @@ class MaskGenerator(object):
             # the trusted range. This identifies bad pixels, but does not include
             # pixels that are overloaded on some images.
             if self.params.use_trusted_range:
+                raise DeprecationWarning(
+                    "Checking for hot pixels using the trusted_range is deprecated. https://github.com/dials/dials/issues/1156"
+                )
                 trusted_mask = None
                 low, high = panel.get_trusted_range()
 

--- a/util/masking.py
+++ b/util/masking.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import math
 from collections import namedtuple
+import warnings
 
 from cctbx import crystal
 from iotbx.phil import parse
@@ -214,8 +215,10 @@ class MaskGenerator(object):
             # the trusted range. This identifies bad pixels, but does not include
             # pixels that are overloaded on some images.
             if self.params.use_trusted_range:
-                logger.warn(
-                    "Checking for hot pixels using the trusted_range is deprecated. https://github.com/dials/dials/issues/1156"
+                warnings.warn(
+                    "Checking for hot pixels using the trusted_range is"
+                    " deprecated. https://github.com/dials/dials/issues/1156",
+                    DeprecationWarning,
                 )
                 trusted_mask = None
                 low, high = panel.get_trusted_range()

--- a/util/masking.py
+++ b/util/masking.py
@@ -214,7 +214,7 @@ class MaskGenerator(object):
             # the trusted range. This identifies bad pixels, but does not include
             # pixels that are overloaded on some images.
             if self.params.use_trusted_range:
-                raise DeprecationWarning(
+                logger.warn(
                     "Checking for hot pixels using the trusted_range is deprecated. https://github.com/dials/dials/issues/1156"
                 )
                 trusted_mask = None


### PR DESCRIPTION
Is this the right way to deprecate something, just emit a `logger.warning`?