### PR TITLE
DIALS 2.2.5

### DIFF
--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -9,6 +9,7 @@ import json
 import iotbx.merging_statistics
 import pytest
 import procrunner
+import iotbx.mtz
 from libtbx import phil
 from dxtbx.serialize import load
 from dxtbx.model.experiment_list import ExperimentList
@@ -393,6 +394,8 @@ def test_scale_physical(dials_data, tmpdir):
         "error_model=None",
         "intensity_choice=profile",
         "unmerged_mtz=unmerged.mtz",
+        "crystal_name=foo",
+        "project_name=bar",
         "use_free_set=1",
         "outlier_rejection=simple",
         "json=scaling.json",
@@ -401,6 +404,10 @@ def test_scale_physical(dials_data, tmpdir):
     assert tmpdir.join("unmerged.mtz").check()
     assert tmpdir.join("merged.mtz").check()
     assert tmpdir.join("scaling.json").check()
+    for f in ("unmerged.mtz", "merged.mtz"):
+        mtz_obj = iotbx.mtz.object(tmpdir.join(f).strpath)
+        assert mtz_obj.crystals()[1].name() == "foo"
+        assert mtz_obj.crystals()[1].project_name() == "bar"
 
     # Now inspect output, check it hasn't changed drastically, or if so verify
     # that the new behaviour is more correct and update test accordingly.

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -124,6 +124,11 @@ phil_scope = parse(
     crystal_name = XTAL
       .type = str
       .help = "The name of the crystal, for the mtz file metadata"
+
+    project_name = DIALS
+      .type = str
+      .help = "The project name for the mtz file metadata"
+
   }
 
   sadabs {

--- a/command_line/reciprocal_lattice_viewer.py
+++ b/command_line/reciprocal_lattice_viewer.py
@@ -52,7 +52,6 @@ def run(args):
                 reflections[0].extend(reflections[i])
     elif "imageset_id" not in reflections[0]:
         reflections[0]["imageset_id"] = reflections[0]["id"]
-        reflections[0]["id"] = flex.int(reflections[0].size(), -1)
 
     reflections = reflections[0]
 

--- a/command_line/rl_png.py
+++ b/command_line/rl_png.py
@@ -89,6 +89,10 @@ class PngScene(object):
         # we do not draw reciprocal lattice vectors at this time
         pass
 
+    def set_reciprocal_crystal_vectors(self, *args, **kwargs):
+        # we do not draw reciprocal crystak vectors at this time either
+        pass
+
     def project_2d(self, n):
         d = self.points.dot(n.elems)
         p = d * flex.vec3_double(len(d), n.elems)

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -84,6 +84,9 @@ phil_scope = phil.parse(
       .type = str
       .help = "The crystal name to be exported in the mtz file metadata"
       .expert_level = 1
+    project_name = DIALS
+      .type = str
+      .help = "The project name for the mtz file metadata"
     use_internal_variance = False
       .type = bool
       .help = "Option to use internal spread of the intensities when merging
@@ -122,6 +125,8 @@ def _export_merged_mtz(params, experiments, joint_table):
     merge_params.reporting.merging_stats = False
     merge_params.assess_space_group = False
     merge_params.partiality_threshold = params.cut_data.partiality_cutoff
+    merge_params.output.crystal_names = [params.output.crystal_name]
+    merge_params.output.project_name = params.output.project_name
     mtz_file = merge_data_to_mtz(merge_params, experiments, [joint_table])
     logger.info("\nWriting merged data to %s", (params.output.merged_mtz))
     out = StringIO()
@@ -139,6 +144,7 @@ def _export_unmerged_mtz(params, experiments, reflection_table):
     export_params.intensity = ["scale"]
     export_params.mtz.partiality_threshold = params.cut_data.partiality_cutoff
     export_params.mtz.crystal_name = params.output.crystal_name
+    export_params.mtz.project_name = params.output.project_name
     if params.cut_data.d_min:
         export_params.mtz.d_min = params.cut_data.d_min
     logger.info(

--- a/newsfragments/1259.feature
+++ b/newsfragments/1259.feature
@@ -1,0 +1,1 @@
+dials.reciprocal_lattice_viewer: Add an option to show lattice(s) in the crystal rather than laboratory frame.

--- a/newsfragments/1284.bugfix
+++ b/newsfragments/1284.bugfix
@@ -1,0 +1,1 @@
+dials.reciprocal_lattice_viewer: fix multiple experiment view for integrated data

--- a/test/command_line/test_export.py
+++ b/test/command_line/test_export.py
@@ -34,7 +34,22 @@ def test_nxs(dials_data, tmpdir):
 
 
 def test_mtz(dials_data, tmpdir):
-    run_export("mtz", dials_data, tmpdir)
+    result = procrunner.run(
+        [
+            "dials.export",
+            "format=mtz",
+            "project_name=ham",
+            "crystal_name=spam",
+            dials_data("centroid_test_data").join("experiments.json"),
+            dials_data("centroid_test_data").join("integrated.pickle"),
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("integrated.mtz").check(file=1)
+    mtz_obj = mtz.object(tmpdir.join("integrated.mtz").strpath)
+    assert mtz_obj.crystals()[1].name() == "spam"
+    assert mtz_obj.crystals()[1].project_name() == "ham"
 
 
 def test_multi_sequence_integrated_mtz(dials_data, tmpdir):

--- a/util/export_mtz.py
+++ b/util/export_mtz.py
@@ -559,8 +559,11 @@ def export_mtz(integrated_data, experiment_list, params):
             experiment.data["ROT"] = z
 
     mtz_writer.add_crystal(
-        params.mtz.crystal_name, unit_cell=experiment_list[0].crystal.get_unit_cell()
-    )  # Note: add unit cell here as may have changed basis since creating mtz.
+        crystal_name=params.mtz.crystal_name,
+        project_name=params.mtz.project_name,
+        unit_cell=experiment_list[0].crystal.get_unit_cell(),
+    )
+    # Note: add unit cell here as may have changed basis since creating mtz.
     # For multi-wave unmerged mtz, we add an empty dataset for each wavelength,
     # but only write the data into the final dataset (for unmerged the batches
     # link the unmerged data to the individual wavelengths).

--- a/util/reciprocal_lattice/__init__.py
+++ b/util/reciprocal_lattice/__init__.py
@@ -13,6 +13,9 @@ phil_scope = libtbx.phil.parse(
 reverse_phi = False
   .type = bool
   .optional = True
+crystal_frame = False
+  .type = bool
+  .optional = True
 beam_centre = None
   .type = floats(size=2)
   .help = "Fast, slow beam centre coordinates (mm)."
@@ -87,6 +90,16 @@ class Render3d(object):
                 for c in crystals
             ]
             self.viewer.set_reciprocal_lattice_vectors(vecs)
+            vecs = [
+                [
+                    matrix.col(l)
+                    for l in (100 * matrix.sqr(c.get_B()))
+                    .transpose()
+                    .as_list_of_lists()
+                ]
+                for c in crystals
+            ]
+            self.viewer.set_reciprocal_crystal_vectors(vecs)
         self.map_points_to_reciprocal_space()
         self.set_points()
 
@@ -106,7 +119,9 @@ class Render3d(object):
                 )
 
         self.reflections.map_centroids_to_reciprocal_space(
-            experiments, calculated=calculated
+            experiments,
+            calculated=calculated,
+            crystal_frame=self.settings.crystal_frame,
         )
 
     def set_points(self):

--- a/util/reciprocal_lattice/viewer.py
+++ b/util/reciprocal_lattice/viewer.py
@@ -299,11 +299,24 @@ class SettingsWindow(wxtbx.utils.SettingsPanel):
             setting="show_reciprocal_cell", label="Show reciprocal cell"
         )
         self.panel_sizer.Add(ctrls[0], 0, wx.ALL, 5)
+
         self.reverse_phi_ctrl = self.create_controls(
             setting="reverse_phi", label="Invert rotation axis"
         )[0]
         self.panel_sizer.Add(self.reverse_phi_ctrl, 0, wx.ALL, 5)
+
         self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.reverse_phi_ctrl)
+
+        self.crystal_frame_tooltip = wx.ToolTip(
+            "Show the reciprocal lattice(s) in the crystal rather than the laboratory frame"
+        )
+        self.crystal_frame_ctrl = self.create_controls(
+            setting="crystal_frame", label="Show in crystal frame"
+        )[0]
+        self.crystal_frame_ctrl.SetToolTip(self.crystal_frame_tooltip)
+        self.panel_sizer.Add(self.crystal_frame_ctrl, 0, wx.ALL, 5)
+
+        self.Bind(wx.EVT_CHECKBOX, self.OnChangeSettings, self.crystal_frame_ctrl)
 
         self.beam_fast_ctrl = floatspin.FloatSpin(parent=self, increment=0.01, digits=2)
         self.beam_fast_ctrl.Bind(wx.EVT_SET_FOCUS, lambda evt: None)
@@ -406,6 +419,7 @@ class SettingsWindow(wxtbx.utils.SettingsPanel):
             self.beam_slow_ctrl.GetValue(),
         )
         self.settings.reverse_phi = self.reverse_phi_ctrl.GetValue()
