### PR TITLE
Reset bad_for_scaling flags in prepare_input

### DIFF
--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -2,6 +2,7 @@
 Definitions of the scaling algorithm.
 """
 from __future__ import absolute_import, division, print_function
+import itertools
 import logging
 import json
 from libtbx import Auto
@@ -94,10 +95,12 @@ def prepare_input(params, experiments, reflections):
 
     #### Assign experiment identifiers.
     experiments, reflections = assign_unique_identifiers(experiments, reflections)
-    ids = flex.size_t()
-    for r in reflections:
-        ids.extend(r.experiment_identifiers().keys())
+    ids = itertools.chain.from_iterable(
+        r.experiment_identifiers().keys() for r in reflections
+    )
     logger.info("\nDataset ids are: %s \n", ",".join(str(i) for i in ids))
+    for r in reflections:
+        r.unset_flags(flex.bool(len(r), True), r.flags.bad_for_scaling)
     reflections, experiments = exclude_image_ranges_for_scaling(
         reflections, experiments, params.exclude_images
     )

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -217,14 +217,27 @@ def test_scale_script_prepare_input():
         True,
         True,
     ]
-    params.cut_data.d_max = 2.25
-    params, _, script_reflections = prepare_input(params, exp, reflections)
+
+    # Ensure that the user_excluded_in_scaling flags are reset before applying any new
+    # cutoffs by re-passing script_reflections to prepare_input
+    params.cut_data.d_min = None
+    params, _, script_reflections = prepare_input(params, exp, script_reflections)
     r = script_reflections[0]
     assert list(r.get_flags(r.flags.user_excluded_in_scaling)) == [
         False,
         False,
+        False,
+        False,
+    ]
+
+    params.cut_data.d_max = 1.25
+    params, _, script_reflections = prepare_input(params, exp, reflections)
+    r = script_reflections[0]
+    assert list(r.get_flags(r.flags.user_excluded_in_scaling)) == [
         True,
         True,
+        False,
+        False,
     ]
 
     params, exp, reflections = generate_test_input(n=1)

--- a/newsfragments/1275.bugfix
+++ b/newsfragments/1275.bugfix
@@ -1,0 +1,1 @@
+Ensure that reflections excluded from scaling in one dials.scale job aren't permanently excluded from any subsequent dials.scale jobs.


### PR DESCRIPTION
This means that bad_for_scaling flags are no longer persistent from
one scaling job to the next, which allows e.g. the user to specify
a higher resolution cut_data.d_min cutoff in subsequent scaling jobs.

Fixes #1275