### PR TITLE
Give option to show reciprocal lattice in crystal frame

### DIFF
--- a/array_family/flex_ext.py
+++ b/array_family/flex_ext.py
@@ -1176,11 +1176,6 @@ Found %s"""
             else:
                 sel_expt = self["id"] == i
 
-            u_mat = matrix.sqr((1, 0, 0, 0, 1, 0, 0, 0, 1))
-
-            if expt.crystal and crystal_frame:
-                u_mat = matrix.sqr(expt.crystal.get_U())
-
             for i_panel in range(len(expt.detector)):
                 sel = sel_expt & (panel_numbers == i_panel)
                 if calculated:
@@ -1198,7 +1193,10 @@ Found %s"""
                         expt.goniometer.get_setting_rotation()
                     )
                     rotation_axis = expt.goniometer.get_rotation_axis_datum()
-                    fixed_rotation = matrix.sqr(expt.goniometer.get_fixed_rotation())
+                    sample_rotation = matrix.sqr(expt.goniometer.get_fixed_rotation())
+                    if expt.crystal and crystal_frame:
+                        sample_rotation *= matrix.sqr(expt.crystal.get_U())
+
                     self["rlp"].set_selected(sel, tuple(setting_rotation.inverse()) * S)
                     self["rlp"].set_selected(
                         sel,
@@ -1207,9 +1205,7 @@ Found %s"""
                         .rotate_around_origin(rotation_axis, -rot_angle),
                     )
                     self["rlp"].set_selected(
-                        sel,
-                        tuple((fixed_rotation * u_mat).inverse())
-                        * self["rlp"].select(sel),
+                        sel, tuple(sample_rotation.inverse()) * self["rlp"].select(sel),
                     )
                 else:
                     self["rlp"].set_selected(sel, S)

--- a/newsfragments/1259.feature
+++ b/newsfragments/1259.feature
@@ -1,0 +1,1 @@
+Add an option to show lattice(s) in the crystal rather than laboratory frame.

--- a/newsfragments/1259.feature
+++ b/newsfragments/1259.feature
@@ -1,1 +1,1 @@
-Add an option to show lattice(s) in the crystal rather than laboratory frame.
+dials.reciprocal_lattice_viewer: Add an option to show lattice(s) in the crystal rather than laboratory frame.

--- a/util/reciprocal_lattice/__init__.py
+++ b/util/reciprocal_lattice/__init__.py
@@ -90,6 +90,16 @@ class Render3d(object):
                 for c in crystals
             ]
             self.viewer.set_reciprocal_lattice_vectors(vecs)
+            vecs = [
+                [
+                    matrix.col(l)
+                    for l in (100 * matrix.sqr(c.get_B()))
+                    .transpose()
+                    .as_list_of_lists()
+                ]
+                for c in crystals
+            ]
+            self.viewer.set_reciprocal_crystal_vectors(vecs)
         self.map_points_to_reciprocal_space()
         self.set_points()
 

--- a/util/reciprocal_lattice/__init__.py
+++ b/util/reciprocal_lattice/__init__.py
@@ -13,6 +13,9 @@ phil_scope = libtbx.phil.parse(
 reverse_phi = False
   .type = bool
   .optional = True
+crystal_frame = False
+  .type = bool
+  .optional = True
 beam_centre = None
   .type = floats(size=2)
   .help = "Fast, slow beam centre coordinates (mm)."
@@ -106,7 +109,9 @@ class Render3d(object):
                 )
 
         self.reflections.map_centroids_to_reciprocal_space(
-            experiments, calculated=calculated
+            experiments,
+            calculated=calculated,
+            crystal_frame=self.settings.crystal_frame,
         )
 
     def set_points(self):

--- a/util/reciprocal_lattice/viewer.py
+++ b/util/reciprocal_lattice/viewer.py
@@ -299,11 +299,20 @@ class SettingsWindow(wxtbx.utils.SettingsPanel):
             setting="show_reciprocal_cell", label="Show reciprocal cell"
         )
         self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
+
         self.reverse_phi_ctrl = self.create_controls(
             setting="reverse_phi", label="Invert rotation axis"
         )[0]
         self.panel_sizer.Add(self.reverse_phi_ctrl, 0, wx.ALL, 5)
+
         self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.reverse_phi_ctrl)
+
+        self.crystal_frame_ctrl = self.create_controls(
+            setting="crystal_frame", label="Show in crystal frame"
+        )[0]
+        self.panel_sizer.Add(self.crystal_frame_ctrl, 0, wx.ALL, 5)
+
+        self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.crystal_frame_ctrl)
 
         self.beam_fast_ctrl = floatspin.FloatSpin(parent=self, increment=0.01, digits=2)
         self.beam_fast_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
@@ -406,6 +415,7 @@ class SettingsWindow(wxtbx.utils.SettingsPanel):
             self.beam_slow_ctrl.GetValue(),
         )
         self.settings.reverse_phi = self.reverse_phi_ctrl.GetValue()
+        self.settings.crystal_frame = self.crystal_frame_ctrl.GetValue()
         self.settings.marker_size = self.marker_size_ctrl.GetValue()
         for i, display in enumerate(("all", "indexed", "unindexed", "integrated")):
             if self.btn.values[i]:

--- a/util/reciprocal_lattice/viewer.py
+++ b/util/reciprocal_lattice/viewer.py
@@ -307,9 +307,13 @@ class SettingsWindow(wxtbx.utils.SettingsPanel):
 
         self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.reverse_phi_ctrl)
 
+        self.crystal_frame_tooltip = wx.ToolTip(
+            "Show the reciprocal lattice(s) in the crystal rather than the laboratory frame"
+        )
         self.crystal_frame_ctrl = self.create_controls(
             setting="crystal_frame", label="Show in crystal frame"
         )[0]
+        self.crystal_frame_ctrl.SetToolTip(self.crystal_frame_tooltip)
         self.panel_sizer.Add(self.crystal_frame_ctrl, 0, wx.ALL, 5)
 
         self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.crystal_frame_ctrl)

--- a/util/reciprocal_lattice/viewer.py
+++ b/util/reciprocal_lattice/viewer.py
@@ -524,22 +524,21 @@ class RLVWindow(wx_viewer.show_points_and_lines_mixin):
             self.draw_axis(self.beam_vector, "beam")
 
         if self.settings.show_reciprocal_cell:
+            vectors = None
             if self.settings.crystal_frame and self.recip_crystal_vectors:
-                for i, axes in enumerate(self.recip_crystal_vectors):
-                    if self.settings.experiment_ids:
-                        if i not in self.settings.experiment_ids:
-                            continue
-                    j = (i + 1) % self.palette.size()
-                    color = self.palette[j]
-                    self.draw_cell(axes, color)
+                vectors = self.recip_crystal_vectors
             elif self.recip_latt_vectors:
-                for i, axes in enumerate(self.recip_latt_vectors):
+                vectors = self.recip_latt_vectors
+
+            if vectors:
+                for i, axes in enumerate(vectors):
                     if self.settings.experiment_ids:
                         if i not in self.settings.experiment_ids:
                             continue
                     j = (i + 1) % self.palette.size()
                     color = self.palette[j]
                     self.draw_cell(axes, color)
+
         self.GetParent().update_statusbar()
 
     def draw_axis(self, axis, label):

--- a/util/reciprocal_lattice/viewer.py
+++ b/util/reciprocal_lattice/viewer.py
@@ -447,6 +447,7 @@ class RLVWindow(wx_viewer.show_points_and_lines_mixin):
         self.rotation_axis = None
         self.beam_vector = None
         self.recip_latt_vectors = None
+        self.recip_crystal_vectors = None
         self.flag_show_minimum_covering_sphere = False
         self.minimum_covering_sphere = None
         self.field_of_view_y = 0.001
@@ -490,6 +491,9 @@ class RLVWindow(wx_viewer.show_points_and_lines_mixin):
     def set_reciprocal_lattice_vectors(self, vectors_per_crystal):
         self.recip_latt_vectors = vectors_per_crystal
 
+    def set_reciprocal_crystal_vectors(self, vectors_per_crystal):
+        self.recip_crystal_vectors = vectors_per_crystal
+
     # --- user input and settings
     def update_settings(self):
         self.points_display_list = None
@@ -514,14 +518,24 @@ class RLVWindow(wx_viewer.show_points_and_lines_mixin):
             self.draw_axis(self.rotation_axis, "phi")
         if self.beam_vector is not None and self.settings.show_beam_vector:
             self.draw_axis(self.beam_vector, "beam")
-        if self.recip_latt_vectors is not None and self.settings.show_reciprocal_cell:
-            for i, axes in enumerate(self.recip_latt_vectors):
-                if self.settings.experiment_ids:
-                    if i not in self.settings.experiment_ids:
-                        continue
-                j = (i + 1) % self.palette.size()
-                color = self.palette[j]
-                self.draw_cell(axes, color)
+
+        if self.settings.show_reciprocal_cell:
+            if self.settings.crystal_frame and self.recip_crystal_vectors:
+                for i, axes in enumerate(self.recip_crystal_vectors):
+                    if self.settings.experiment_ids:
+                        if i not in self.settings.experiment_ids:
+                            continue
+                    j = (i + 1) % self.palette.size()
+                    color = self.palette[j]
+                    self.draw_cell(axes, color)
+            elif self.recip_latt_vectors:
+                for i, axes in enumerate(self.recip_latt_vectors):
+                    if self.settings.experiment_ids:
+                        if i not in self.settings.experiment_ids:
+                            continue
+                    j = (i + 1) % self.palette.size()
+                    color = self.palette[j]
+                    self.draw_cell(axes, color)
         self.GetParent().update_statusbar()
 
     def draw_axis(self, axis, label):

--- a/util/reciprocal_lattice/viewer.py
+++ b/util/reciprocal_lattice/viewer.py
@@ -524,11 +524,10 @@ class RLVWindow(wx_viewer.show_points_and_lines_mixin):
             self.draw_axis(self.beam_vector, "beam")
 
         if self.settings.show_reciprocal_cell:
-            vectors = None
-            if self.settings.crystal_frame and self.recip_crystal_vectors:
+            # if we don't have one sort of vector we don't have the other either
+            vectors = self.recip_latt_vectors
+            if self.settings.crystal_frame:
                 vectors = self.recip_crystal_vectors
-            elif self.recip_latt_vectors:
-                vectors = self.recip_latt_vectors
 
             if vectors:
                 for i, axes in enumerate(vectors):


### PR DESCRIPTION
Contributes to https://github.com/dials/dials/issues/279

Includes "Crystal frame" toggle, which shows the reciprocal lattice points and reciprocal lattice vectors in the crystal frame i.e. `B*h` rather than `U*B*h`

Illustrations:

Before:
![Screenshot 2020-05-12 at 09 18 20](https://user-images.githubusercontent.com/1241716/81659767-ed136100-9431-11ea-860c-99805701ea50.png)

After:
![Screenshot 2020-05-12 at 09 18 42](https://user-images.githubusercontent.com/1241716/81659831-ff8d9a80-9431-11ea-960d-f851c586b843.png)

You have to zoom in closely to see differences between reciprocal lattices, but they _are_ there 🙂