+        self.settings.crystal_frame = self.crystal_frame_ctrl.GetValue()
         self.settings.marker_size = self.marker_size_ctrl.GetValue()
         for i, display in enumerate(("all", "indexed", "unindexed", "integrated")):
             if self.btn.values[i]:
@@ -437,6 +451,7 @@ class RLVWindow(wx_viewer.show_points_and_lines_mixin):
         self.rotation_axis = None
         self.beam_vector = None
         self.recip_latt_vectors = None
+        self.recip_crystal_vectors = None
         self.flag_show_minimum_covering_sphere = False
         self.minimum_covering_sphere = None
         self.field_of_view_y = 0.001
@@ -480,6 +495,9 @@ class RLVWindow(wx_viewer.show_points_and_lines_mixin):
     def set_reciprocal_lattice_vectors(self, vectors_per_crystal):
         self.recip_latt_vectors = vectors_per_crystal
 
+    def set_reciprocal_crystal_vectors(self, vectors_per_crystal):
+        self.recip_crystal_vectors = vectors_per_crystal
+
     # --- user input and settings
     def update_settings(self):
         self.points_display_list = None
@@ -504,14 +522,22 @@ class RLVWindow(wx_viewer.show_points_and_lines_mixin):
             self.draw_axis(self.rotation_axis, "phi")
         if self.beam_vector is not None and self.settings.show_beam_vector:
             self.draw_axis(self.beam_vector, "beam")
