### PR TITLE
Remove cache from expt/refl phil parsers

### DIFF
--- a/test/test_phil.py
+++ b/test/test_phil.py
@@ -39,12 +39,3 @@ def test(ExperimentListFactory, dials_data):
     assert isinstance(params.input.reflections2.data, flex.reflection_table)
     # Check we had the correct calls made
     assert ExperimentListFactory.from_json_file.call_args[0] == (experiments_path,)
-
-    # We now need to clear the phil converter caches
-    # as they are polluted by MagicMock() objects
-    for conv in (
-        dials.util.phil.ExperimentListConverters,
-        dials.util.phil.ReflectionTableConverters,
-        dials.util.phil.ReflectionTableSelectorConverters,
-    ):
-        conv.cache.clear()

--- a/util/options.py
+++ b/util/options.py
@@ -282,9 +282,7 @@ class Importer(object):
         )
         if len(experiments) > 0:
             filename = "<image files>"
-            obj = FilenameDataWrapper(filename, experiments)
-            ExperimentListConverters.cache[filename] = obj
-            self.experiments.append(obj)
+            self.experiments.append(FilenameDataWrapper(filename, experiments))
         return unhandled
 
     def try_read_experiments(self, args, check_format, verbose):

--- a/util/options.py
+++ b/util/options.py
@@ -283,9 +283,10 @@ class Importer(object):
             format_kwargs=format_kwargs,
             load_models=load_models,
         )
-        if len(experiments) > 0:
-            filename = "<image files>"
-            self.experiments.append(FilenameDataWrapper(filename, experiments))
+        if experiments:
+            self.experiments.append(
+                FilenameDataWrapper(filename="<image files>", data=experiments)
+            )
         return unhandled
 
     def try_read_experiments(self, args, check_format, verbose):

--- a/util/phil.py
+++ b/util/phil.py
@@ -28,10 +28,15 @@ class ExperimentListConverters(object):
         s = libtbx.phil.str_from_words(words=words)
         if s is None:
             return None
+        if s == "<image files>":
+            return FilenameDataWrapper(filename=s, data=None)
         if not os.path.exists(s):
             raise Sorry("File %s does not exist" % s)
         return FilenameDataWrapper(
-            s, ExperimentListFactory.from_json_file(s, check_format=self._check_format),
+            filename=s,
+            data=ExperimentListFactory.from_json_file(
+                s, check_format=self._check_format
+            ),
         )
 
     def as_words(self, python_object, master):
@@ -56,7 +61,7 @@ class ReflectionTableConverters(object):
             return None
         if not os.path.exists(s):
             raise Sorry("File %s does not exist" % s)
-        return FilenameDataWrapper(s, flex.reflection_table.from_file(s))
+        return FilenameDataWrapper(filename=s, data=flex.reflection_table.from_file(s))
 
     def as_words(self, python_object, master):
         if python_object is None:

--- a/util/phil.py
+++ b/util/phil.py
@@ -21,8 +21,6 @@ class ExperimentListConverters(object):
 
     phil_type = "experiment_list"
 
-    cache = {}
-
     def __init__(self, check_format=True):
         self._check_format = check_format
 
@@ -34,16 +32,11 @@ class ExperimentListConverters(object):
 
         if s is None:
             return None
-        if s not in self.cache:
-            if not os.path.exists(s):
-                raise Sorry("File %s does not exist" % s)
-            self.cache[s] = FilenameDataWrapper(
-                s,
-                ExperimentListFactory.from_json_file(
-                    s, check_format=self._check_format
-                ),
-            )
-        return self.cache[s]
+        if not os.path.exists(s):
+            raise Sorry("File %s does not exist" % s)
+        return FilenameDataWrapper(
+            s, ExperimentListFactory.from_json_file(s, check_format=self._check_format),
+        )
 
     def from_words(self, words, master):
         return self.from_string(libtbx.phil.str_from_words(words=words))
@@ -61,19 +54,15 @@ class ReflectionTableConverters(object):
 
     phil_type = "reflection_table"
 
-    cache = {}
-
     def __str__(self):
         return self.phil_type
 
     def from_string(self, s):
         if s is None:
             return None
-        if s not in self.cache:
-            if not os.path.exists(s):
-                raise Sorry("File %s does not exist" % s)
-            self.cache[s] = FilenameDataWrapper(s, flex.reflection_table.from_file(s))
-        return self.cache[s]
+        if not os.path.exists(s):
+            raise Sorry("File %s does not exist" % s)
+        return FilenameDataWrapper(s, flex.reflection_table.from_file(s))
 
     def from_words(self, words, master):
         return self.from_string(libtbx.phil.str_from_words(words=words))
@@ -90,8 +79,6 @@ class ReflectionTableSelectorConverters(object):
     """A phil converter for the reflection table selector class."""
 
     phil_type = "reflection_table_selector"
-
-    cache = {}
 
     def __str__(self):
         return self.phil_type


### PR DESCRIPTION
The cache meant that if an experiment list/reflection table was read in once, and then modified, that if it was then re-read in later by another phil parser in the same process that the modified object was returned, rather than the original, unmodified, object which could lead to potentially surprising behaviour.

See https://github.com/xia2/xia2/issues/454