### PR TITLE
Map to minimum cell via joint reference settings

### DIFF
--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -181,14 +181,19 @@ def change_of_basis_ops_to_minimum_cell(
             groups = metric_subgroups(
                 expt.crystal.get_crystal_symmetry(),
                 max_delta,
+                best_monoclinic_beta=False,
                 enforce_max_delta_for_generated_two_folds=True,
             )
             group = groups.result_groups[0]
-            cb_op_best_to_min = group[
-                "best_subsym"
-            ].change_of_basis_op_to_minimum_cell()
-            cb_op_inp_min = cb_op_best_to_min * group["cb_op_inp_best"]
-            cb_ops.append(cb_op_inp_min)
+            cb_ops.append(group["cb_op_inp_best"])
+        ref_expts = experiments.change_basis(cb_ops)
+        cb_op_ref_min = (
+            ref_expts[0]
+            .crystal.get_crystal_symmetry()
+            .customized_copy(unit_cell=median_unit_cell(ref_expts))
+            .change_of_basis_op_to_minimum_cell()
+        )
+        cb_ops = [cb_op_ref_min * cb_op for cb_op in cb_ops]
     return cb_ops
 
 

--- a/test/command_line/test_symmetry.py
+++ b/test/command_line/test_symmetry.py
@@ -375,6 +375,33 @@ def test_change_of_basis_ops_to_minimum_cell_1037(mocker):
     assert cb_ops_as_xyz[0] in ("x,y,z", "-x,y,-z", "x-y,-y,-z")
 
 
+def test_change_of_basis_ops_to_minimum_cell_mpro():
+    input_ucs = [
+        (46.023, 55.001, 64.452, 64.744, 78.659, 89.824),
+        (44.747, 53.916, 62.554, 114.985, 99.610, 90.736),
+    ]
+
+    # Setup the input experiments and reflection tables
+    expts = ExperimentList()
+    for uc in input_ucs:
+        uc = uctbx.unit_cell(uc)
+        sg = sgtbx.space_group_info("P1").group()
+        B = scitbx.matrix.sqr(uc.fractionalization_matrix()).transpose()
+        expts.append(Experiment(crystal=Crystal(B, space_group=sg, reciprocal=True)))
+
+    # Actually run the method we are testing
+    cb_ops = change_of_basis_ops_to_minimum_cell(
+        expts, max_delta=5, relative_length_tolerance=0.05, absolute_angle_tolerance=2
+    )
+    expts.change_basis(cb_ops, in_place=True)
+    assert symmetry.unit_cells_are_similar_to(
+        expts,
+        median_unit_cell(expts),
+        relative_length_tolerance=0.05,
+        absolute_angle_tolerance=2,
+    )
+
+
 def test_median_cell():
     unit_cells = [
         uctbx.unit_cell(uc)


### PR DESCRIPTION
A hopefully more numerically stable attempt at mapping to consistent minimum unit cells:

1. map all experiments to the reference setting
2. calculate the median unit cell for all the reference settings
3. calculate the change of basis op to minimum cell based on that median cell