### PR TITLE
Rationalise dials.index handling of symmetry

### DIFF
--- a/algorithms/indexing/basis_vector_search/test_combinations.py
+++ b/algorithms/indexing/basis_vector_search/test_combinations.py
@@ -44,7 +44,7 @@ def test_combinations(setup_rlp):
         )
         filtered_crystal_models = list(filtered_crystal_models)
 
-        assert len(filtered_crystal_models)
+        assert filtered_crystal_models
         for model in filtered_crystal_models:
             best_subgroup = find_matching_symmetry(
                 model.get_unit_cell(), target_symmetry.space_group()

--- a/algorithms/indexing/basis_vector_search/test_combinations.py
+++ b/algorithms/indexing/basis_vector_search/test_combinations.py
@@ -6,6 +6,7 @@ from cctbx import sgtbx
 import scitbx.matrix
 from scitbx.math import euler_angles_as_matrix
 from dxtbx.model import Crystal
+from dials.algorithms.indexing.symmetry import find_matching_symmetry
 
 from . import combinations, FFT1D
 
@@ -15,20 +16,29 @@ def test_combinations(setup_rlp):
     strategy = FFT1D(max_cell)
     basis_vectors, used = strategy.find_basis_vectors(setup_rlp["rlp"])
 
+    target_symmetry_primitive = (
+        setup_rlp["crystal_symmetry"]
+        .primitive_setting()
+        .customized_copy(space_group_info=sgtbx.space_group().info())
+    )
+    target_symmetry_sg_only = (
+        setup_rlp["crystal_symmetry"]
+        .primitive_setting()
+        .customized_copy(unit_cell=None)
+    )
+    target_symmetry_ref = setup_rlp["crystal_symmetry"].as_reference_setting()
+
     for target_symmetry in (
         setup_rlp["crystal_symmetry"],
-        setup_rlp["crystal_symmetry"]
-        .primitive_setting()
-        .customized_copy(space_group_info=sgtbx.space_group().info()),
-        setup_rlp["crystal_symmetry"]
-        .primitive_setting()
-        .customized_copy(unit_cell=None),
-        setup_rlp["crystal_symmetry"].as_reference_setting(),
+        target_symmetry_primitive,
+        target_symmetry_sg_only,
+        target_symmetry_ref,
     ):
 
         crystal_models = combinations.candidate_orientation_matrices(
             basis_vectors, max_combinations=50
         )
+        crystal_models = list(crystal_models)
         filtered_crystal_models = combinations.filter_known_symmetry(
             crystal_models, target_symmetry=target_symmetry
         )
@@ -36,13 +46,25 @@ def test_combinations(setup_rlp):
 
         assert len(filtered_crystal_models)
         for model in filtered_crystal_models:
+            best_subgroup = find_matching_symmetry(
+                model.get_unit_cell(), target_symmetry.space_group()
+            )
             if target_symmetry.unit_cell() is not None:
-                assert model.get_unit_cell().minimum_cell().is_similar_to(
-                    target_symmetry.minimum_cell().unit_cell(),
+                assert best_subgroup["best_subsym"].unit_cell().is_similar_to(
+                    setup_rlp["crystal_symmetry"]
+                    .as_reference_setting()
+                    .best_cell()
+                    .unit_cell(),
                     relative_length_tolerance=0.1,
                     absolute_angle_tolerance=5,
-                ) or model.get_unit_cell().is_similar_to(
-                    target_symmetry.unit_cell(),
+                ) or best_subgroup[
+                    "best_subsym"
+                ].minimum_cell().unit_cell().is_similar_to(
+                    setup_rlp["crystal_symmetry"]
+                    .as_reference_setting()
+                    .best_cell()
+                    .minimum_cell()
+                    .unit_cell(),
                     relative_length_tolerance=0.1,
                     absolute_angle_tolerance=5,
                 )

--- a/algorithms/indexing/lattice_search/__init__.py
+++ b/algorithms/indexing/lattice_search/__init__.py
@@ -252,17 +252,12 @@ class LatticeSearch(indexer.Indexer):
                     continue
 
             if self.params.known_symmetry.space_group is not None:
-                new_crystal, cb_op_to_primitive = self._symmetry_handler.apply_symmetry(
+                new_crystal, _ = self._symmetry_handler.apply_symmetry(
                     experiments[0].crystal
                 )
                 if new_crystal is None:
                     continue
                 experiments[0].crystal.update(new_crystal)
-                if not cb_op_to_primitive.is_identity_op():
-                    sel = refl["id"] > -1
-                    miller_indices = refl["miller_index"].select(sel)
-                    miller_indices = cb_op_to_primitive.apply(miller_indices)
-                    refl["miller_index"].set_selected(sel, miller_indices)
 
             args.append((experiments, refl))
             if len(args) == self.params.basis_vector_combinations.max_refine:

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -488,28 +488,15 @@ class StillsIndexer(Indexer):
                 self.params.stills.refine_candidates_with_known_symmetry
                 and self.params.known_symmetry.space_group is not None
             ):
-                new_crystal, cb_op_to_primitive = self._symmetry_handler.apply_symmetry(
-                    cm
-                )
+                new_crystal, cb_op = self._symmetry_handler.apply_symmetry(cm)
                 if new_crystal is None:
                     logger.info("Cannot convert to target symmetry, candidate %d", icm)
                     continue
-                new_crystal = new_crystal.change_basis(
-                    self._symmetry_handler.cb_op_primitive_inp
-                )
-                cm = new_crystal
+                cm = new_crystal.change_basis(cb_op)
                 experiments = self.experiment_list_for_crystal(cm)
 
-                if not cb_op_to_primitive.is_identity_op():
-                    indexed["miller_index"] = cb_op_to_primitive.apply(
-                        indexed["miller_index"]
-                    )
-                if self._symmetry_handler.cb_op_primitive_inp is not None:
-                    indexed[
-                        "miller_index"
-                    ] = self._symmetry_handler.cb_op_primitive_inp.apply(
-                        indexed["miller_index"]
-                    )
+                if not cb_op.is_identity_op():
+                    indexed["miller_index"] = cb_op.apply(indexed["miller_index"])
 
             if params.indexing.stills.refine_all_candidates:
                 try:

--- a/algorithms/indexing/symmetry.py
+++ b/algorithms/indexing/symmetry.py
@@ -143,7 +143,9 @@ class SymmetryHandler(object):
 
         if unit_cell is not None:
 
-            assert space_group, "space_group must be provided in combination with unit_cell"
+            assert (
+                space_group
+            ), "space_group must be provided in combination with unit_cell"
 
             if target_space_group:
                 self.target_symmetry_inp = crystal.symmetry(
@@ -172,7 +174,7 @@ class SymmetryHandler(object):
         cb_op_reference_to_primitive = (
             self.target_symmetry_reference_setting.change_of_basis_op_to_primitive_setting()
         )
-        if unit_cell is not None:
+        if unit_cell:
             self.target_symmetry_primitive = self.target_symmetry_reference_setting.change_basis(
                 cb_op_reference_to_primitive
             )

--- a/algorithms/indexing/symmetry.py
+++ b/algorithms/indexing/symmetry.py
@@ -145,7 +145,7 @@ class SymmetryHandler(object):
 
             assert space_group, "space_group must be provided in combination with unit_cell"
 
-            if unit_cell is not None and target_space_group is not None:
+            if target_space_group:
                 self.target_symmetry_inp = crystal.symmetry(
                     unit_cell=unit_cell, space_group=target_space_group
                 )

--- a/algorithms/indexing/symmetry.py
+++ b/algorithms/indexing/symmetry.py
@@ -143,9 +143,7 @@ class SymmetryHandler(object):
 
         if unit_cell is not None:
 
-            assert (
-                space_group is not None
-            ), "space_group must be provided in combination with unit_cell"
+            assert space_group, "space_group must be provided in combination with unit_cell"
 
             if unit_cell is not None and target_space_group is not None:
                 self.target_symmetry_inp = crystal.symmetry(

--- a/algorithms/indexing/symmetry.py
+++ b/algorithms/indexing/symmetry.py
@@ -5,14 +5,13 @@ import logging
 import scitbx.matrix
 from cctbx import crystal, sgtbx
 from cctbx.crystal_orientation import crystal_orientation
-from cctbx.sgtbx import change_of_basis_op, lattice_symmetry, subgroups
+from cctbx.sgtbx import change_of_basis_op, subgroups
 from cctbx.sgtbx.bravais_types import bravais_lattice
 from rstbx.dps_core.lepage import iotbx_converter
 from scitbx.array_family import flex
 
 from dxtbx.model import Crystal
 
-from dials.algorithms.indexing import DialsIndexError
 
 logger = logging.getLogger(__name__)
 
@@ -136,126 +135,87 @@ class SymmetryHandler(object):
         self.target_symmetry_primitive = None
         self.target_symmetry_reference_setting = None
         self.cb_op_inp_ref = None
+        self.cb_op_inp_best = None
 
-        target_unit_cell = unit_cell
         target_space_group = space_group
         if target_space_group is not None:
             target_space_group = target_space_group.build_derived_patterson_group()
 
-        if target_unit_cell is not None or target_space_group is not None:
+        if unit_cell is not None:
 
-            if target_unit_cell is not None and target_space_group is not None:
-                self._setup_target_unit_cell_and_space_group(
-                    target_unit_cell, target_space_group
+            assert (
+                space_group is not None
+            ), "space_group must be provided in combination with unit_cell"
+
+            if unit_cell is not None and target_space_group is not None:
+                self.target_symmetry_inp = crystal.symmetry(
+                    unit_cell=unit_cell, space_group=target_space_group
                 )
-
-            elif target_unit_cell is not None:
-                self.target_symmetry_reference_setting = crystal.symmetry(
-                    unit_cell=target_unit_cell, space_group=sgtbx.space_group()
-                )
-                self.cb_op_inp_ref = sgtbx.change_of_basis_op()
-
-            elif target_space_group is not None:
                 self.cb_op_inp_ref = (
-                    target_space_group.info().change_of_basis_op_to_reference_setting()
+                    self.target_symmetry_inp.change_of_basis_op_to_reference_setting()
                 )
-                self.target_symmetry_reference_setting = crystal.symmetry(
-                    space_group=target_space_group.change_basis(self.cb_op_inp_ref)
+                self.target_symmetry_reference_setting = self.target_symmetry_inp.change_basis(
+                    self.cb_op_inp_ref
+                )
+                self.cb_op_inp_best = (
+                    self.target_symmetry_reference_setting.change_of_basis_op_to_best_cell()
+                    * self.cb_op_inp_ref
                 )
 
-            self.cb_op_reference_to_primitive = (
-                self.target_symmetry_reference_setting.change_of_basis_op_to_primitive_setting()
+        elif target_space_group is not None:
+            self.target_symmetry_inp = crystal.symmetry(space_group=target_space_group)
+            self.cb_op_inp_ref = (
+                target_space_group.info().change_of_basis_op_to_reference_setting()
             )
-            if target_unit_cell is not None:
-                self.target_symmetry_primitive = self.target_symmetry_reference_setting.change_basis(
-                    self.cb_op_reference_to_primitive
-                )
-            else:
-                self.target_symmetry_primitive = crystal.symmetry(
-                    space_group=self.target_symmetry_reference_setting.space_group().change_basis(
-                        self.cb_op_reference_to_primitive
-                    )
-                )
-            self.cb_op_ref_inp = self.cb_op_inp_ref.inverse()
-            self.cb_op_primitive_inp = (
-                self.cb_op_ref_inp * self.cb_op_reference_to_primitive.inverse()
+            self.target_symmetry_reference_setting = crystal.symmetry(
+                space_group=target_space_group.change_basis(self.cb_op_inp_ref)
             )
 
-            if self.target_symmetry_reference_setting:
-                logger.debug(
-                    "Target symmetry (reference setting):\n%s",
-                    self.target_symmetry_reference_setting,
+        cb_op_reference_to_primitive = (
+            self.target_symmetry_reference_setting.change_of_basis_op_to_primitive_setting()
+        )
+        if unit_cell is not None:
+            self.target_symmetry_primitive = self.target_symmetry_reference_setting.change_basis(
+                cb_op_reference_to_primitive
+            )
+        else:
+            self.target_symmetry_primitive = crystal.symmetry(
+                space_group=self.target_symmetry_reference_setting.space_group().change_basis(
+                    cb_op_reference_to_primitive
                 )
-            if self.target_symmetry_primitive:
-                logger.debug(
-                    "Target symmetry (primitive cell):\n%s",
-                    self.target_symmetry_primitive,
-                )
+            )
+        self.cb_op_ref_inp = self.cb_op_inp_ref.inverse()
+        self.cb_op_primitive_inp = (
+            self.cb_op_ref_inp * cb_op_reference_to_primitive.inverse()
+        )
+
+        if self.target_symmetry_reference_setting:
             logger.debug(
-                "cb_op reference->primitive: %s", self.cb_op_reference_to_primitive
+                "Target symmetry (reference setting):\n%s",
+                self.target_symmetry_reference_setting,
             )
-            logger.debug("cb_op primitive->input: %s", self.cb_op_primitive_inp)
-
-    def _setup_target_unit_cell_and_space_group(
-        self, target_unit_cell, target_space_group
-    ):
-
-        target_bravais_t = bravais_lattice(
-            group=target_space_group.info().reference_setting().group()
-        )
-        best_subgroup = None
-        best_angular_difference = 1e8
-
-        space_groups = [target_space_group]
-        if target_space_group.conventional_centring_type_symbol() != "P":
-            space_groups.append(sgtbx.space_group())
-        for target in space_groups:
-            cs = crystal.symmetry(
-                unit_cell=target_unit_cell,
-                space_group=target,
-                assert_is_compatible_unit_cell=False,
+        if self.target_symmetry_primitive:
+            logger.debug(
+                "Target symmetry (primitive cell):\n%s", self.target_symmetry_primitive,
             )
-            target_best_cell = cs.best_cell().unit_cell()
-            subgroups = lattice_symmetry.metric_subgroups(cs, max_delta=0.1)
-            for subgroup in subgroups.result_groups:
-                bravais_t = bravais_lattice(group=subgroup["ref_subsym"].space_group())
-                if bravais_t == target_bravais_t:
-                    # allow for the cell to be given as best cell, reference setting
-                    # primitive settings, or minimum cell
-                    best_subsym = subgroup["best_subsym"]
-                    ref_subsym = best_subsym.as_reference_setting()
-                    if not (
-                        best_subsym.unit_cell().is_similar_to(target_unit_cell)
-                        or ref_subsym.unit_cell().is_similar_to(target_unit_cell)
-                        or ref_subsym.primitive_setting()
-                        .unit_cell()
-                        .is_similar_to(target_unit_cell)
-                        or best_subsym.primitive_setting()
-                        .unit_cell()
-                        .is_similar_to(target_unit_cell)
-                        or best_subsym.minimum_cell()
-                        .unit_cell()
-                        .is_similar_to(target_unit_cell.minimum_cell())
-                        or best_subsym.unit_cell().is_similar_to(target_best_cell)
-                    ):
-                        continue
-                    if subgroup["max_angular_difference"] < best_angular_difference:
-                        best_subgroup = subgroup
-                        best_angular_difference = subgroup["max_angular_difference"]
-
-        if best_subgroup is None:
-            raise DialsIndexError("Unit cell incompatible with space group")
-
-        cb_op_inp_best = best_subgroup["cb_op_inp_best"]
-        best_subsym = best_subgroup["best_subsym"]
-        cb_op_best_ref = best_subsym.change_of_basis_op_to_reference_setting()
-        self.cb_op_inp_ref = cb_op_best_ref * cb_op_inp_best
-        self.target_symmetry_reference_setting = crystal.symmetry(
-            unit_cell=target_unit_cell.change_basis(self.cb_op_inp_ref),
-            space_group=target_space_group.info().as_reference_setting().group(),
-        )
+        logger.debug("cb_op primitive->input: %s", self.cb_op_primitive_inp)
 
     def apply_symmetry(self, crystal_model):
+        """Apply symmetry constraints to a crystal model.
+
+        Returns the crystal model (with symmetry constraints applied) in the same
+        setting as provided as input. The cb_op returned by the method is
+        that necessary to transform that model to the user-provided
+        target symmetry.
+
+        Args:
+            crystal_model (dxtbx.model.Crystal): The input crystal model to which to
+              apply symmetry constraints.
+
+        Returns: (dxtbx.model.Crystal, cctbx.sgtbx.change_of_basis_op):
+        The crystal model with symmetry constraints applied, and the change_of_basis_op
+        that transforms the returned model to the user-specified target symmetry.
+        """
         if not (
             self.target_symmetry_primitive
             and self.target_symmetry_primitive.space_group()
@@ -270,11 +230,9 @@ class SymmetryHandler(object):
         items = iotbx_converter(crystal_model.get_unit_cell(), max_delta=max_delta)
         target_sg_ref = target_space_group.info().reference_setting().group()
         best_angular_difference = 1e8
-        best_subgroup = None
+
         for item in items:
-            if bravais_lattice(group=target_sg_ref) != bravais_lattice(
-                group=item["ref_subsym"].space_group()
-            ):
+            if bravais_lattice(group=target_sg_ref) != item["bravais"]:
                 continue
             if item["max_angular_difference"] < best_angular_difference:
                 best_angular_difference = item["max_angular_difference"]
@@ -284,27 +242,37 @@ class SymmetryHandler(object):
             return None, None
 
         cb_op_inp_best = best_subgroup["cb_op_inp_best"]
-        orient = crystal_orientation(A, True)
-        orient_best = orient.change_basis(
-            scitbx.matrix.sqr(cb_op_inp_best.c().as_double_array()[0:9]).transpose()
-        )
-        constrain_orient = orient_best.constrain(best_subgroup["system"])
-
         best_subsym = best_subgroup["best_subsym"]
-        cb_op_best_ref = best_subsym.change_of_basis_op_to_reference_setting()
-        target_sg_best = target_sg_ref.change_basis(cb_op_best_ref.inverse())
-        ref_subsym = best_subsym.change_basis(cb_op_best_ref)
-        cb_op_ref_primitive = ref_subsym.change_of_basis_op_to_primitive_setting()
-        cb_op_best_primitive = cb_op_ref_primitive * cb_op_best_ref
-        cb_op_inp_primitive = cb_op_ref_primitive * cb_op_best_ref * cb_op_inp_best
+        ref_subsym = best_subgroup["ref_subsym"]
+        cb_op_ref_best = ref_subsym.change_of_basis_op_to_best_cell()
+        cb_op_best_ref = cb_op_ref_best.inverse()
+        cb_op_inp_ref = cb_op_best_ref * cb_op_inp_best
+        cb_op_ref_inp = cb_op_inp_ref.inverse()
 
+        orient = crystal_orientation(A, True)
+        orient_ref = orient.change_basis(
+            scitbx.matrix.sqr((cb_op_inp_ref).c().as_double_array()[0:9]).transpose()
+        )
+        constrain_orient = orient_ref.constrain(best_subgroup["system"])
         direct_matrix = constrain_orient.direct_matrix()
 
         a = scitbx.matrix.col(direct_matrix[:3])
         b = scitbx.matrix.col(direct_matrix[3:6])
         c = scitbx.matrix.col(direct_matrix[6:9])
-        model = Crystal(a, b, c, space_group=target_sg_best)
-        assert target_sg_best.is_compatible_unit_cell(model.get_unit_cell())
+        model = Crystal(a, b, c, space_group=target_sg_ref)
+        assert target_sg_ref.is_compatible_unit_cell(model.get_unit_cell())
 
-        model = model.change_basis(cb_op_best_primitive)
-        return model, cb_op_inp_primitive
+        model = model.change_basis(cb_op_ref_inp)
+
+        if self.cb_op_inp_best is not None:
+            # Then the unit cell has been provided: this is the cb_op to map to the
+            # user-provided input unit cell
+            return model, self.cb_op_inp_best.inverse() * cb_op_inp_best
+        if not self.cb_op_ref_inp.is_identity_op():
+            if self.target_symmetry_inp.space_group() == best_subsym.space_group():
+                # Handle where e.g. the user has requested I2 instead of the reference C2
+                return model, cb_op_inp_best
+            # The user has specified a setting that is not the reference setting
+            return model, self.cb_op_ref_inp * cb_op_inp_ref
+        # Default to reference setting
+        return model, cb_op_inp_ref

--- a/algorithms/indexing/test_symmetry.py
+++ b/algorithms/indexing/test_symmetry.py
@@ -19,15 +19,9 @@ def test_SymmetryHandler(space_group_symbol):
 
     handler = symmetry.SymmetryHandler(unit_cell=uc, space_group=sg)
 
-    assert handler.target_symmetry_primitive.unit_cell().parameters() == pytest.approx(
-        cs.best_cell().primitive_setting().unit_cell().parameters()
-    )
     assert (
         handler.target_symmetry_primitive.space_group()
         == sg.build_derived_patterson_group().info().primitive_setting().group()
-    )
-    assert handler.target_symmetry_reference_setting.unit_cell().parameters() == pytest.approx(
-        cs.best_cell().as_reference_setting().unit_cell().parameters()
     )
     assert (
         handler.target_symmetry_reference_setting.space_group()
@@ -73,17 +67,57 @@ def test_SymmetryHandler(space_group_symbol):
     crystal_new, cb_op = handler.apply_symmetry(crystal)
     crystal_new.get_crystal_symmetry(assert_is_compatible_unit_cell=True)
 
-    handler = symmetry.SymmetryHandler(unit_cell=cs.minimum_cell().unit_cell())
+    handler = symmetry.SymmetryHandler(
+        unit_cell=cs.minimum_cell().unit_cell(), space_group=sgtbx.space_group(),
+    )
     assert handler.target_symmetry_primitive.unit_cell().parameters() == pytest.approx(
         cs.minimum_cell().unit_cell().parameters()
     )
-    assert handler.target_symmetry_primitive.space_group() == sgtbx.space_group()
+    assert handler.target_symmetry_primitive.space_group() == sgtbx.space_group("P-1")
     assert handler.target_symmetry_reference_setting.unit_cell().parameters() == pytest.approx(
         cs.minimum_cell().unit_cell().parameters()
     )
-    assert (
-        handler.target_symmetry_reference_setting.space_group() == sgtbx.space_group()
+    assert handler.target_symmetry_reference_setting.space_group() == sgtbx.space_group(
+        "P-1"
     )
+
+
+# https://github.com/dials/dials/issues/1217
+def test_symmetry_handler_c2_i2():
+    cs = crystal.symmetry(
+        unit_cell=(44.66208171, 53.12629403, 62.53397661, 64.86329707, 78.27343894, 90),
+        space_group_symbol="C 1 2/m 1 (z,x+y,-2*x)",
+    )
+    cs_ref = cs.as_reference_setting()
+    cs_best = cs_ref.best_cell()
+    # best -> ref is different to cs_ref above
+    cs_best_ref = cs_best.as_reference_setting()
+    assert not cs_ref.is_similar_symmetry(cs_best_ref)
+
+    B = scitbx.matrix.sqr(cs.unit_cell().fractionalization_matrix()).transpose()
+    cryst = Crystal(B, sgtbx.space_group())
+
+    for cs_ in (cs, cs_ref, cs_best):
+        print(cs_)
+        handler = symmetry.SymmetryHandler(space_group=cs_.space_group())
+        new_cryst, cb_op = handler.apply_symmetry(cryst)
+        assert (
+            new_cryst.change_basis(cb_op)
+            .get_crystal_symmetry()
+            .is_similar_symmetry(cs_)
+        )
+
+    for cs_ in (cs, cs_ref, cs_best, cs_best_ref):
+        print(cs_)
+        handler = symmetry.SymmetryHandler(
+            unit_cell=cs_.unit_cell(), space_group=cs_.space_group()
+        )
+        new_cryst, cb_op = handler.apply_symmetry(cryst)
+        assert (
+            new_cryst.change_basis(cb_op)
+            .get_crystal_symmetry()
+            .is_similar_symmetry(cs_)
+        )
 
 
 crystal_symmetries = []

--- a/newsfragments/1217.bugfix
+++ b/newsfragments/1217.bugfix
@@ -1,0 +1,1 @@
+Ensure dials.index chooses the C2 setting with the smallest beta angle


### PR DESCRIPTION
filter_known_symmetry now only filters: don't modify crystal models, but simply filter the list for those crystal models which match the input symmetry.

`SymmetryHandler.apply_symmetry` now returns the model in the same
setting as provided as input. The cb_op returned by the method is
that necessary to transform that model to the user-provided
target symmetry.

Handle the following cases:
- user specifies reference setting space group (e.g. C2)
- user specifies space group corresponding to "best" cell (e.g. I2)
- user specifies space group in specific setting (e.g. primitive C2 setting)
- user specifies alternative reference setting (e.g. alternative C2 setting)

No longer support user specifying unit_cell only. If you know the unit_cell,
then you almost certainly know the space_group.

Fixes #1217