### PR TITLE
DIALS 2.2.2

### DIFF
--- a/algorithms/indexing/bravais_settings.py
+++ b/algorithms/indexing/bravais_settings.py
@@ -38,6 +38,11 @@ cc_n_bins = None
   .type = int(value_min=1)
   .help = "Number of resolution bins to use for calculation of correlation coefficients"
 
+best_monoclinic_beta = True
+  .type = bool
+  .help = "If True, then for monoclinic centered cells, I2 will be preferred over C2 if"
+          "it gives a more oblique cell (i.e. smaller beta angle)."
+
 include scope dials.algorithms.refinement.refiner.phil_scope
 """,
     process_includes=True,
@@ -112,7 +117,7 @@ class RefinedSettingsList(list):
 
         return result
 
-    def as_str(self):
+    def __str__(self):
         table_data = [
             [
                 "Solution",
@@ -207,7 +212,9 @@ def refined_settings_from_refined_triclinic(experiments, reflections, params):
     UC = crystal.get_unit_cell()
 
     refined_settings = RefinedSettingsList()
-    for item in iotbx_converter(UC, params.lepage_max_delta):
+    for item in iotbx_converter(
+        UC, params.lepage_max_delta, best_monoclinic_beta=params.best_monoclinic_beta
+    ):
         refined_settings.append(BravaisSetting(item))
 
     triclinic = refined_settings.triclinic()
@@ -219,22 +226,20 @@ def refined_settings_from_refined_triclinic(experiments, reflections, params):
     for j in range(Nset):
         refined_settings[j].setting_number = Nset - j
 
-    for j in range(Nset):
-        cb_op = refined_settings[j]["cb_op_inp_best"].c().as_double_array()[0:9]
-        orient = crystal_orientation(crystal.get_A(), True)
-        orient_best = orient.change_basis(scitbx.matrix.sqr(cb_op).transpose())
-        constrain_orient = orient_best.constrain(refined_settings[j]["system"])
-        bravais = refined_settings[j]["bravais"]
-        cb_op_best_ref = refined_settings[j][
-            "best_subsym"
-        ].change_of_basis_op_to_reference_setting()
+    for subgroup in refined_settings:
         space_group = sgtbx.space_group_info(
-            number=bravais_lattice_to_lowest_symmetry_spacegroup_number[bravais]
+            number=bravais_lattice_to_lowest_symmetry_spacegroup_number[
+                subgroup["bravais"]
+            ]
         ).group()
-        space_group = space_group.change_basis(cb_op_best_ref.inverse())
-        bravais = str(bravais_types.bravais_lattice(group=space_group))
-        refined_settings[j]["bravais"] = bravais
-        refined_settings[j].unrefined_crystal = dxtbx_crystal_from_orientation(
+        orient = crystal_orientation(crystal.get_A(), True).change_basis(
+            scitbx.matrix.sqr(
+                subgroup["cb_op_inp_best"].c().as_double_array()[0:9]
+            ).transpose()
+        )
+        constrain_orient = orient.constrain(subgroup["system"])
+        subgroup["bravais"] = str(bravais_types.bravais_lattice(group=space_group))
+        subgroup.unrefined_crystal = dxtbx_crystal_from_orientation(
             constrain_orient, space_group
         )
 
@@ -291,8 +296,7 @@ def refine_subgroup(args):
 
     used_reflections = copy.deepcopy(used_reflections)
     triclinic_miller = used_reflections["miller_index"]
-    cb_op = subgroup["cb_op_inp_best"]
-    higher_symmetry_miller = cb_op.apply(triclinic_miller)
+    higher_symmetry_miller = subgroup["cb_op_inp_best"].apply(triclinic_miller)
     used_reflections["miller_index"] = higher_symmetry_miller
     unrefined_crystal = copy.deepcopy(subgroup.unrefined_crystal)
     for expt in experiments:

--- a/algorithms/indexing/bravais_settings.py
+++ b/algorithms/indexing/bravais_settings.py
@@ -117,6 +117,9 @@ class RefinedSettingsList(list):
 
         return result
 
+    def as_str(self):
+        return str(self)
+
     def __str__(self):
         table_data = [
             [

--- a/algorithms/indexing/lattice_search/__init__.py
+++ b/algorithms/indexing/lattice_search/__init__.py
@@ -252,17 +252,12 @@ class LatticeSearch(indexer.Indexer):
                     continue
 
             if self.params.known_symmetry.space_group is not None:
-                new_crystal, cb_op_to_primitive = self._symmetry_handler.apply_symmetry(
+                new_crystal, _ = self._symmetry_handler.apply_symmetry(
                     experiments[0].crystal
                 )
                 if new_crystal is None:
                     continue
                 experiments[0].crystal.update(new_crystal)
-                if not cb_op_to_primitive.is_identity_op():
-                    sel = refl["id"] > -1
-                    miller_indices = refl["miller_index"].select(sel)
-                    miller_indices = cb_op_to_primitive.apply(miller_indices)
-                    refl["miller_index"].set_selected(sel, miller_indices)
 
             args.append((experiments, refl))
             if len(args) == self.params.basis_vector_combinations.max_refine:

--- a/algorithms/indexing/stills_indexer.py
+++ b/algorithms/indexing/stills_indexer.py
@@ -488,28 +488,15 @@ class StillsIndexer(Indexer):
                 self.params.stills.refine_candidates_with_known_symmetry
                 and self.params.known_symmetry.space_group is not None
             ):
-                new_crystal, cb_op_to_primitive = self._symmetry_handler.apply_symmetry(
-                    cm
-                )
+                new_crystal, cb_op = self._symmetry_handler.apply_symmetry(cm)
                 if new_crystal is None:
                     logger.info("Cannot convert to target symmetry, candidate %d", icm)
                     continue
-                new_crystal = new_crystal.change_basis(
-                    self._symmetry_handler.cb_op_primitive_inp
-                )
-                cm = new_crystal
+                cm = new_crystal.change_basis(cb_op)
                 experiments = self.experiment_list_for_crystal(cm)
 
-                if not cb_op_to_primitive.is_identity_op():
-                    indexed["miller_index"] = cb_op_to_primitive.apply(
-                        indexed["miller_index"]
-                    )
-                if self._symmetry_handler.cb_op_primitive_inp is not None:
-                    indexed[
-                        "miller_index"
-                    ] = self._symmetry_handler.cb_op_primitive_inp.apply(
-                        indexed["miller_index"]
-                    )
+                if not cb_op.is_identity_op():
+                    indexed["miller_index"] = cb_op.apply(indexed["miller_index"])
 
             if params.indexing.stills.refine_all_candidates:
                 try:

--- a/algorithms/indexing/symmetry.py
+++ b/algorithms/indexing/symmetry.py
@@ -275,4 +275,9 @@ class SymmetryHandler(object):
             # The user has specified a setting that is not the reference setting
             return model, self.cb_op_ref_inp * cb_op_inp_ref
         # Default to reference setting
-        return model, cb_op_inp_ref
+        # This change of basis op will ensure that we get the best beta angle without
+        # changing the centring (e.g. from C2 to I2)
+        cb_op_ref_best = ref_subsym.change_of_basis_op_to_best_cell(
+            best_monoclinic_beta=False
+        )
+        return model, cb_op_ref_best * cb_op_inp_ref

--- a/algorithms/indexing/test_symmetry.py
+++ b/algorithms/indexing/test_symmetry.py
@@ -19,15 +19,9 @@ def test_SymmetryHandler(space_group_symbol):
 
     handler = symmetry.SymmetryHandler(unit_cell=uc, space_group=sg)
 
-    assert handler.target_symmetry_primitive.unit_cell().parameters() == pytest.approx(
-        cs.best_cell().primitive_setting().unit_cell().parameters()
-    )
     assert (
         handler.target_symmetry_primitive.space_group()
         == sg.build_derived_patterson_group().info().primitive_setting().group()
-    )
-    assert handler.target_symmetry_reference_setting.unit_cell().parameters() == pytest.approx(
-        cs.best_cell().as_reference_setting().unit_cell().parameters()
     )
     assert (
         handler.target_symmetry_reference_setting.space_group()
@@ -73,17 +67,57 @@ def test_SymmetryHandler(space_group_symbol):
     crystal_new, cb_op = handler.apply_symmetry(crystal)
     crystal_new.get_crystal_symmetry(assert_is_compatible_unit_cell=True)
 
-    handler = symmetry.SymmetryHandler(unit_cell=cs.minimum_cell().unit_cell())
+    handler = symmetry.SymmetryHandler(
+        unit_cell=cs.minimum_cell().unit_cell(), space_group=sgtbx.space_group(),
+    )
     assert handler.target_symmetry_primitive.unit_cell().parameters() == pytest.approx(
         cs.minimum_cell().unit_cell().parameters()
     )
-    assert handler.target_symmetry_primitive.space_group() == sgtbx.space_group()
+    assert handler.target_symmetry_primitive.space_group() == sgtbx.space_group("P-1")
     assert handler.target_symmetry_reference_setting.unit_cell().parameters() == pytest.approx(
         cs.minimum_cell().unit_cell().parameters()
     )
-    assert (
-        handler.target_symmetry_reference_setting.space_group() == sgtbx.space_group()
+    assert handler.target_symmetry_reference_setting.space_group() == sgtbx.space_group(
+        "P-1"
     )
+
+
+# https://github.com/dials/dials/issues/1217
+def test_symmetry_handler_c2_i2():
+    cs = crystal.symmetry(
+        unit_cell=(44.66208171, 53.12629403, 62.53397661, 64.86329707, 78.27343894, 90),
+        space_group_symbol="C 1 2/m 1 (z,x+y,-2*x)",
+    )
+    cs_ref = cs.as_reference_setting()
+    cs_best = cs_ref.best_cell()
+    # best -> ref is different to cs_ref above
+    cs_best_ref = cs_best.as_reference_setting()
+    assert not cs_ref.is_similar_symmetry(cs_best_ref)
+
+    B = scitbx.matrix.sqr(cs.unit_cell().fractionalization_matrix()).transpose()
+    cryst = Crystal(B, sgtbx.space_group())
+
+    for cs_ in (cs, cs_ref, cs_best):
+        print(cs_)
+        handler = symmetry.SymmetryHandler(space_group=cs_.space_group())
+        new_cryst, cb_op = handler.apply_symmetry(cryst)
+        assert (
+            new_cryst.change_basis(cb_op)
+            .get_crystal_symmetry()
+            .is_similar_symmetry(cs_)
+        )
+
+    for cs_ in (cs, cs_ref, cs_best, cs_best_ref):
+        print(cs_)
+        handler = symmetry.SymmetryHandler(
+            unit_cell=cs_.unit_cell(), space_group=cs_.space_group()
+        )
+        new_cryst, cb_op = handler.apply_symmetry(cryst)
+        assert (
+            new_cryst.change_basis(cb_op)
+            .get_crystal_symmetry()
+            .is_similar_symmetry(cs_)
+        )
 
 
 crystal_symmetries = []

--- a/algorithms/symmetry/__init__.py
+++ b/algorithms/symmetry/__init__.py
@@ -37,6 +37,7 @@ class symmetry_base(object):
         min_cc_half=0.6,
         relative_length_tolerance=None,
         absolute_angle_tolerance=None,
+        best_monoclinic_beta=True,
     ):
         u"""Initialise a symmetry_base object.
 
