### PR TITLE
New dials.missing_reflections command

### DIFF
--- a/command_line/missing_reflections.py
+++ b/command_line/missing_reflections.py
@@ -1,0 +1,114 @@
+"""
+Identify connected regions of missing reflections in the asymmetric unit.
+
+This is achieved by first generating the complete set of possible miller indices,
+then performing connected components analysis on a graph of nearest neighbours in
+the list of missing reflections.
+
+Examples::
+
+  dials.missing_reflections integrated.expt integrated.refl
+
+  dials.missing_reflections scaled.expt scaled.refl min_component_size=10
+"""
+
+import logging
+import sys
+from typing import List
+
+import libtbx.phil
+from cctbx import uctbx
+
+import dials.util.log
+from dials.report.analysis import scaled_data_as_miller_array
+from dials.util.filter_reflections import filtered_arrays_from_experiments_reflections
+from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util import missing_reflections
+from dials.util.version import dials_version
+
+
+logger = logging.getLogger("dials.missing_reflections")
+
+phil_scope = libtbx.phil.parse(
+    """
+    min_component_size = 0
+      .type = int(value_min=0)
+      .help = "Only show connected regions larger than or equal to this."
+    """
+)
+
+
+def run(args=None, phil=phil_scope):  # type: (List[str], libtbx.phil.scope) -> None
+    usage = "dials.missing_reflections [options] scaled.expt scaled.refl"
+
+    parser = OptionParser(
+        usage=usage,
+        phil=phil,
+        read_reflections=True,
+        read_experiments=True,
+        check_format=False,
+        epilog=__doc__,
+    )
+
+    params, options = parser.parse_args(args=args, show_diff_phil=False)
+
+    # Configure the logging.
+    dials.util.log.config(options.verbose)
+    logger.info(dials_version())
+
+    # Log the difference between the PHIL scope definition and the active PHIL scope,
+    # which will include the parsed user inputs.
+    diff_phil = parser.diff_phil.as_str()
+    if diff_phil:
+        logger.info("The following parameters have been modified:\n%s", diff_phil)
+
+    experiments = flatten_experiments(params.input.experiments)
+    reflections = flatten_reflections(params.input.reflections)
+
+    if not experiments or not reflections:
+        parser.print_help()
+        return
+    if len(reflections) != 1 and len(experiments) != len(reflections):
+        sys.exit("Number of experiments must equal the number of reflection tables")
+
+    from dials.util.multi_dataset_handling import (
+        assign_unique_identifiers,
+        parse_multiple_datasets,
+    )
+
+    reflections = parse_multiple_datasets(reflections)
+    experiments, reflections = assign_unique_identifiers(experiments, reflections)
+
+    if all("inverse_scale_factor" in refl for refl in reflections):
+        # Assume all arrays have been scaled
+        miller_array = scaled_data_as_miller_array(
+            reflections, experiments, anomalous_flag=False
+        )
+    else:
+        # Else get the integrated intensities
+        miller_arrays = filtered_arrays_from_experiments_reflections(
+            experiments, reflections,
+        )
+        miller_array = miller_arrays[0]
+        for ma in miller_arrays[1:]:
+            miller_array = miller_array.concatenate(ma)
+
+    # Get the regions of missing reflections
+    complete_set, unique_ms = missing_reflections.connected_components(miller_array)
+
+    # Print some output for user
+    if len(unique_ms):
+        n_expected = complete_set.size()
+        unique_ms = [ms for ms in unique_ms if ms.size() > params.min_component_size]
+        for ms in unique_ms:
+            d_max, d_min = (uctbx.d_star_sq_as_d(ds2) for ds2 in ms.min_max_d_star_sq())
+            logger.info(
+                f"{ms.size()} reflections ({100 * ms.size() / n_expected:.1f}%): {d_max:.2f}-{d_min:.2f} Å"
+            )
+    else:
+        logger.info("No connected regions of missing reflections identified")
+
+
+if __name__ == "__main__":
+    with dials.util.show_mail_on_error():
+        run()

