### PR TITLE
DIALS 2.2.4

### DIFF
--- a/algorithms/indexing/symmetry.py
+++ b/algorithms/indexing/symmetry.py
@@ -231,6 +231,7 @@ class SymmetryHandler(object):
         target_sg_ref = target_space_group.info().reference_setting().group()
         best_angular_difference = 1e8
 
+        best_subgroup = None
         for item in items:
             if bravais_lattice(group=target_sg_ref) != item["bravais"]:
                 continue

--- a/algorithms/indexing/test_symmetry.py
+++ b/algorithms/indexing/test_symmetry.py
@@ -82,6 +82,19 @@ def test_SymmetryHandler(space_group_symbol):
     )
 
 
+# https://github.com/dials/dials/issues/1254
+def test_SymmetryHandler_no_match():
+    sgi = sgtbx.space_group_info(symbol="P422")
+    cs = sgi.any_compatible_crystal_symmetry(volume=10000)
+    B = scitbx.matrix.sqr(cs.unit_cell().fractionalization_matrix()).transpose()
+    crystal = Crystal(B, sgtbx.space_group())
+
+    handler = symmetry.SymmetryHandler(
+        unit_cell=None, space_group=sgtbx.space_group_info("I23").group()
+    )
+    assert handler.apply_symmetry(crystal) == (None, None)
+
+
 # https://github.com/dials/dials/issues/1217
 @pytest.mark.parametrize(
     "crystal_symmetry",

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function
 import itertools
 import logging
 import math
-import resource
 from dials.util import tabulate
 from time import time
 
@@ -25,6 +24,12 @@ from dials_algorithms_integration_integrator_ext import (
     ReflectionManagerPerImage,
     ShoeboxProcessor,
 )
+
+try:
+    import resource
+except ImportError:
+    # resource does not exist on non-Linux, so can't float the import
+    resource = None
 
 __all__ = [
     "Block",
@@ -782,7 +787,10 @@ class Manager(object):
         _report("Memory required per process", memory_required_per_process / 1e9)
 
         # Check if a ulimit applies
-        rlimit = getattr(resource, "RLIMIT_VMEM", getattr(resource, "RLIMIT_AS"))
+        # Note that resource may be None on non-Linux platforms.
+        # We can't use psutil as platform-independent solution in this instance due to
+        # https://github.com/conda-forge/psutil-feedstock/issues/47
+        rlimit = getattr(resource, "RLIMIT_VMEM", getattr(resource, "RLIMIT_AS", None))
         if rlimit:
             try:
                 ulimit = resource.getrlimit(rlimit)[0]

--- a/algorithms/symmetry/cosym/plots.py
+++ b/algorithms/symmetry/cosym/plots.py
@@ -26,6 +26,8 @@ def plot_coords(coords, labels=None, key="cosym_coordinates"):
 
     colours = plt.cm.Spectral(numpy.linspace(0, 1, n_clusters)).tolist()
 
+    if -1 in unique_labels:
+        colours.insert(0, (0, 0, 0, 1))
     data = []
     for k, col in zip(unique_labels, colours):
         isel = (labels == k).iselection()
@@ -42,7 +44,7 @@ def plot_coords(coords, labels=None, key="cosym_coordinates"):
                     "alpha": 0.5,
                     "color": "rgb(%f,%f,%f)" % tuple(col[:3]),
                 },
-                "name": "Cluster %i" % k,
+                "name": "Cluster %i" % k if k >= 0 else "Noise",
             }
         )
     d = {

--- a/algorithms/symmetry/cosym/test_plots.py
+++ b/algorithms/symmetry/cosym/test_plots.py
@@ -5,16 +5,22 @@ from scitbx.array_family import flex
 
 
 def test_plot_coords():
-    coords = flex.double([0, 1, 0, 1, 1, 0, 1, 0])
-    coords.reshape(flex.grid((4, 2)))
-    labels = flex.int([0, 0, 1, 1])
+    coords = flex.double([0.5, 0.5, 0, 1, 0, 1, 1, 0, 1, 0])
+    coords.reshape(flex.grid((5, 2)))
+    labels = flex.int([-1, 0, 0, 1, 1])
     d = plots.plot_coords(coords, labels=labels)
     assert "cosym_coordinates" in d
     assert set(d["cosym_coordinates"]) == {"layout", "data"}
-    assert d["cosym_coordinates"]["data"][0]["x"] == [0.0, 0.0]
-    assert d["cosym_coordinates"]["data"][0]["y"] == [1.0, 1.0]
-    assert d["cosym_coordinates"]["data"][1]["x"] == [1.0, 1.0]
-    assert d["cosym_coordinates"]["data"][1]["y"] == [0.0, 0.0]
+    assert (
+        d["cosym_coordinates"]["data"][0]["marker"]["color"]
+        == "rgb(0.000000,0.000000,0.000000)"
+    )
+    assert d["cosym_coordinates"]["data"][0]["x"] == [0.5]
+    assert d["cosym_coordinates"]["data"][0]["y"] == [0.5]
+    assert d["cosym_coordinates"]["data"][1]["x"] == [0.0, 0.0]
+    assert d["cosym_coordinates"]["data"][1]["y"] == [1.0, 1.0]
+    assert d["cosym_coordinates"]["data"][2]["x"] == [1.0, 1.0]
+    assert d["cosym_coordinates"]["data"][2]["y"] == [0.0, 0.0]
 
 
 def test_plot_rij_histogram():


### PR DESCRIPTION
* Show unit cell information with a sensible precision (cctbx/dxtbx#165)
* Understand the new SLS EIGER file format (cctbx/dxtbx#168)
* `dials.cosym`: fix issues with the generated plots
* `dials.index`: fix `UnboundLocalError` crash (#1254)
* `dials.integrate`: fix `ImportError` crash on Windows (#1251)
* `xia2`: Ensure data/log files are copied to the DataFiles/LogFiles directories even when processing failed (xia2/xia2#439)
* `xia2`: Fix broken multiplicity plots on Python 3
* `xia2`: Fix excessive outlier rejection with the `3dii` pipeline (xia2/xia2#388, xia2/xia2#445, xia2/xia2#446)
* `xia2.multiplex`: Fix missing graphs with multiplex report plots