@@ -60,6 +61,9 @@ class symmetry_base(object):
             consistency of input unit cells against the median unit cell.
           absolute_angle_tolerance (float): Absolute angle tolerance in checking
             consistency of input unit cells against the median unit cell.
+          best_monoclinic_beta (bool): If True, then for monoclinic centered cells, I2
+            will be preferred over C2 if it gives a more oblique cell (i.e. smaller
+            beta angle).
         """
         self.input_intensities = intensities
 
@@ -94,6 +98,7 @@ class symmetry_base(object):
             self.intensities.crystal_symmetry(),
             max_delta=self.lattice_symmetry_max_delta,
             bravais_types_only=False,
+            best_monoclinic_beta=best_monoclinic_beta,
         )
 
         self.cb_op_inp_min = self.subgroups.cb_op_inp_minimum

--- a/algorithms/symmetry/laue_group.py
+++ b/algorithms/symmetry/laue_group.py
@@ -36,6 +36,7 @@ class LaueGroupAnalysis(symmetry_base):
         min_cc_half=0.6,
         relative_length_tolerance=None,
         absolute_angle_tolerance=None,
+        best_monoclinic_beta=True,
     ):
         """Intialise a LaueGroupAnalysis object.
 
@@ -59,6 +60,9 @@ class LaueGroupAnalysis(symmetry_base):
             consistency of input unit cells against the median unit cell.
           absolute_angle_tolerance (float): Absolute angle tolerance in checking
             consistency of input unit cells against the median unit cell.
