### PR TITLE
Make some tools more robust to few reflections

### DIFF
--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -217,14 +217,25 @@ def merge_and_truncate(params, experiments, reflections):
 
     if params.reporting.wilson_stats:
         if not intensities.space_group().is_centric():
-            wilson_scaling = data_statistics.wilson_scaling(
-                miller_array=intensities, n_residues=params.n_residues
-            )  # XXX default n_residues?
-            # Divert output through logger - do with StringIO rather than
-            # info_handle else get way too much whitespace in output.
-            out = StringIO()
-            wilson_scaling.show(out=out)
-            logger.info(out.getvalue())
+            try:
+                wilson_scaling = data_statistics.wilson_scaling(
+                    miller_array=intensities, n_residues=params.n_residues
+                )  # XXX default n_residues?
+            except (IndexError, RuntimeError) as e:
+                logger.error(
+                    "\n"
+                    "Error encountered during Wilson statistics calculation:\n"
+                    "Perhaps there are too few unique reflections.\n"
+                    "%s",
+                    e,
+                    exc_info=True,
+                )
+            else:
+                # Divert output through logger - do with StringIO rather than
+                # info_handle else get way too much whitespace in output.
+                out = StringIO()
+                wilson_scaling.show(out=out)
+                logger.info(out.getvalue())
 
     # Apply wilson B to give absolute scale?
 

--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -248,9 +248,9 @@ def merge_and_truncate(params, experiments, reflections):
                 params.merging.use_internal_variance,
             )
         except DialsMergingStatisticsError as e:
-            logger.info(e)
+            logger.error(e, exc_info=True)
         else:
-            if params.merging.anomalous:
+            if params.merging.anomalous and anom_stats:
                 logger.info(make_merging_statistics_summary(anom_stats))
             else:
                 logger.info(make_merging_statistics_summary(stats))