--- a/command_line/missing_reflections.py
+++ b/command_line/missing_reflections.py
@@ -99,7 +99,7 @@ def run(args=None, phil=phil_scope):  # type: (List[str], libtbx.phil.scope) -> 
     # Print some output for user
     if len(unique_ms):
         n_expected = complete_set.size()
-        unique_ms = [ms for ms in unique_ms if ms.size() > params.min_component_size]
+        unique_ms = [ms for ms in unique_ms if ms.size() >= params.min_component_size]
         for ms in unique_ms:
             d_max, d_min = (uctbx.d_star_sq_as_d(ds2) for ds2 in ms.min_max_d_star_sq())
             logger.info(

--- a/doc/sphinx/documentation/programs/dials_missing_reflections.rst
+++ b/doc/sphinx/documentation/programs/dials_missing_reflections.rst
@@ -1,0 +1,14 @@
+dials.missing_reflections
+=========================
+
+Introduction
+------------
+
+.. python_string:: dials.command_line.missing_reflections.__doc__
+
+Full parameter definitions
+--------------------------
+
+.. phil:: dials.command_line.missing_reflections.phil_scope
+   :expert-level: 2
+   :attributes-level: 2

--- a/doc/sphinx/documentation/programs/index.rst
+++ b/doc/sphinx/documentation/programs/index.rst
@@ -48,6 +48,7 @@ Utilities:
    dials_combine_experiments
    dials_align_crystal
    dials_anvil_correction
+   dials_missing_reflections
 
 Printable command line reference:
 

--- a/newsfragments/1285.feature
+++ b/newsfragments/1285.feature
@@ -1,0 +1,1 @@
+New dials.missing_reflections command to identify connected regions of missing reflections in the asymmetric unit.

--- a/test/command_line/test_missing_reflections.py
+++ b/test/command_line/test_missing_reflections.py
@@ -32,4 +32,5 @@ def test_insulin_scaled(dials_data, capsys):
         ]
     )
     captured = capsys.readouterr()
-    assert "No connected regions of missing reflections identified" in captured.out
+    assert "2925 reflections (20.6%): 1.84-1.45 Å" in captured.out
+    assert "163 reflections (1.1%): 1.57-1.45 Å" in captured.out

--- a/test/command_line/test_missing_reflections.py
+++ b/test/command_line/test_missing_reflections.py
@@ -9,7 +9,10 @@ def test_l_cysteine_4_sweeps_scaled(dials_data, capsys):
         ]
     )
     captured = capsys.readouterr()
-    assert "260 reflections (16.0%): 1.37-0.59 Å" in captured.out
+    assert "Completeness in resolution range: 0.754473" in captured.out
+    assert "Completeness with d_max=infinity: 0.753543" in captured.out
+    assert "# reflections |   % missing | Resolution range (Å)" in captured.out
+    assert "260 |        16   | 1.37-0.59" in captured.out
 
 
 def test_vmxi_proteinase_k_sweeps_integrated(dials_data, capsys):
@@ -20,8 +23,11 @@ def test_vmxi_proteinase_k_sweeps_integrated(dials_data, capsys):
         ]
     )
     captured = capsys.readouterr()
-    assert "6648 reflections (28.2%): 2.51-1.80 Å" in captured.out
-    assert "307 reflections (1.3%): 103.98-1.80 Å" in captured.out
+    assert "Completeness in resolution range: 0.700412" in captured.out
+    assert "Completeness with d_max=infinity: 0.700382" in captured.out
+    assert "# reflections |   % missing | Resolution range (Å)" in captured.out
+    assert "6648 |        28.2 | 2.51-1.80" in captured.out
+    assert "307 |         1.3 | 103.98-1.80" in captured.out
 
 
 def test_insulin_scaled(dials_data, capsys):
@@ -32,5 +38,8 @@ def test_insulin_scaled(dials_data, capsys):
         ]
     )
     captured = capsys.readouterr()
