### PR TITLE
export_mtz: don't change basis to reference setting

### DIFF
--- a/newsfragments/1279.bugfix
+++ b/newsfragments/1279.bugfix
@@ -1,0 +1,1 @@
+Bug fix for dials.export format=mtz when given input in non-reference setting (e.g. I2, or primitive setting of a centred cell). Previously the batches, miller indices and overall mtz space group and unit cell were inconsistent.

--- a/test/command_line/test_export.py
+++ b/test/command_line/test_export.py
@@ -8,9 +8,11 @@ import pytest
 from cctbx import uctbx
 from dials.array_family import flex
 from dials.util.multi_dataset_handling import assign_unique_identifiers
+from dxtbx.model import ExperimentList
 from dxtbx.serialize.load import _decode_dict
 from dxtbx.serialize import load
 from iotbx import mtz
+
 
 # Tests used to check for h5py
 # May need to add this again if lack of this check causes issues.
@@ -195,6 +197,39 @@ def test_mtz_multi_wavelength(dials_data, run_in_tmpdir):
             n_batches.append(dataset.n_batches())
     assert n_batches == [0, 25, 25]  # base, dataset1, dataset2
     assert wavelengths == [0, 0.5, 1.0]  # base, dataset1, dataset2
+
+
+def test_mtz_primitive_cell(dials_data):
+    scaled_expt = dials_data("insulin_processed") / "scaled.expt"
+    scaled_refl = dials_data("insulin_processed") / "scaled.refl"
+
+    # First reindex to the primitive setting
+    expts = ExperimentList.from_file(scaled_expt.strpath)
+    cs = expts[0].crystal.get_crystal_symmetry()
+    cb_op = cs.change_of_basis_op_to_primitive_setting()
+    procrunner.run(
+        [
+            "dials.reindex",
+            scaled_expt.strpath,
+            scaled_refl.strpath,
+            f'change_of_basis_op="{cb_op}"',
+        ]
+    )
+
+    # Now export the reindexed experiments/reflections
+    procrunner.run(["dials.export", "reindexed.expt", "reindexed.refl"])
+
+    mtz_obj = mtz.object("scaled.mtz")
+    assert mtz_obj.space_group() == expts[0].crystal.get_space_group()
+    cs_primitive = cs.change_basis(cb_op)
+    refl = flex.reflection_table.from_file(scaled_refl.strpath)
+    refl = refl.select(~refl.get_flags(refl.flags.bad_for_scaling, all=False))
+    for ma in mtz_obj.as_miller_arrays():
+        print(ma.crystal_symmetry(), cs_primitive)
+        assert ma.crystal_symmetry().is_similar_symmetry(cs_primitive)
+        assert ma.d_max_min() == pytest.approx(
+            (flex.max(refl["d"]), flex.min(refl["d"]))
+        )
 
 
 @pytest.mark.parametrize("hklout", [None, "my.cif"])

--- a/test/command_line/test_export.py
+++ b/test/command_line/test_export.py
@@ -212,7 +212,7 @@ def test_mtz_primitive_cell(dials_data):
             "dials.reindex",
             scaled_expt.strpath,
             scaled_refl.strpath,
-            f'change_of_basis_op="{cb_op}"',
+            'change_of_basis_op="%s"' % cb_op,
         ]
     )
 

--- a/util/export_mtz.py
+++ b/util/export_mtz.py
@@ -301,7 +301,7 @@ class UnmergedMTZWriter(MTZWriterBase):
             )
 
         self.mtz_file.replace_original_index_miller_indices(
-            integrated_data["miller_index_rebase"]
+            integrated_data["miller_index"]
         )
 
         dataset.add_column("BATCH", type_table["BATCH"]).set_values(
@@ -527,17 +527,6 @@ def export_mtz(integrated_data, experiment_list, params):
         image_range = image_ranges[loc]
         reflections = assign_batches_to_reflections([reflections], [batch_offset])[0]
         experiment.data = dict(reflections)
-
-        # Do any crystal transformations for the experiment
-        cb_op_to_ref = (
-            experiment.crystal.get_space_group()
-            .info()
-            .change_of_basis_op_to_reference_setting()
-        )
-        experiment.crystal = experiment.crystal.change_basis(cb_op_to_ref)
-        experiment.data["miller_index_rebase"] = cb_op_to_ref.apply(
-            experiment.data["miller_index"]
-        )
 
         s0n = matrix.col(experiment.beam.get_s0()).normalize().elems
         logger.debug("Beam vector: %.4f %.4f %.4f" % s0n)


### PR DESCRIPTION
This can lead to inconsistencies between the batches, miller indices and the overall mtz space group and unit cell.

Fixes #1278