### PR TITLE
Fix propagation of best_unit_cell and d_min cutoffs in dials.scale/export_mtz

### DIFF
--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -149,7 +149,9 @@ def prepare_input(params, experiments, reflections):
         reflections.append(reflection_table)
 
     #### Perform any non-batch cutting of the datasets, including the target dataset
-    best_unit_cell = determine_best_unit_cell(experiments)
+    best_unit_cell = params.reflection_selection.best_unit_cell
+    if best_unit_cell is None:
+        best_unit_cell = determine_best_unit_cell(experiments)
     for reflection in reflections:
         if params.cut_data.d_min or params.cut_data.d_max:
             d = best_unit_cell.d(reflection["miller_index"])
@@ -208,7 +210,10 @@ class ScalingAlgorithm(Subject):
         self.scale()
         self.remove_bad_data()
         self.scaled_miller_array = scaled_data_as_miller_array(
-            self.reflections, self.experiments, anomalous_flag=False
+            self.reflections,
+            self.experiments,
+            anomalous_flag=False,
+            best_unit_cell=self.params.reflection_selection.best_unit_cell,
         )
         try:
             self.calculate_merging_stats()
@@ -467,7 +472,10 @@ Scaling and filtering can only be performed in multi-dataset scaling mode
         self.scaler.params.scaling_options.full_matrix = initial_full_matrix
         self.remove_bad_data()
         self.scaled_miller_array = scaled_data_as_miller_array(
-            self.reflections, self.experiments, anomalous_flag=False
+            self.reflections,
+            self.experiments,
+            anomalous_flag=False,
+            best_unit_cell=self.params.reflection_selection.best_unit_cell,
         )
         try:
             self.calculate_merging_stats()

--- a/algorithms/scaling/scaling_options.py
+++ b/algorithms/scaling/scaling_options.py
@@ -43,7 +43,7 @@ phil_scope = iotbx.phil.parse(
         .expert_level=1
     }
     best_unit_cell = None
-      .type = floats(size=6)
+      .type = unit_cell
       .help = "Best unit cell value, to use when performing resolution cutting"
               "and merging statistics. If None, the median cell will be used."
     E2_range = 0.8, 5.0

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -9,6 +9,7 @@ import json
 import iotbx.merging_statistics
 import pytest
 import procrunner
+from cctbx import uctbx
 from libtbx import phil
 from dxtbx.serialize import load
 from dxtbx.model.experiment_list import ExperimentList
@@ -506,6 +507,30 @@ def test_scale_dose_decay_model(dials_data, tmpdir):
     assert tmpdir.join("dials.scale.html").check()
     expts = load.experiment_list(tmpdir.join("scaled.expt").strpath, check_format=False)
     assert expts[0].scaling_model.id_ == "dose_decay"
+
+
+def test_scale_best_unit_cell_d_min(dials_data, tmpdir):
+    location = dials_data("multi_crystal_proteinase_k")
+    best_unit_cell = uctbx.unit_cell((42, 42, 39, 90, 90, 90))
+    d_min = 2
+    command = [
+        "dials.scale",
+        "best_unit_cell=%g,%g,%g,%g,%g,%g" % best_unit_cell.parameters(),
+        "d_min=%g" % d_min,
+        "unmerged_mtz=unmerged.mtz",
+    ]
+    for i in [1, 2, 3, 4, 5, 7, 10]:
+        command.append(location.join("experiments_" + str(i) + ".json").strpath)
+        command.append(location.join("reflections_" + str(i) + ".pickle").strpath)
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("scaled.refl").check()
+    assert tmpdir.join("scaled.expt").check()
+    stats = get_merging_stats(tmpdir.join("unmerged.mtz").strpath)
+    assert stats.overall.d_min >= d_min
+    assert stats.crystal_symmetry.unit_cell().parameters() == pytest.approx(
+        best_unit_cell.parameters()
+    )
 
 
 def test_scale_and_filter_dataset_mode(dials_data, tmpdir):

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import sys
 
-from libtbx.phil import parse
+from iotbx.phil import parse
 from libtbx import Auto
 
 logger = logging.getLogger("dials.command_line.export")
