### PR TITLE
Add best_monoclinic_beta=True to dials.refine_bravais_settings and dials.symmetry

### DIFF
--- a/algorithms/indexing/bravais_settings.py
+++ b/algorithms/indexing/bravais_settings.py
@@ -7,7 +7,7 @@ import math
 
 import libtbx
 import libtbx.phil
-from cctbx import crystal, miller
+from cctbx import crystal, miller, sgtbx
 from cctbx.crystal_orientation import crystal_orientation
 from cctbx.sgtbx import bravais_types
 from libtbx.introspection import number_of_processors
@@ -227,9 +227,11 @@ def refined_settings_from_refined_triclinic(experiments, reflections, params):
         refined_settings[j].setting_number = Nset - j
 
     for subgroup in refined_settings:
-        space_group = (
-            subgroup["best_subsym"].space_group().build_derived_acentric_group()
-        )
+        space_group = sgtbx.space_group_info(
+            number=bravais_lattice_to_lowest_symmetry_spacegroup_number[
+                subgroup["bravais"]
+            ]
+        ).group()
         orient = crystal_orientation(crystal.get_A(), True).change_basis(
             scitbx.matrix.sqr(
                 subgroup["cb_op_inp_best"].c().as_double_array()[0:9]

--- a/algorithms/indexing/bravais_settings.py
+++ b/algorithms/indexing/bravais_settings.py
@@ -37,6 +37,12 @@ nproc = Auto
 cc_n_bins = None
   .type = int(value_min=1)
   .help = "Number of resolution bins to use for calculation of correlation coefficients"
+setting = reference *best
+  .type = choice
+  .help = "This affects the chosen Laue group setting for centered monoclinic lattices."
+          "'reference' will always choose the C-centered setting, whereas 'best' may"
+          "choose the I-centered setting if it leads to a less oblique cell than the"
+          "C-centred setting."
 
 include scope dials.algorithms.refinement.refiner.phil_scope
 """,
@@ -219,24 +225,29 @@ def refined_settings_from_refined_triclinic(experiments, reflections, params):
     for j in range(Nset):
         refined_settings[j].setting_number = Nset - j
 
-    for j in range(Nset):
-        cb_op = refined_settings[j]["cb_op_inp_best"].c().as_double_array()[0:9]
-        orient = crystal_orientation(crystal.get_A(), True)
-        orient_best = orient.change_basis(scitbx.matrix.sqr(cb_op).transpose())
-        constrain_orient = orient_best.constrain(refined_settings[j]["system"])
-        bravais = refined_settings[j]["bravais"]
-        cb_op_best_ref = refined_settings[j][
-            "best_subsym"
-        ].change_of_basis_op_to_reference_setting()
+    for subgroup in refined_settings:
+        bravais = subgroup["bravais"]
         space_group = sgtbx.space_group_info(
             number=bravais_lattice_to_lowest_symmetry_spacegroup_number[bravais]
         ).group()
-        space_group = space_group.change_basis(cb_op_best_ref.inverse())
-        bravais = str(bravais_types.bravais_lattice(group=space_group))
-        refined_settings[j]["bravais"] = bravais
-        refined_settings[j].unrefined_crystal = dxtbx_crystal_from_orientation(
+        cb_op_inp_best = subgroup["cb_op_inp_best"]
+        cb_op_ref_best = subgroup["ref_subsym"].change_of_basis_op_to_best_cell()
+        cb_op_best_ref = cb_op_ref_best.inverse()
+        cb_op_inp_ref = cb_op_ref_best.inverse() * cb_op_inp_best
+        if params.setting == "reference":
+            cb_op = cb_op_inp_ref
+        else:
+            cb_op = cb_op_inp_best
+            space_group = space_group.change_basis(cb_op_best_ref.inverse())
+        orient = crystal_orientation(crystal.get_A(), True).change_basis(
+            scitbx.matrix.sqr(cb_op.c().as_double_array()[0:9]).transpose()
+        )
+        constrain_orient = orient.constrain(subgroup["system"])
+        subgroup["bravais"] = str(bravais_types.bravais_lattice(group=space_group))
+        subgroup.unrefined_crystal = dxtbx_crystal_from_orientation(
             constrain_orient, space_group
         )
+        subgroup.cb_op = cb_op
 
     with concurrent.futures.ProcessPoolExecutor(max_workers=params.nproc) as pool:
         for i, result in enumerate(
@@ -291,7 +302,7 @@ def refine_subgroup(args):
 
     used_reflections = copy.deepcopy(used_reflections)
     triclinic_miller = used_reflections["miller_index"]
-    cb_op = subgroup["cb_op_inp_best"]
+    cb_op = subgroup.cb_op
     higher_symmetry_miller = cb_op.apply(triclinic_miller)
     used_reflections["miller_index"] = higher_symmetry_miller
     unrefined_crystal = copy.deepcopy(subgroup.unrefined_crystal)

--- a/algorithms/indexing/bravais_settings.py
+++ b/algorithms/indexing/bravais_settings.py
@@ -108,7 +108,7 @@ class RefinedSettingsList(list):
                 "nspots": item.Nmatches,
                 "bravais": item["bravais"],
                 "unit_cell": uc.parameters(),
-                "cb_op": item["cb_op_inp_best"].as_abc(),
+                "cb_op": item.cb_op.as_abc(),
                 "max_cc": item.max_cc,
                 "min_cc": item.min_cc,
                 "correlation_coefficients": list(item.correlation_coefficients),
@@ -118,7 +118,7 @@ class RefinedSettingsList(list):
 
         return result
 
-    def as_str(self):
+    def __str__(self):
         table_data = [
             [
                 "Solution",
@@ -152,7 +152,7 @@ class RefinedSettingsList(list):
                     "%(bravais)s" % item,
                     "%6.2f %6.2f %6.2f %6.2f %6.2f %6.2f" % P,
                     "%.0f" % uc.volume(),
-                    "%s" % item["cb_op_inp_best"].as_abc(),
+                    "%s" % item.cb_op.as_abc(),
                 ]
             )
 

--- a/algorithms/symmetry/__init__.py
+++ b/algorithms/symmetry/__init__.py
@@ -37,6 +37,7 @@ class symmetry_base(object):
         min_cc_half=0.6,
         relative_length_tolerance=None,
         absolute_angle_tolerance=None,
+        best_monoclinic_beta=True,
     ):
         u"""Initialise a symmetry_base object.
 
@@ -60,6 +61,9 @@ class symmetry_base(object):
             consistency of input unit cells against the median unit cell.
           absolute_angle_tolerance (float): Absolute angle tolerance in checking
             consistency of input unit cells against the median unit cell.
+          best_monoclinic_beta (bool): If True, then for monoclinic centered cells, I2
+            will be preferred over C2 if it gives a more oblique cell (i.e. smaller
+            beta angle).
         """
         self.input_intensities = intensities
 
@@ -94,6 +98,7 @@ class symmetry_base(object):
             self.intensities.crystal_symmetry(),
             max_delta=self.lattice_symmetry_max_delta,
             bravais_types_only=False,
+            best_monoclinic_beta=best_monoclinic_beta,
         )
 
         self.cb_op_inp_min = self.subgroups.cb_op_inp_minimum

--- a/algorithms/symmetry/laue_group.py
+++ b/algorithms/symmetry/laue_group.py
@@ -36,6 +36,7 @@ class LaueGroupAnalysis(symmetry_base):
         min_cc_half=0.6,
         relative_length_tolerance=None,
         absolute_angle_tolerance=None,
+        best_monoclinic_beta=True,
     ):
         """Intialise a LaueGroupAnalysis object.
 
@@ -59,6 +60,9 @@ class LaueGroupAnalysis(symmetry_base):
             consistency of input unit cells against the median unit cell.
           absolute_angle_tolerance (float): Absolute angle tolerance in checking
             consistency of input unit cells against the median unit cell.
+          best_monoclinic_beta (bool): If True, then for monoclinic centered cells, I2
+            will be preferred over C2 if it gives a more oblique cell (i.e. smaller
+            beta angle).
         """
         super(LaueGroupAnalysis, self).__init__(
             intensities,
@@ -69,6 +73,7 @@ class LaueGroupAnalysis(symmetry_base):
             min_cc_half=min_cc_half,
             relative_length_tolerance=relative_length_tolerance,
             absolute_angle_tolerance=absolute_angle_tolerance,
+            best_monoclinic_beta=best_monoclinic_beta,
         )
 
         self._estimate_cc_sig_fac()

--- a/algorithms/symmetry/laue_group.py
+++ b/algorithms/symmetry/laue_group.py
@@ -376,10 +376,6 @@ class LaueGroupAnalysis(symmetry_base):
                 "unit_cell": self.median_unit_cell.parameters(),
             },
             "cb_op_inp_min": self.cb_op_inp_min.as_xyz(),
-            "min_cell_symmetry": {
-                "hall_symbol": self.intensities.space_group().type().hall_symbol(),
-                "unit_cell": self.intensities.unit_cell().parameters(),
-            },
             "lattice_point_group": self.lattice_group.type().hall_symbol(),
             "cc_unrelated_pairs": self.corr_unrelated.coefficient(),
             "n_unrelated_pairs": self.corr_unrelated.n(),

--- a/algorithms/symmetry/test_laue_group.py
+++ b/algorithms/symmetry/test_laue_group.py
@@ -2,22 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from cctbx import miller
-from cctbx import sgtbx
+from cctbx import crystal, miller, sgtbx
 from dials.algorithms.symmetry.cosym._generate_test_data import generate_intensities
 from dials.algorithms.symmetry.laue_group import LaueGroupAnalysis
 
 
-@pytest.mark.parametrize("space_group", ["P2", "P3", "P6", "R3:h", "I23"][:])
-def test_determine_space_group(space_group):
-
-    sgi = sgtbx.space_group_info(symbol=space_group)
-    sg = sgi.group()
-    cs = sgi.any_compatible_crystal_symmetry(volume=10000)
-    cs = cs.best_cell()
-    cs = cs.minimum_cell()
+def generate_fake_intensities(crystal_symmetry):
     intensities = (
-        generate_intensities(cs, d_min=1.0)
+        generate_intensities(crystal_symmetry, d_min=1.0)
         .generate_bijvoet_mates()
         .set_observation_type_xray_intensity()
     )
@@ -25,6 +17,18 @@ def test_determine_space_group(space_group):
     # needed to give vaguely sensible E_cc_true values
     intensities = intensities.customized_copy(sigmas=intensities.data() / 50)
     intensities.set_info(miller.array_info(source="fake", source_type="mtz"))
+    return intensities
+
+
+@pytest.mark.parametrize("space_group", ["P2", "P3", "P6", "R3:h", "I23"][:])
+def test_determine_space_group(space_group):
+    sgi = sgtbx.space_group_info(symbol=space_group)
+    sg = sgi.group()
+    cs = sgi.any_compatible_crystal_symmetry(volume=10000)
+    cs = cs.best_cell()
+    cs = cs.minimum_cell()
+
+    intensities = generate_fake_intensities(cs)
     result = LaueGroupAnalysis([intensities], normalisation=None)
     print(result)
     assert (
@@ -34,3 +38,29 @@ def test_determine_space_group(space_group):
     assert result.best_solution.likelihood > 0.8
     for score in result.subgroup_scores[1:]:
         assert score.likelihood < 0.1
+
+
+def test_determine_space_group_best_monoclinic_beta():
+    cs = crystal.symmetry(
+        unit_cell=(44.66208171, 53.12629403, 62.53397661, 64.86329707, 78.27343894, 90),
+        space_group_symbol="C 1 2/m 1 (z,x+y,-2*x)",
+    )
+    intensities = generate_fake_intensities(cs)
+    result = LaueGroupAnalysis([intensities], normalisation=None)
+    print(result)
+    assert result.best_solution.subgroup["best_subsym"].is_similar_symmetry(
+        crystal.symmetry(
+            unit_cell=(44.66208171, 53.12629403, 111.9989451, 90, 99.89337396, 90),
+            space_group_symbol="I 1 2/m 1",
+        )
+    )
+    result = LaueGroupAnalysis(
+        [intensities], best_monoclinic_beta=False, normalisation=None
+    )
+    print(result)
+    assert result.best_solution.subgroup["best_subsym"].is_similar_symmetry(
+        crystal.symmetry(
+            unit_cell=(113.2236274, 53.12629403, 44.66208171, 90, 102.9736126, 90),
+            space_group_symbol="C 1 2/m 1",
+        )
+    )

--- a/algorithms/symmetry/test_laue_group.py
+++ b/algorithms/symmetry/test_laue_group.py
@@ -45,6 +45,7 @@ def test_determine_space_group_best_monoclinic_beta():
         unit_cell=(44.66208171, 53.12629403, 62.53397661, 64.86329707, 78.27343894, 90),
         space_group_symbol="C 1 2/m 1 (z,x+y,-2*x)",
     )
+    cs = cs.best_cell().primitive_setting()
     intensities = generate_fake_intensities(cs)
     result = LaueGroupAnalysis([intensities], normalisation=None)
     print(result)
@@ -54,6 +55,10 @@ def test_determine_space_group_best_monoclinic_beta():
             space_group_symbol="I 1 2/m 1",
         )
     )
+    d = result.as_dict()
+    assert cs.change_basis(
+        sgtbx.change_of_basis_op(d["subgroup_scores"][0]["cb_op"])
+    ).is_similar_symmetry(result.best_solution.subgroup["best_subsym"])
     result = LaueGroupAnalysis(
         [intensities], best_monoclinic_beta=False, normalisation=None
     )
@@ -64,3 +69,7 @@ def test_determine_space_group_best_monoclinic_beta():
             space_group_symbol="C 1 2/m 1",
         )
     )
+    d = result.as_dict()
+    assert cs.change_basis(
+        sgtbx.change_of_basis_op(d["subgroup_scores"][0]["cb_op"])
+    ).is_similar_symmetry(result.best_solution.subgroup["best_subsym"])

--- a/command_line/refine_bravais_settings.py
+++ b/command_line/refine_bravais_settings.py
@@ -203,7 +203,7 @@ def run(args=None):
     )
     possible_bravais_settings = {solution["bravais"] for solution in refined_settings}
     bravais_lattice_to_space_group_table(possible_bravais_settings)
-    logger.info(refined_settings.as_str())
+    logger.info(refined_settings)
 
     prefix = params.output.prefix
     if prefix is None:

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -83,6 +83,11 @@ laue_group = auto
 change_of_basis_op = None
   .type = str
 
+best_monoclinic_beta = True
+  .type = bool
+  .help = "If True, then for monoclinic centered cells, I2 will be preferred over C2 if"
+          "it gives a more oblique cell (i.e. smaller beta angle)."
+
 systematic_absences {
 
   check = True
@@ -312,6 +317,7 @@ def symmetry(experiments, reflection_tables, params=None):
             lattice_symmetry_max_delta=params.lattice_symmetry_max_delta,
             relative_length_tolerance=params.relative_length_tolerance,
             absolute_angle_tolerance=params.absolute_angle_tolerance,
+            best_monoclinic_beta=params.best_monoclinic_beta,
         )
         logger.info("")
         logger.info(result)

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -325,8 +325,9 @@ def symmetry(experiments, reflection_tables, params=None):
         if params.output.json is not None:
             d = result.as_dict()
             d["cb_op_inp_min"] = [str(cb_op) for cb_op in cb_ops]
-            # This is not the input symmetry as we have already mapped it to minimum
-            # cell, so delete from the output dictionary to avoid confusion
+            # Copy the "input_symmetry" to "min_cell_symmetry" as it isn't technically
+            # the input symmetry to dials.symmetry
+            d["min_cell_symmetry"] = d["input_symmetry"]
             del d["input_symmetry"]
             json_str = json.dumps(d, indent=2)
             with open(params.output.json, "w") as f:

--- a/newsfragments/1226.feature
+++ b/newsfragments/1226.feature
@@ -1,0 +1,4 @@
+New best_monoclinic_beta parameter for dials.refine_bravais_settings and dials.symmetry.
+Setting this to False will ensure that C2 is selected in preference to I2, where I2
+would lead to a less oblique cell (i.e. smaller beta angle).
+

--- a/test/command_line/test_refine_bravais_settings.py
+++ b/test/command_line/test_refine_bravais_settings.py
@@ -170,21 +170,30 @@ def test_refine_bravais_settings_554(dials_regression, tmpdir):
 
 
 @pytest.mark.parametrize(
-    "setting,expected_space_group,expected_unit_cell",
+    "best_monoclinic_beta,expected_space_group,expected_unit_cell",
     [
-        ("best", "I 1 2 1", (44.47, 52.85, 111.46, 90.00, 99.91, 90.00)),
-        ("reference", "C 1 2 1", (112.67, 52.85, 44.47, 90.00, 102.97, 90.00)),
+        (True, "I 1 2 1", (44.47, 52.85, 111.46, 90.00, 99.91, 90.00)),
+        (False, "C 1 2 1", (112.67, 52.85, 44.47, 90.00, 102.97, 90.00)),
     ],
 )
 def test_setting_c2_vs_i2(
-    setting, expected_space_group, expected_unit_cell, dials_data, tmpdir, capsys
+    best_monoclinic_beta,
+    expected_space_group,
+    expected_unit_cell,
+    dials_data,
+    tmpdir,
+    capsys,
 ):
     data_dir = dials_data("mpro_x0305_processed")
     refl_path = data_dir.join("indexed.refl")
     experiments_path = data_dir.join("indexed.expt")
     with tmpdir.as_cwd():
         refine_bravais_settings.run(
-            [experiments_path.strpath, refl_path.strpath, "setting=%s" % setting]
+            [
+                experiments_path.strpath,
+                refl_path.strpath,
+                "best_monoclinic_beta=%s" % best_monoclinic_beta,
+            ]
         )
     expts_orig = load.experiment_list(experiments_path.strpath, check_format=False)
 


### PR DESCRIPTION
This is similar to the [POINTLESS `SETTING` parameter](http://www.ccp4.ac.uk/html/pointless.html#setting) and allows the user to enforce that C2 is selected in preference to I2. The default behaviour remains as before, i.e. I2 is preferred to C2 if it gives rise to a less oblique cell.

Fixes #1222, fixes #1224 

New dials.refine_bravais_settings test depends on dials/data-files#15 and dials/data#175