### PR TITLE
In detect blanks, stop if still

### DIFF
--- a/command_line/detect_blanks.py
+++ b/command_line/detect_blanks.py
@@ -233,6 +233,9 @@ def run(args):
 
     imagesets = experiments.imagesets()
 
+    if any(experiment.is_still() for experiment in experiments):
+        sys.exit("dials.detect_blanks can only be used with rotation data")
+
     assert len(imagesets) == 1
     imageset = imagesets[0]
     scan = imageset.get_scan()


### PR DESCRIPTION
Fixes #1250

```
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
The following parameters have been modified:

input {
  experiments = imported.expt
  reflections = strong.refl
}

dials.detect_blanks can only be used with rotation data
```

rather than

```
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
The following parameters have been modified:

input {
  experiments = imported.expt
  reflections = strong.refl
}

Analysis of 916 strong reflections:
Traceback (most recent call last):
  File "/Users/graeme/svn/cctbx/build/../modules/dials/command_line/detect_blanks.py", line 325, in <module>
    run(sys.argv[1:])
  File "/Users/graeme/svn/cctbx/build/../modules/dials/command_line/detect_blanks.py", line 251, in run
    fractional_loss=params.counts_fractional_loss,
  File "/Users/graeme/svn/cctbx/build/../modules/dials/command_line/detect_blanks.py", line 52, in blank_counts_analysis
    n_images_per_step = iceil(phi_step / osc)
ZeroDivisionError: float division by zero
```