### PR TITLE
Fix reciprocal lattice viewer of multi-sweep data

### DIFF
--- a/command_line/reciprocal_lattice_viewer.py
+++ b/command_line/reciprocal_lattice_viewer.py
@@ -52,7 +52,6 @@ def run(args):
                 reflections[0].extend(reflections[i])
     elif "imageset_id" not in reflections[0]:
         reflections[0]["imageset_id"] = reflections[0]["id"]
-        reflections[0]["id"] = flex.int(reflections[0].size(), -1)
 
     reflections = reflections[0]
 

--- a/newsfragments/1284.bugfix
+++ b/newsfragments/1284.bugfix
@@ -1,0 +1,1 @@
+dials.reciprocal_lattice_viewer: fix multiple experiment view for integrated data


### PR DESCRIPTION
In loading multiple experiments worth of reflections, don't rewrite id as -1

Fixes #1283