+          best_monoclinic_beta (bool): If True, then for monoclinic centered cells, I2
+            will be preferred over C2 if it gives a more oblique cell (i.e. smaller
+            beta angle).
         """
         super(LaueGroupAnalysis, self).__init__(
             intensities,
@@ -69,6 +73,7 @@ class LaueGroupAnalysis(symmetry_base):
             min_cc_half=min_cc_half,
             relative_length_tolerance=relative_length_tolerance,
             absolute_angle_tolerance=absolute_angle_tolerance,
+            best_monoclinic_beta=best_monoclinic_beta,
         )
 
         self._estimate_cc_sig_fac()
@@ -371,10 +376,6 @@ class LaueGroupAnalysis(symmetry_base):
                 "unit_cell": self.median_unit_cell.parameters(),
             },
             "cb_op_inp_min": self.cb_op_inp_min.as_xyz(),
-            "min_cell_symmetry": {
-                "hall_symbol": self.intensities.space_group().type().hall_symbol(),
-                "unit_cell": self.intensities.unit_cell().parameters(),
-            },
             "lattice_point_group": self.lattice_group.type().hall_symbol(),
             "cc_unrelated_pairs": self.corr_unrelated.coefficient(),
             "n_unrelated_pairs": self.corr_unrelated.n(),

--- a/algorithms/symmetry/test_laue_group.py
+++ b/algorithms/symmetry/test_laue_group.py
@@ -2,22 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from cctbx import miller
-from cctbx import sgtbx
+from cctbx import crystal, miller, sgtbx
 from dials.algorithms.symmetry.cosym._generate_test_data import generate_intensities
 from dials.algorithms.symmetry.laue_group import LaueGroupAnalysis
 
 
-@pytest.mark.parametrize("space_group", ["P2", "P3", "P6", "R3:h", "I23"][:])
-def test_determine_space_group(space_group):
-
-    sgi = sgtbx.space_group_info(symbol=space_group)
-    sg = sgi.group()
-    cs = sgi.any_compatible_crystal_symmetry(volume=10000)
-    cs = cs.best_cell()
-    cs = cs.minimum_cell()
+def generate_fake_intensities(crystal_symmetry):
     intensities = (
-        generate_intensities(cs, d_min=1.0)
+        generate_intensities(crystal_symmetry, d_min=1.0)
         .generate_bijvoet_mates()
         .set_observation_type_xray_intensity()
     )
@@ -25,6 +17,18 @@ def test_determine_space_group(space_group):
     # needed to give vaguely sensible E_cc_true values
     intensities = intensities.customized_copy(sigmas=intensities.data() / 50)
     intensities.set_info(miller.array_info(source="fake", source_type="mtz"))
+    return intensities
+
+
+@pytest.mark.parametrize("space_group", ["P2", "P3", "P6", "R3:h", "I23"][:])
+def test_determine_space_group(space_group):
+    sgi = sgtbx.space_group_info(symbol=space_group)
+    sg = sgi.group()
+    cs = sgi.any_compatible_crystal_symmetry(volume=10000)
+    cs = cs.best_cell()
+    cs = cs.minimum_cell()
+
+    intensities = generate_fake_intensities(cs)
     result = LaueGroupAnalysis([intensities], normalisation=None)
     print(result)
     assert (
@@ -34,3 +38,38 @@ def test_determine_space_group(space_group):
     assert result.best_solution.likelihood > 0.8
     for score in result.subgroup_scores[1:]:
         assert score.likelihood < 0.1
+
+
+def test_determine_space_group_best_monoclinic_beta():
+    cs = crystal.symmetry(
+        unit_cell=(44.66208171, 53.12629403, 62.53397661, 64.86329707, 78.27343894, 90),
+        space_group_symbol="C 1 2/m 1 (z,x+y,-2*x)",
+    )
+    cs = cs.best_cell().primitive_setting()
+    intensities = generate_fake_intensities(cs)
+    result = LaueGroupAnalysis([intensities], normalisation=None)
+    print(result)
+    assert result.best_solution.subgroup["best_subsym"].is_similar_symmetry(
+        crystal.symmetry(
+            unit_cell=(44.66208171, 53.12629403, 111.9989451, 90, 99.89337396, 90),
+            space_group_symbol="I 1 2/m 1",
+        )
+    )
+    d = result.as_dict()
+    assert cs.change_basis(
+        sgtbx.change_of_basis_op(d["subgroup_scores"][0]["cb_op"])
+    ).is_similar_symmetry(result.best_solution.subgroup["best_subsym"])
+    result = LaueGroupAnalysis(
+        [intensities], best_monoclinic_beta=False, normalisation=None
+    )
+    print(result)
+    assert result.best_solution.subgroup["best_subsym"].is_similar_symmetry(
+        crystal.symmetry(
+            unit_cell=(113.2236274, 53.12629403, 44.66208171, 90, 102.9736126, 90),
+            space_group_symbol="C 1 2/m 1",
+        )
+    )
+    d = result.as_dict()
+    assert cs.change_basis(
+        sgtbx.change_of_basis_op(d["subgroup_scores"][0]["cb_op"])
+    ).is_similar_symmetry(result.best_solution.subgroup["best_subsym"])

--- a/command_line/refine_bravais_settings.py
+++ b/command_line/refine_bravais_settings.py
@@ -203,7 +203,7 @@ def run(args=None):
     )
     possible_bravais_settings = {solution["bravais"] for solution in refined_settings}
     bravais_lattice_to_space_group_table(possible_bravais_settings)
-    logger.info(refined_settings.as_str())
+    logger.info(refined_settings)
 
     prefix = params.output.prefix
     if prefix is None:

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -83,6 +83,11 @@ laue_group = auto
 change_of_basis_op = None
   .type = str
 
+best_monoclinic_beta = True
+  .type = bool
+  .help = "If True, then for monoclinic centered cells, I2 will be preferred over C2 if"
+          "it gives a more oblique cell (i.e. smaller beta angle)."
+
 systematic_absences {
 
   check = True
@@ -312,6 +317,7 @@ def symmetry(experiments, reflection_tables, params=None):
             lattice_symmetry_max_delta=params.lattice_symmetry_max_delta,
             relative_length_tolerance=params.relative_length_tolerance,
             absolute_angle_tolerance=params.absolute_angle_tolerance,
+            best_monoclinic_beta=params.best_monoclinic_beta,
         )
         logger.info("")
         logger.info(result)
@@ -319,8 +325,9 @@ def symmetry(experiments, reflection_tables, params=None):
         if params.output.json is not None:
             d = result.as_dict()
             d["cb_op_inp_min"] = [str(cb_op) for cb_op in cb_ops]
-            # This is not the input symmetry as we have already mapped it to minimum
-            # cell, so delete from the output dictionary to avoid confusion
+            # Copy the "input_symmetry" to "min_cell_symmetry" as it isn't technically
+            # the input symmetry to dials.symmetry
+            d["min_cell_symmetry"] = d["input_symmetry"]
             del d["input_symmetry"]
             json_str = json.dumps(d, indent=2)
             with open(params.output.json, "w") as f:

--- a/doc/sphinx/publications.rst
+++ b/doc/sphinx/publications.rst
@@ -6,6 +6,7 @@ Publications
 DIALS Journal Articles
 ----------------------
 
+* .. pubmed:: 32254063 dials.scale
 * .. pubmed:: 30950396 How best to use photons
 * .. pubmed:: 30198898 Serial crystallography
 * .. pubmed:: 29872002 Electron diffraction

--- a/newsfragments/1217.bugfix
+++ b/newsfragments/1217.bugfix
@@ -1,0 +1,1 @@
+Ensure dials.index chooses the C2 setting with the smallest beta angle

--- a/newsfragments/1226.feature
+++ b/newsfragments/1226.feature
@@ -1,0 +1,4 @@
+New best_monoclinic_beta parameter for dials.refine_bravais_settings and dials.symmetry.
+Setting this to False will ensure that C2 is selected in preference to I2, where I2
+would lead to a less oblique cell (i.e. smaller beta angle).
+

--- a/test/command_line/test_refine_bravais_settings.py
+++ b/test/command_line/test_refine_bravais_settings.py
@@ -207,7 +207,7 @@ def test_setting_c2_vs_i2(
     with tmpdir.join("bravais_summary.json").open("rb") as fh:
         bravais_summary = json.load(fh)
     # Verify that the cb_op converts from the input setting to the refined setting
-    cb_op = sgtbx.change_of_basis_op(bravais_summary["2"]["cb_op"])
+    cb_op = sgtbx.change_of_basis_op(str(bravais_summary["2"]["cb_op"]))
     assert (
         expts_orig[0]
         .crystal.change_basis(cb_op)


### PR DESCRIPTION
* `dials.index` will now choose the C2 setting with the smallest beta angle
* `dials.refine_bravais_settings` and `dials.symmetry` have a new `best_monoclinic_beta` parameter. Setting this to False will ensure that C2 is selected in preference to I2, where I2
would lead to a less oblique cell (i.e. smaller beta angle).
* [The `dials.scale` paper has been published (Beilsten-Edmands _et al._, 2020)](https://doi.org/10.1107/S2059798320003198) 
* `iota`: fixed bug where processing with defaults fails
* `xia2`: restore lost sweep settings when using `remove_blanks`
* `xia2`: choose correct unit cell when processing data in C2 space group