### PR TITLE
Decoy measurements for stills processing

### DIFF
--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -1501,6 +1501,24 @@ class Processor(object):
                     self.params.output.integrated_filename,
                 )
 
+            if self.params.dispatch.coset:
+                if (
+                    len(self.all_coset_experiments) > 0
+                    and self.params.output.coset_experiments_filename
+                ):
+
+                    self.all_coset_experiments.as_json(
+                        self.params.output.coset_experiments_filename
+                    )
+
+                if (
+                    len(self.all_coset_reflections) > 0
+                    and self.params.output.coset_filename
+                ):
+                    self.save_reflections(
+                        self.all_coset_reflections, self.params.output.coset_filename
+                    )
+
             # Create a tar archive of the integration dictionary pickles
             if len(self.all_int_pickles) > 0 and self.params.output.integration_pickle:
                 tar_template_integration_pickle = self.params.output.integration_pickle.replace(

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -81,8 +81,8 @@ control_phil_str = """
     coset = False
       .expert_level = 2
       .type = bool
-      .help = Within the integrate dispatcher, integrate a sublattice coset intended to represent
-      .help = negative control spots with no Bragg diffraction.
+      .help = Within the integrate dispatcher, integrate a sublattice coset intended to represent \
+              negative control spots with no Bragg diffraction.
     hit_finder{
       enable = True
         .type = bool
@@ -210,9 +210,10 @@ dials_phil_str = """
     coset {
       transformation = 6
         .type = int(value_min=0, value_max=6)
-        .help = The index number of the modulus=2 sublattice transformation.
-        .help = The only supported value is 6, representing body-centered cell doubling.
-        .help = See Sauter and Zwart, Acta D (2009) 65:553
+        .multiple = False
+        .help = The index number(s) of the modulus=2 sublattice transformation(s) used to produce distince coset results. \
+                0=Double a, 1=Double b, 2=Double c, 3=C-face centering, 4=B-face centering, 5=A-face centering, 6=Body centering \
+                See Sauter and Zwart, Acta D (2009) 65:553
     }
   }
 """


### PR DESCRIPTION
Option to integrate blank shoeboxes in dials.stills_process, as a control for background modeling.

Uses body-centering as default to predict areas without Bragg diffraction, one of seven modulus=2 sublattice transformation(s) used to produce distinct coset results.  See Sauter and Zwart, Acta D (2009) 65:553.