--- a/algorithms/scaling/Ih_table.py
+++ b/algorithms/scaling/Ih_table.py
@@ -676,7 +676,8 @@ Not all rows of h_index_matrix appear to be filled in IhTableBlock setup."""
         relative_tolerance = 1e-6
         d_star_sq_max += span * relative_tolerance
         d_star_sq_min -= span * relative_tolerance
-        step = (d_star_sq_max - d_star_sq_min) / n_resolution_bins
+        # Avoid a zero-size step that would otherwise anger the d_star_sq_step binner.
+        step = max((d_star_sq_max - d_star_sq_min) / n_resolution_bins, 0.004)
 
         self.binner = ma.setup_binner_d_star_sq_step(
             auto_binning=False,

--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -209,6 +209,8 @@ class ScalingAlgorithm(Subject):
         start_time = time.time()
         self.scale()
         self.remove_bad_data()
+        if not self.experiments:
+            raise ValueError("All data sets have been rejected as bad.")
         self.scaled_miller_array = scaled_data_as_miller_array(
             self.reflections,
             self.experiments,
@@ -264,11 +266,9 @@ class ScalingAlgorithm(Subject):
         if removed_ids:
             logger.info("deleting removed datasets from memory: %s", removed_ids)
             expids = list(self.experiments.identifiers())
-            locs_in_list = []
-            for id_ in removed_ids:
-                locs_in_list.append(expids.index(id_))
+            locs_in_list = [expids.index(expid) for expid in removed_ids]
             self.experiments, self.reflections = select_datasets_on_ids(
-                self.experiments, self.reflections, exclude_datasets=removed_ids
+                self.experiments, self.reflections, exclude_datasets=locs_in_list
             )
         # also remove negative scales (or scales below 0.001)
         n = 0

--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -291,7 +291,7 @@ class ScalingAlgorithm(Subject):
                 self.params.output.use_internal_variance,
             )
         except DialsMergingStatisticsError as e:
-            logger.info(e)
+            logger.warning(e, exc_info=True)
 
     def finish(self):
         """Save the experiments json and scaled pickle file."""

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 """
 Test the command line script dials.scale, for successful completion.
 """
@@ -17,6 +19,7 @@ from dxtbx.model import Crystal, Scan, Beam, Goniometer, Detector, Experiment
 from dials.array_family import flex
 from dials.util.options import OptionParser
 from dials.algorithms.scaling.algorithm import ScalingAlgorithm, prepare_input
+from dials.command_line import merge, report, scale
 
 
 def run_one_scaling(working_directory, argument_list):
@@ -491,11 +494,7 @@ def test_scale_and_filter_image_group_mode(dials_data, tmpdir):
 def test_scale_dose_decay_model(dials_data, tmpdir):
     """Test the scale and filter command line program."""
     location = dials_data("multi_crystal_proteinase_k")
-    command = [
-        "dials.scale",
-        "d_min=2.0",
-        "model=dose_decay",
-    ]
+    command = ["dials.scale", "d_min=2.0", "model=dose_decay"]
     for i in [1, 2, 3, 4, 5, 7, 10]:
         command.append(location.join("experiments_" + str(i) + ".json").strpath)
         command.append(location.join("reflections_" + str(i) + ".pickle").strpath)
@@ -765,3 +764,51 @@ def test_scale_cross_validate(dials_data, tmpdir, mode, parameter, parameter_val
     command = ["dials.scale", refl, expt] + extra_args
     result = procrunner.run(command, working_directory=tmpdir)
     assert not result.returncode and not result.stderr
+
+
+def test_few_reflections(dials_data):
+    u"""
+    Test that dials.symmetry does something sensible if given few reflections.
+
+    Use some example integrated data generated from two ten-image 1° sweeps.  These
+    each contain a few dozen integrated reflections.
+
+    Also test the behaviour of dials.merge and dials.report on the output.
+
+    By suppressing the output from dials.scale and dials.report, we obviate the need to
+    run in a temporary directory.
+
+    Args:
+        dials_data: DIALS custom Pytest fixture for access to test data.
+    """
+    # Get the input experiment lists and reflection tables.
+    data_dir = dials_data("l_cysteine_dials_output")
+    experiments = ExperimentList.from_file(data_dir / "11_integrated.expt")
+    experiments.extend(ExperimentList.from_file(data_dir / "23_integrated.expt"))
+    refls = "11_integrated.refl", "23_integrated.refl"
+    reflections = [flex.reflection_table.from_file(data_dir / refl) for refl in refls]
+
+    # Get and use the default parameters for dials.scale, suppressing HTML output.
+    scale_params = scale.phil_scope.fetch(
+        source=phil.parse("output.html=None")
+    ).extract()
+    # Does what it says on the tin.  Run scaling.
+    scaled_expt, scaled_refl = scale.run_scaling(scale_params, experiments, reflections)
+
+    # Get and use the default parameters for dials.merge.
+    merge_params = merge.phil_scope.fetch(source=phil.parse("")).extract()
+    # Run dials.merge on the scaling output.
+    merge.merge_data_to_mtz(merge_params, scaled_expt, [scaled_refl])
+
+    # Get and use the default parameters for dials.report, suppressing HTML output.
+    report_params = report.phil_scope.fetch(
+        source=phil.parse("output.html=None")
+    ).extract()
+    # Get an Analyser object, which does the dials.report stuff.
+    analyse = report.Analyser(
+        report_params,
+        grid_size=report_params.grid_size,
+        centroid_diff_max=report_params.centroid_diff_max,
+    )
+    # Run dials.report on scaling output.
+    analyse(scaled_refl, scaled_expt)

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -65,7 +65,7 @@ merging {
 reporting {
     wilson_stats = True
         .type = bool
-        .help = "Option to turn off reporting of wilson statistics"
+        .help = "Option to turn off reporting of Wilson statistics"
     merging_stats = True
         .type = bool
         .help = "Option to turn off reporting of merging statistics."

--- a/newsfragments/1263.bugfix
+++ b/newsfragments/1263.bugfix
@@ -1,0 +1,1 @@
+Make some of the DIALS tools furthest downstream (``dials.scale``, ``dials.symmetry``, ``dials.merge`` and ``dials.report``) more robust in the case of very few reflections.

--- a/report/plots.py
+++ b/report/plots.py
@@ -725,10 +725,11 @@ class ResolutionPlotsAndStats(ResolutionPlotterMixin):
         completeness_bins = [
             bin_stats.completeness for bin_stats in self.dataset_statistics.bins
         ]
-        anom_completeness_bins = [
-            bin_stats.anom_completeness
-            for bin_stats in self.anomalous_dataset_statistics.bins
-        ]
+        if self.anomalous_dataset_statistics:
+            anom_completeness_bins = [
+                bin_stats.anom_completeness
+                for bin_stats in self.anomalous_dataset_statistics.bins
+            ]
 
         return {
             "completeness": {
@@ -746,7 +747,7 @@ class ResolutionPlotsAndStats(ResolutionPlotterMixin):
                             "type": "scatter",
                             "name": "Anomalous completeness",
                         }
-                        if not self.is_centric
+                        if not self.is_centric and self.anomalous_dataset_statistics
                         else {}
                     ),
                 ],
@@ -767,10 +768,11 @@ class ResolutionPlotsAndStats(ResolutionPlotterMixin):
         multiplicity_bins = [
             bin_stats.mean_redundancy for bin_stats in self.dataset_statistics.bins
         ]
-        anom_multiplicity_bins = [
-            bin_stats.mean_redundancy
-            for bin_stats in self.anomalous_dataset_statistics.bins
-        ]
+        if self.anomalous_dataset_statistics:
+            anom_multiplicity_bins = [
+                bin_stats.mean_redundancy
+                for bin_stats in self.anomalous_dataset_statistics.bins
+            ]
 
         return {
             "multiplicity_vs_resolution": {
@@ -788,7 +790,7 @@ class ResolutionPlotsAndStats(ResolutionPlotterMixin):
                             "type": "scatter",
                             "name": "Anomalous multiplicity",
                         }
-                        if not self.is_centric
+                        if not self.is_centric and self.anomalous_dataset_statistics
                         else {}
                     ),
                 ],

--- a/test/command_line/test_symmetry.py
+++ b/test/command_line/test_symmetry.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 from __future__ import absolute_import, division, print_function
 
 import os
@@ -24,6 +26,7 @@ from dials.command_line.symmetry import (
 )
 from dials.util.multi_dataset_handling import assign_unique_identifiers
 from dials.util.exclude_images import exclude_image_ranges_from_scans
+from dials.util.phil import parse
 
 
 def test_symmetry_laue_only(dials_data, tmpdir):
@@ -436,3 +439,27 @@ def test_eliminate_sys_absent():
         (-25, -3, -3),
         (-42, -8, -2),
     ]
+
+
+def test_few_reflections(dials_data, run_in_tmpdir):
+    u"""
+    Test that dials.symmetry does something sensible if given few reflections.
+
+    Use some example integrated data generated from a ten-image 1° sweep.  These
+    contain a few dozen integrated reflections.
+
+    Args:
+        dials_data: DIALS custom Pytest fixture for access to test data.
+        run_in_tmpdir: DIALS custom Pytest fixture to run this test in a temporary
+                       directory.
+    """
+    # Get and use the default parameters for dials.symmetry.
+    params = symmetry.phil_scope.fetch(source=parse("")).extract()
+
+    # Use the integrated data from the first ten images of the first sweep.
+    data_dir = dials_data("l_cysteine_dials_output")
+    experiments = ExperimentList.from_file(data_dir / "11_integrated.expt")
+    reflections = [flex.reflection_table.from_file(data_dir / "11_integrated.refl")]
+
+    # Run dials.symmetry on the above data files.
+    symmetry.symmetry(experiments, reflections, params)


### PR DESCRIPTION
Some of the DIALS tools furthest downstream, such as `dials.scale`, `dials.symmetry` and `dials.merge`, rely on receiving a sufficient number of unique reflections to perform their calculations.  Existing checks that the input is valid are not explicit and are insufficient to catch all failure modes.  Changes here attempt to rationalise some behaviour in cases of very few input reflections, as from a very narrow wedge of a rotation data set.

Details of changes:
 * If `dials.algorithms.scaling.ScalingAlgorithm.remove_bad_data` results in no remaining data, raise an exception.
 * Fix the intended behaviour of `remove_bad_data` to correctly handle experiment UID strings.
 * In `dials.algorithms.scaling.Ih_table.IhTableBlock.setup_binner`, be less prescriptive in the choice of binner parameters in the case of few reflections.
 * If `modules.dials.algorithms.merging.merge.merge_and_truncate` does not receive enough reflections to calculate Wilson statistics for log output, catch the resulting exception and log an error-level message instead.
 * In the existing check for a similar failure to calculate and log the merging statistics, increase the logging level of the resuting message to error, for consistency.
 * In `dials.algorithms.symmetry.symmetry_base._normalise`, if an exception is encountered when trying to perform the normalisation, rather than raise a cryptic exception, simply log a warning and default to un-normalised intensities.
 * Correct a typo in `modules.dials.command_line.merge.phil_scope`.