### PR TITLE
Feature for masking: mask out whole panels

### DIFF
--- a/test/command_line/test_generate_mask.py
+++ b/test/command_line/test_generate_mask.py
@@ -171,3 +171,23 @@ def test_generate_mask_trusted_range(dials_data, tmpdir):
 
     # Overloads should not be included in the mask
     assert (mask1[0] == mask2[0]).all_eq(True)
+
+
+def test_generate_whole_panel_mask(input_experiment_list, tmpdir):
+    params = phil_scope.fetch(
+        phil.parse(
+            """
+untrusted {
+  panel = 0
+}
+"""
+        )
+    ).extract()
+
+    with tmpdir.as_cwd():
+        generate_mask(input_experiment_list, params)
+
+    assert tmpdir.join("pixels.mask").check()
+    with tmpdir.join("pixels.mask").open("rb") as fh:
+        mask = pickle.load(fh)
+    assert mask[0].count(False) == len(mask[0])

--- a/util/masking.py
+++ b/util/masking.py
@@ -46,7 +46,7 @@ phil_scope = parse(
     .multiple = True
   {
 
-    panel = 0
+    panel = None
       .type = int
       .help = "The panel number"
       .help = "If no geometric attributes are given (circle, rectangle, etc)"
@@ -254,6 +254,8 @@ class MaskGenerator(object):
 
             # Apply the untrusted regions
             for region in self.params.untrusted:
+                if region.panel is None:
+                    region.panel = 0
                 if region.panel == index:
                     if not any(
                         [region.circle, region.rectangle, region.polygon, region.pixel]

--- a/util/masking.py
+++ b/util/masking.py
@@ -49,6 +49,8 @@ phil_scope = parse(
     panel = 0
       .type = int
       .help = "The panel number"
+      .help = "If no geometric attributes are given (circle, rectangle, etc)"
+      .help = "then the whole panel is masked out"
 
     circle = None
       .type = ints(3)
@@ -253,6 +255,12 @@ class MaskGenerator(object):
             # Apply the untrusted regions
             for region in self.params.untrusted:
                 if region.panel == index:
+                    if not any(
+                        [region.circle, region.rectangle, region.polygon, region.pixel]
+                    ):
+                        mask[:, :] = flex.bool(flex.grid(mask.focus()), False)
+                        continue
+
                     if region.circle is not None:
                         xc, yc, radius = region.circle
                         logger.info("Generating circle mask:")


### PR DESCRIPTION
If untrusted.panel is specified but no geometric masks are specified (like rectangle, circle, etc.), then mask out the whole panel.

Suggested by @nksauter.