-        if self.recip_latt_vectors is not None and self.settings.show_reciprocal_cell:
-            for i, axes in enumerate(self.recip_latt_vectors):
-                if self.settings.experiment_ids:
-                    if i not in self.settings.experiment_ids:
-                        continue
-                j = (i + 1) % self.palette.size()
-                color = self.palette[j]
-                self.draw_cell(axes, color)
+
+        if self.settings.show_reciprocal_cell:
+            # if we don't have one sort of vector we don't have the other either
+            vectors = self.recip_latt_vectors
+            if self.settings.crystal_frame:
+                vectors = self.recip_crystal_vectors
+
+            if vectors:
+                for i, axes in enumerate(vectors):
+                    if self.settings.experiment_ids:
+                        if i not in self.settings.experiment_ids:
+                            continue
+                    j = (i + 1) % self.palette.size()
+                    color = self.palette[j]
+                    self.draw_cell(axes, color)
+
         self.GetParent().update_statusbar()
 
     def draw_axis(self, axis, label):


### PR DESCRIPTION
* fix reading of single-image Eiger files (cctbx/dxtbx#164)
* we now support Spring2020 Nexus files, including multi-wavelength
  beams and absence of goniometer/scan (dials/dxtbx#41)
* project names are now correctly written into .mtz files
* `dials.reciprocal_lattice_viewer`: show correct sweep colour for integrated data (#1283)
* `dials.reciprocal_lattice_viewer`: added option to show lattice in crystal frame (#1259)
* `xia2`: fix treatment of missing individual images (xia2/xia2#462, xia2/xia2#463)
