### PR TITLE
Print stack traces on SIGUSR2

### DIFF
--- a/newsfragments/1277.feature
+++ b/newsfragments/1277.feature
@@ -1,0 +1,1 @@
+On posix systems you can print a stack trace from DIALS commands by sending a SIGUSR2 signal to the process

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -117,6 +117,10 @@ def show_mail_on_error():
         import faulthandler
 
         faulthandler.enable()
+        with contextlib.suppress(AttributeError, ImportError):
+            import signal
+
+            faulthandler.register(signal.SIGUSR2, all_threads=True)
     try:
         yield
     except Exception as e:


### PR DESCRIPTION
This feels like a useful addition? (Inspired by ["Python debugging tools"](https://blog.ionelmc.ro/2013/06/05/python-debugging-tools/#quick-stacktrace-on-a-signal-faulthandler))

Terminal 1:
```bash
dials.find_spots nproc=2 imported.expt
```
Terminal 2:
```bash
kill -SIGUSR2 $PARENT_PROCESS_PID
```
Terminal 1:
```
(...)
Found 550 strong pixels on image 37
Found 546 strong pixels on image 38
Found 527 strong pixels on image 39
Found 536 strong pixels on image 40
Current thread 0x00007f74af203740 (most recent call first):
  File "/scratch/wra62962/files/dials/conda_base/lib/python3.6/selectors.py", line 376 in select
  File "/scratch/wra62962/files/dials/conda_base/lib/python3.6/multiprocessing/connection.py", line 911 in wait
  File "/scratch/wra62962/files/dials/conda_base/lib/python3.6/multiprocessing/connection.py", line 414 in _poll
  File "/scratch/wra62962/files/dials/conda_base/lib/python3.6/multiprocessing/connection.py", line 257 in poll
  File "/scratch/wra62962/files/dials/conda_base/lib/python3.6/multiprocessing/queues.py", line 104 in get
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/scheduling/job_scheduler.py", line 200 in poll
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/scheduling/job_scheduler.py", line 134 in results
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/scheduling/parallel_for.py", line 271 in process_next_one
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/scheduling/parallel_for.py", line 246 in __next__
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/easy_mp.py", line 633 in parallel_map
  File "/scratch/wra62962/files/dials/modules/dials/util/mp.py", line 84 in __call__
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/scheduling/mainthread.py", line 100 in poll
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/scheduling/mainthread.py", line 50 in results
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/scheduling/parallel_for.py", line 271 in process_next_one
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/scheduling/parallel_for.py", line 246 in __next__
  File "/scratch/wra62962/files/dials/modules/cctbx_project/libtbx/easy_mp.py", line 633 in parallel_map
  File "/scratch/wra62962/files/dials/modules/dials/util/mp.py", line 46 in parallel_map
  File "/scratch/wra62962/files/dials/modules/dials/util/mp.py", line 154 in multi_node_parallel_map
  File "/scratch/wra62962/files/dials/modules/dials/util/mp.py", line 182 in batch_multi_node_parallel_map
  File "/scratch/wra62962/files/dials/modules/dials/algorithms/spot_finding/finder.py", line 567 in _find_spots
  File "/scratch/wra62962/files/dials/modules/dials/algorithms/spot_finding/finder.py", line 463 in __call__
  File "/scratch/wra62962/files/dials/modules/dials/algorithms/spot_finding/finder.py", line 868 in _find_spots_in_imageset
  File "/scratch/wra62962/files/dials/modules/dials/algorithms/spot_finding/finder.py", line 758 in __call__
  File "/scratch/wra62962/files/dials/modules/dials/array_family/flex_ext.py", line 173 in from_observations
  File "/scratch/wra62962/files/dials/build/../modules/dials/command_line/find_spots.py", line 154 in run
  File "/scratch/wra62962/files/dials/build/../modules/dials/command_line/find_spots.py", line 232 in <module>
Found 600 strong pixels on image 41
Found 677 strong pixels on image 42
(...)
```