-    assert "2925 reflections (20.6%): 1.84-1.45 Å" in captured.out
-    assert "163 reflections (1.1%): 1.57-1.45 Å" in captured.out
+    assert "Completeness in resolution range: 0.792288" in captured.out
+    assert "Completeness with d_max=infinity: 0.792288" in captured.out
+    assert "# reflections |   % missing | Resolution range (Å)" in captured.out
+    assert "2925 |        20.6 | 1.84-1.45" in captured.out
+    assert "163 |         1.1 | 1.57-1.45" in captured.out

--- a/test/command_line/test_missing_reflections.py
+++ b/test/command_line/test_missing_reflections.py
@@ -1,0 +1,35 @@
+from dials.command_line import missing_reflections
+
+
+def test_l_cysteine_4_sweeps_scaled(dials_data, capsys):
+    missing_reflections.run(
+        args=[
+            (dials_data("l_cysteine_4_sweeps_scaled") / "scaled_30.expt").strpath,
+            (dials_data("l_cysteine_4_sweeps_scaled") / "scaled_30.refl").strpath,
+        ]
+    )
+    captured = capsys.readouterr()
+    assert "260 reflections (16.0%): 1.37-0.59 Å" in captured.out
+
+
+def test_vmxi_proteinase_k_sweeps_integrated(dials_data, capsys):
+    missing_reflections.run(
+        args=[
+            (dials_data("vmxi_proteinase_k_sweeps") / "experiments_0.expt").strpath,
+            (dials_data("vmxi_proteinase_k_sweeps") / "reflections_0.refl").strpath,
+        ]
+    )
+    captured = capsys.readouterr()
+    assert "6648 reflections (28.2%): 2.51-1.80 Å" in captured.out
+    assert "307 reflections (1.3%): 103.98-1.80 Å" in captured.out
+
+
+def test_insulin_scaled(dials_data, capsys):
+    missing_reflections.run(
+        args=[
+            (dials_data("insulin_processed") / "scaled.expt").strpath,
+            (dials_data("insulin_processed") / "scaled.refl").strpath,
+        ]
+    )
+    captured = capsys.readouterr()
+    assert "No connected regions of missing reflections identified" in captured.out

--- a/test/command_line/test_missing_reflections.py
+++ b/test/command_line/test_missing_reflections.py
@@ -38,8 +38,26 @@ def test_insulin_scaled(dials_data, capsys):
         ]
     )
     captured = capsys.readouterr()
+    assert "Resolution range: 55.2195 1.45064" in captured.out
     assert "Completeness in resolution range: 0.792288" in captured.out
     assert "Completeness with d_max=infinity: 0.792288" in captured.out
     assert "# reflections |   % missing | Resolution range (Å)" in captured.out
     assert "2925 |        20.6 | 1.84-1.45" in captured.out
     assert "163 |         1.1 | 1.57-1.45" in captured.out
