### PR TITLE
DIALS 2.2.1

### DIFF
--- a/command_line/rl_csv.py
+++ b/command_line/rl_csv.py
@@ -1,7 +1,11 @@
 # LIBTBX_SET_DISPATCHER_NAME dev.dials.csv
 from __future__ import absolute_import, division, print_function
 
+import gzip
+import io
+
 import iotbx.phil
+import six
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dxtbx.model import ExperimentList
 
@@ -56,9 +60,12 @@ def run(args):
     assert len(experiments) == len(spots)
 
     if params.output.compress:
-        import gzip
-
         fout = gzip.GzipFile(params.output.csv, "w")
+        if six.PY3:
+            # GzipFile() always provides binary access only.
+            # Replace the file object with one that allows writing text:
+            fout = io.TextIOWrapper(fout)
+            # Rely on garbage collection to close the underlying GzipFile.
     else:
         fout = open(params.output.csv, "w")
 

--- a/report/test_plots.py
+++ b/report/test_plots.py
@@ -83,6 +83,7 @@ def test_IntensityStatisticsPlots(iobs):
     wilson_scaling.mean_I_obs_data = [1.0, 2.0]
     wilson_scaling.mean_I_obs_theory = [1.0, 2.0]
     wilson_scaling.mean_I_normalisation = [1.0, 2.0]
+    wilson_scaling.iso_p_scale = 1.0
     # mock the twin results
     twin_results = mock.Mock()
     twin_results.nz_test.z = [1.0, 2.0]
@@ -98,6 +99,7 @@ def test_IntensityStatisticsPlots(iobs):
     xtriage_analyses = mock.Mock()
     xtriage_analyses.wilson_scaling = wilson_scaling
     xtriage_analyses.twin_results = twin_results
+    xtriage_analyses.iso_b_wilson = 2.0
 
     plotter = IntensityStatisticsPlots(
         iobs, n_resolution_bins=n_bins, xtriage_analyses=xtriage_analyses

--- a/test/command_line/test_export.py
+++ b/test/command_line/test_export.py
@@ -123,19 +123,24 @@ def test_mtz_multi_wavelength(dials_data, run_in_tmpdir):
     assert wavelengths == [0, 0.5, 1.0]  # base, dataset1, dataset2
 
 
-def test_mmcif(dials_data, tmpdir):
+@pytest.mark.parametrize("hklout", [None, "my.cif"])
+def test_mmcif(hklout, dials_data, tmpdir):
     # Call dials.export after integration
-    result = procrunner.run(
-        [
-            "dials.export",
-            "format=mmcif",
-            dials_data("centroid_test_data").join("experiments.json").strpath,
-            dials_data("centroid_test_data").join("integrated.pickle").strpath,
-        ],
-        working_directory=tmpdir.strpath,
-    )
+
+    command = [
+        "dials.export",
+        "format=mmcif",
+        dials_data("centroid_test_data").join("experiments.json").strpath,
+        dials_data("centroid_test_data").join("integrated.pickle").strpath,
+    ]
+    if hklout is not None:
+        command.append("mmcif.hklout=%s" % hklout)
+    result = procrunner.run(command, working_directory=tmpdir.strpath)
     assert not result.returncode and not result.stderr
-    assert tmpdir.join("integrated.cif").check(file=1)
+    if hklout is not None:
+        assert tmpdir.join(hklout).check(file=1)
+    else:
+        assert tmpdir.join("integrated.cif").check(file=1)
 
     # TODO include similar test for exporting scaled data in mmcif format
 

--- a/util/export_mmcif.py
+++ b/util/export_mmcif.py
@@ -43,13 +43,15 @@ class MMCIFOutputFile(object):
             ):
                 filename = "scaled.cif"
                 logger.info(
-                    "Data appears to be scaled, setting mmcif.hklout = 'scaled_unmerged.cif'"
+                    "Data appears to be scaled, setting mmcif.hklout = 'scaled.cif'"
                 )
             else:
                 filename = "integrated.cif"
                 logger.info(
                     "Data appears to be unscaled, setting mmcif.hklout = 'integrated.cif'"
                 )
+        else:
+            filename = self.params.mmcif.hklout
 
         # Select reflections
         selection = reflections.get_flags(reflections.flags.integrated, all=True)
@@ -58,8 +60,8 @@ class MMCIFOutputFile(object):
         # Filter out bad variances and other issues, but don't filter on ice rings
         # or alter partialities.
 
-        ### Assumes you want to apply the lp and dqe corrections to sum and prf
-        ### Do we want to combine partials?
+        # Assumes you want to apply the lp and dqe corrections to sum and prf
+        # Do we want to combine partials?
         reflections = filter_reflection_table(
             reflections,
             self.params.intensity,
@@ -93,7 +95,7 @@ class MMCIFOutputFile(object):
         # FIXME finish metadata addition - detector and source details needed
         # http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Categories/index.html
 
-        ## Add source information;
+        # Add source information;
         # _diffrn_source.pdbx_wavelength_list = (list of wavelengths)
         # _diffrn_source.source = (general class of source e.g. synchrotron)
         # _diffrn_source.type = (specific beamline or instrument e.g DIAMOND BEAMLINE I04)
@@ -108,7 +110,7 @@ class MMCIFOutputFile(object):
             str(w) for w in unique_wls
         )
 
-        ## Add detector information;
+        # Add detector information;
         # _diffrn_detector.detector  = (general class e.g. PIXEL, PLATE etc)
         # _diffrn_detector.pdbx_collection_date = (Date of collection yyyy-mm-dd)
         # _diffrn_detector.type = (full name of detector e.g. DECTRIS PILATUS3 2M)

--- a/util/export_mtz.py
+++ b/util/export_mtz.py
@@ -398,9 +398,7 @@ def export_mtz(integrated_data, experiment_list, params):
             "intensity.scale.variance" in integrated_data
         ):
             params.mtz.hklout = "scaled.mtz"
-            logger.info(
-                "Data appears to be scaled, setting mtz.hklout = 'scaled_unmerged.mtz'"
-            )
+            logger.info("Data appears to be scaled, setting mtz.hklout = 'scaled.mtz'")
         else:
             params.mtz.hklout = "integrated.mtz"
             logger.info(


### PR DESCRIPTION
* `dials.export`: fix crash when using `mmcif.hklout=` parameter (#1204)
* `dials.report`: fix high resolution end of French-Wilson plot (#1169, #1194)
* `xia2.compare_merging_stats`: new parameters `d_min`, `d_max`, and `small_multiples`. The latter plots each dataset on an individual subplot for clarity.
* Fixed a crash in `xia2.to_shelxcde`
* Fix issues with multitile `.cbf`s
* Fix 'invalid load key' issue (cctbx/dxtbx#154)