@@ -124,6 +124,13 @@ phil_scope = parse(
     crystal_name = XTAL
       .type = str
       .help = "The name of the crystal, for the mtz file metadata"
+
+    best_unit_cell = None
+    .type = unit_cell
+    .help = "Best unit cell value, to use when performing resolution cutting,"
+            "and as the overall unit cell in the exported mtz. If None, the median"
+            "cell will be used."
+
   }
 
   sadabs {

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -139,6 +139,7 @@ def _export_unmerged_mtz(params, experiments, reflection_table):
     export_params.intensity = ["scale"]
     export_params.mtz.partiality_threshold = params.cut_data.partiality_cutoff
     export_params.mtz.crystal_name = params.output.crystal_name
+    export_params.mtz.best_unit_cell = params.reflection_selection.best_unit_cell
     if params.cut_data.d_min:
         export_params.mtz.d_min = params.cut_data.d_min
     logger.info(

--- a/newsfragments/1248.bugfix
+++ b/newsfragments/1248.bugfix
@@ -1,0 +1,2 @@
+Fix propagation of best_unit_cell and application of resolution cutoffs in dials.scale and export_mtz.
+Add a new mtz.best_unit_cell parameter to dials.export

--- a/test/command_line/test_export.py
+++ b/test/command_line/test_export.py
@@ -40,13 +40,10 @@ def test_mtz(dials_data, tmpdir):
 def test_mtz_recalculated_cell(dials_data, tmpdir):
     # First run dials.two_theta_refine to ensure that the crystals have
     # recalculated_unit_cell set
+    scaled_expt = dials_data("x4wide_processed").join("AUTOMATIC_DEFAULT_scaled.expt")
+    scaled_refl = dials_data("x4wide_processed").join("AUTOMATIC_DEFAULT_scaled.refl")
     result = procrunner.run(
-        [
-            "dials.two_theta_refine",
-            dials_data("centroid_test_data").join("experiments.json"),
-            dials_data("centroid_test_data").join("integrated.pickle"),
-        ],
-        working_directory=tmpdir,
+        ["dials.two_theta_refine", scaled_expt, scaled_refl], working_directory=tmpdir,
     )
     assert tmpdir.join("refined_cell.expt").check(file=1)
     refined_expt = load.experiment_list(
@@ -54,21 +51,24 @@ def test_mtz_recalculated_cell(dials_data, tmpdir):
     )
     ttr_cell = refined_expt.crystals()[0].get_recalculated_unit_cell()
 
+    d_min = 1.3
     result = procrunner.run(
         [
             "dials.export",
             "format=mtz",
             tmpdir.join("refined_cell.expt"),
-            dials_data("centroid_test_data").join("integrated.pickle"),
+            scaled_refl,
+            "d_min=%f" % d_min,
         ],
         working_directory=tmpdir,
     )
     assert not result.returncode and not result.stderr
-    assert tmpdir.join("integrated.mtz").check(file=1)
+    assert tmpdir.join("scaled.mtz").check(file=1)
     # The resulting mtz should have the same unit cell set as the recalculated_unit_cell
     # from dials.two_theta_refine
-    for ma in mtz.object(tmpdir.join("integrated.mtz").strpath).as_miller_arrays():
+    for ma in mtz.object(tmpdir.join("scaled.mtz").strpath).as_miller_arrays():
         assert ttr_cell.parameters() == pytest.approx(ma.unit_cell().parameters())
+        assert ma.d_min() >= d_min
 
 
 def test_multi_sequence_integrated_mtz(dials_data, tmpdir):


### PR DESCRIPTION
A number of issues meant that the reflections output by dials.scale in the unmerged mtz file wouldn't necessarily be consistent with the resolution cutoff requested by the user. This PR includes a number of fixes to dials.scale and dials.export to address this (and tests to verify the new behaviour):

dials.export:
- optionally define best_unit_cell on command line
- otherwise get from recalculated_cell/median cell as per scaling
- use this best_unit_cell when calculating resolution cutoff

dials.scale:
- pass best_unit_cell from scaling when calling export_mtz
- respect command line best_unit_cell when calculating merging stats in scaling
- respect command line best_unit_cell when cutting resolution in scaling