+
+
+def test_insulin_scaled_d_min_d_max(dials_data, capsys):
+    missing_reflections.run(
+        args=[
+            (dials_data("insulin_processed") / "scaled.expt").strpath,
+            (dials_data("insulin_processed") / "scaled.refl").strpath,
+            "d_min=1.863199",  # inscribed circle
+            "d_max=55",
+            "min_component_size=10",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert "Resolution range: 39.0461 1.86463" in captured.out
+    assert "Completeness in resolution range: 0.996462" in captured.out
+    assert "Completeness with d_max=infinity: 0.996315" in captured.out
+    assert "No connected regions of missing reflections identified" in captured.out

--- a/test/command_line/test_missing_reflections.py
+++ b/test/command_line/test_missing_reflections.py
@@ -20,14 +20,16 @@ def test_vmxi_proteinase_k_sweeps_integrated(dials_data, capsys):
         args=[
             (dials_data("vmxi_proteinase_k_sweeps") / "experiments_0.expt").strpath,
             (dials_data("vmxi_proteinase_k_sweeps") / "reflections_0.refl").strpath,
+            (dials_data("vmxi_proteinase_k_sweeps") / "experiments_1.expt").strpath,
+            (dials_data("vmxi_proteinase_k_sweeps") / "reflections_1.refl").strpath,
         ]
     )
     captured = capsys.readouterr()
-    assert "Completeness in resolution range: 0.700412" in captured.out
-    assert "Completeness with d_max=infinity: 0.700382" in captured.out
+    assert "Completeness in resolution range: 0.781833" in captured.out
+    assert "Completeness with d_max=infinity: 0.7818" in captured.out
     assert "# reflections |   % missing | Resolution range (Å)" in captured.out
-    assert "6648 |        28.2 | 2.51-1.80" in captured.out
-    assert "307 |         1.3 | 103.98-1.80" in captured.out
+    assert "4899 |        20.7 | 2.36-1.80" in captured.out
+    assert "190 |         0.8 | 2.36-1.80" in captured.out
 
 
 def test_insulin_scaled(dials_data, capsys):

--- a/util/missing_reflections.py
+++ b/util/missing_reflections.py
@@ -29,6 +29,12 @@ def connected_components(
         first item in the list will be the complete set of all possible miller indices.
     """
 
+    # Map to primitive setting for centred cells, otherwise true missing reflections
+    # won't be identified as connected as a result of being separated by systematically
+    # absent reflections.
+    cb_op_to_primitive = miller_array.change_of_basis_op_to_primitive_setting()
+    miller_array = miller_array.change_basis(cb_op_to_primitive)
+
     # First generate the missing_set of reflections. We want the full sphere of missing
     # reflections to allow us to find connected regions that cross the boundary of the
     # asu.
@@ -80,7 +86,12 @@ def connected_components(
             unique_ms.append(ms)
             unique_mi.append(mi)
 
+    # Sort connected regions by size
+    unique_ms = sorted(unique_ms, key=lambda ms: ms.size(), reverse=True)
+
+    # Map indices back to input setting
+    cb_op_primitive_inp = cb_op_to_primitive.inverse()
     return (
-        unique.as_non_anomalous_set().complete_set(),
-        sorted(unique_ms, key=lambda ms: ms.size(), reverse=True),
+        unique.as_non_anomalous_set().complete_set().change_basis(cb_op_primitive_inp),
+        [ms.change_basis(cb_op_primitive_inp) for ms in unique_ms],
     )

--- a/util/missing_reflections.py
+++ b/util/missing_reflections.py
@@ -1,0 +1,86 @@
+"""
+Tools for analysis of missing reflections.
+"""
+
+from annlib_ext import AnnAdaptor
+
+from boost_adaptbx import graph
+from boost_adaptbx.graph import connected_component_algorithm as cca
+
+import cctbx.miller
+from dials.array_family import flex
+
+
+def connected_components(
+    miller_array,  # type: cctbx.miller.array
+):  # type: (...) -> [{}]
+    """
+    Identify connected regions of missing reflections in the asymmetric unit.
+
+    This is achieved by first generating the complete set of possible miller indices,
+    then performing connected components analysis on a graph of nearest neighbours in
+    the list of missing reflections.
+
+    Args:
+        miller_array:  The input list of reflections.
+
+    Returns:
+        The list of miller sets for each connected region of missing reflections. The
+        first item in the list will be the complete set of all possible miller indices.
+    """
+
+    # First generate the missing_set of reflections. We want the full sphere of missing
+    # reflections to allow us to find connected regions that cross the boundary of the
+    # asu.
+    unique = miller_array.unique_under_symmetry().map_to_asu()
+    unique = unique.generate_bijvoet_mates()
+    complete_set = unique.complete_set()
+    missing_set = complete_set.lone_set(unique)
+    missing_set = missing_set.expand_to_p1().customized_copy(
+        crystal_symmetry=missing_set.crystal_symmetry()
+    )
+
+    if missing_set.size() == 0:
+        return complete_set, []
+
+    # Now find the nearest neighbours.
+    mi = missing_set.indices().as_vec3_double().as_double()
+    k = 6
+    ann = AnnAdaptor(data=mi, dim=3, k=k)
+    ann.query(mi)
+
+    # Construct the graph of connected missing reflections
+    g = graph.adjacency_list(
+        graph_type="undirected", vertex_type="vector", edge_type="set",
+    )
+    distance_cutoff = 2 ** 0.5
+    for i in range(missing_set.size()):
+        ik = i * k
+        for i_ann in range(k):
+            if ann.distances[ik + i_ann] <= distance_cutoff:
+                j = ann.nn[ik + i_ann]
+                g.add_edge(i, j)
+
+    # Now do the connected components analysis, filtering out lone missing reflections
+    components = [c for c in cca.connected_components(graph=g) if len(c) > 1]
+
+    # Determine the unique miller indices for each component within the asu
+    unique_mi = []
+    unique_ms = []
+    for i, c in enumerate(components):
+        ms = (
+            missing_set.select(flex.size_t(list(c)))
+            .customized_copy(crystal_symmetry=miller_array)
+            .as_non_anomalous_set()
+            .map_to_asu()
+        )
+        ms = ms.unique_under_symmetry()
+        mi = set(ms.indices())
+        if mi not in unique_mi:
+            unique_ms.append(ms)
+            unique_mi.append(mi)
+
+    return (
+        unique.as_non_anomalous_set().complete_set(),
+        sorted(unique_ms, key=lambda ms: ms.size(), reverse=True),
+    )

--- a/util/test_missing_reflections.py
+++ b/util/test_missing_reflections.py
@@ -1,0 +1,27 @@
+from cctbx import miller
+from dxtbx.model import ExperimentList
+from dials.algorithms.spot_prediction import ScanStaticReflectionPredictor
+from dials.util import missing_reflections
+
+
+def test_connected_components(dials_data):
+    experiment = ExperimentList.from_file(
+        dials_data("centroid_test_data").join("experiments.json").strpath
+    )[0]
+
+    experiment.scan.set_image_range((1, 100))
+    image_ranges = [(1, 9), (1, 100), (1, 1000)]
+    expected_ms_sizes = [[755], [242, 14, 10, 5, 2, 2, 2], []]
+    for image_range, expected_sizes in zip(image_ranges, expected_ms_sizes):
+        experiment.scan.set_image_range(image_range)
+        predict = ScanStaticReflectionPredictor(experiment, dmin=3, margin=1)
+        refl = predict.for_ub(experiment.crystal.get_A())
+        miller_set = miller.set(
+            experiment.crystal.get_crystal_symmetry(),
+            refl["miller_index"],
+            anomalous_flag=False,
+        )
+        miller_array = miller_set.d_spacings().resolution_filter(d_min=3)
+        complete_set, unique_ms = missing_reflections.connected_components(miller_array)
+        assert len(unique_ms) == len(expected_sizes)
+        assert [ms.size() for ms in unique_ms] == expected_sizes

--- a/util/test_missing_reflections.py
+++ b/util/test_missing_reflections.py
@@ -9,7 +9,6 @@ def test_connected_components(dials_data):
         dials_data("centroid_test_data").join("experiments.json").strpath
     )[0]
 
-    experiment.scan.set_image_range((1, 100))
     image_ranges = [(1, 9), (1, 100), (1, 1000)]
     expected_ms_sizes = [[755], [242, 14, 10, 5, 2, 2, 2], []]
     for image_range, expected_sizes in zip(image_ranges, expected_ms_sizes):
@@ -25,3 +24,29 @@ def test_connected_components(dials_data):
         complete_set, unique_ms = missing_reflections.connected_components(miller_array)
         assert len(unique_ms) == len(expected_sizes)
         assert [ms.size() for ms in unique_ms] == expected_sizes
+        # Verify that all the indices reported missing are actually missing from the input
+        for ms in unique_ms:
+            assert ms.common_set(miller_array.map_to_asu()).size() == 0
+        assert complete_set.completeness() == 1
+
+
+def test_connected_components_centred_cell(dials_data):
+    experiment = ExperimentList.from_file(
+        dials_data("insulin_processed").join("scaled.expt").strpath, check_format=False
+    )[0]
+
+    experiment.scan.set_image_range((1, 10))
+    predict = ScanStaticReflectionPredictor(experiment, dmin=3, margin=1)
+    refl = predict.for_ub(experiment.crystal.get_A())
+    miller_set = miller.set(
+        experiment.crystal.get_crystal_symmetry(),
+        refl["miller_index"],
+        anomalous_flag=False,
+    )
+    miller_array = miller_set.d_spacings().resolution_filter(d_min=3)
+    complete_set, unique_ms = missing_reflections.connected_components(miller_array)
+    assert [ms.size() for ms in unique_ms] == [581, 32, 29, 6, 3, 3, 3, 2]
+    # Verify that all the indices reported missing are actually missing from the input
+    for ms in unique_ms:
+        assert ms.common_set(miller_array.map_to_asu()).size() == 0
+    assert complete_set.completeness() == 1


### PR DESCRIPTION
Identify connected regions of missing reflections in the asymmetric unit.

This is achieved by first generating the complete set of possible miller indices, then performing connected components analysis on a graph of nearest neighbours in the list of missing reflections.

Examples:
```
$ dials.missing_reflections $(dials.data get -q l_cysteine_4_sweeps_scaled)/scaled_30.{expt,refl}
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
The following parameters have been modified:
input {
  experiments = /Users/rjgildea/software/cctbx_py3/build/dials_data/l_cysteine_4_sweeps_scaled/scaled_30.expt
  reflections = /Users/rjgildea/software/cctbx_py3/build/dials_data/l_cysteine_4_sweeps_scaled/scaled_30.refl
}

260 reflections (16.0%): 1.37-0.59 Å
57 reflections (3.5%): 1.02-0.60 Å
16 reflections (1.0%): 0.61-0.59 Å
6 reflections (0.4%): 0.65-0.60 Å
6 reflections (0.4%): 0.65-0.60 Å
3 reflections (0.2%): 1.95-1.52 Å
3 reflections (0.2%): 1.36-1.19 Å
3 reflections (0.2%): 0.60-0.60 Å
3 reflections (0.2%): 0.61-0.60 Å
3 reflections (0.2%): 0.61-0.60 Å
3 reflections (0.2%): 0.60-0.59 Å
3 reflections (0.2%): 0.61-0.60 Å
2 reflections (0.1%): 8.22-4.11 Å
2 reflections (0.1%): 0.61-0.60 Å
2 reflections (0.1%): 2.74-1.83 Å
2 reflections (0.1%): 0.60-0.60 Å
Richards-MBP-10:x4wide rjgildea$ dials.missing_reflections $(dials.data get -q l_cysteine_4_sweeps_scaled)/scaled_30.{expt,refl} min_component_size=10
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
The following parameters have been modified:
min_component_size = 10
input {
  experiments = /Users/rjgildea/software/cctbx_py3/build/dials_data/l_cysteine_4_sweeps_scaled/scaled_30.expt
  reflections = /Users/rjgildea/software/cctbx_py3/build/dials_data/l_cysteine_4_sweeps_scaled/scaled_30.refl
}

260 reflections (16.0%): 1.37-0.59 Å
57 reflections (3.5%): 1.02-0.60 Å
16 reflections (1.0%): 0.61-0.59 Å
```

```
$ dials.missing_reflections $(dials.data get -q vmxi_proteinase_k_sweeps)/{experiments_0.expt,reflections_0.refl} min_component_size=10
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
The following parameters have been modified:
min_component_size = 10
input {
  experiments = /Users/rjgildea/software/cctbx_py3/build/dials_data/vmxi_proteinase_k_sweeps/experiments_0.expt
  reflections = /Users/rjgildea/software/cctbx_py3/build/dials_data/vmxi_proteinase_k_sweeps/reflections_0.refl
}

Filtering reflections for dataset 0
Read 76079 predicted reflections
Selected 54367 reflections integrated by profile and summation methods
Combined 1127 partial reflections with other partial reflections
Removed 491 reflections below partiality threshold
Removed 0 intensity.sum.value reflections with I/Sig(I) < -5
Removed 12 intensity.prf.value reflections with I/Sig(I) < -5
6648 reflections (28.2%): 2.51-1.80 Å
307 reflections (1.3%): 103.98-1.80 Å
```