### PR TITLE
Improve handling of profile/sum intensities for scaling.

### DIFF
--- a/algorithms/scaling/combine_intensities.py
+++ b/algorithms/scaling/combine_intensities.py
@@ -195,51 +195,44 @@ class SingleDatasetIntensityCombiner(object):
         return rows, results
 
 
-def combine_intensities(reflection_table, Imid):
-    """Take unscaled data, and apply intensity combination with a given Imid."""
-    assert "intensity.prf.value" in reflection_table
-    assert "intensity.sum.value" in reflection_table
-    assert "prescaling_correction" in reflection_table
-    conv = reflection_table["prescaling_correction"]
-    Ipr = reflection_table["intensity.prf.value"]
-    Vpr = reflection_table["intensity.prf.variance"]
-    Isum = reflection_table["intensity.sum.value"]
-    Vsum = reflection_table["intensity.sum.variance"]
-    if "partiality" in reflection_table:
-        inv_p = _determine_inverse_partiality(reflection_table)
-        Int, Var = _calculate_combined_raw_intensities(
-            Ipr, Isum * inv_p, Vpr, Vsum * inv_p * inv_p, Imid
-        )
-    else:
-        Int, Var = _calculate_combined_raw_intensities(Ipr, Isum, Vpr, Vsum, Imid)
-    intensity = Int * conv
-    variance = Var * conv * conv
-    return intensity, variance
-
-
 def _calculate_suitable_combined_intensities(scaler, max_key):
-    reflections = scaler.reflection_table
-    suitable = scaler.suitable_refl_for_scaling_sel
-    suitable_conv = reflections["prescaling_correction"].select(suitable)
-    Isum = reflections["intensity.sum.value"].select(suitable)
-    Vsum = reflections["intensity.sum.variance"].select(suitable)
+    reflections = scaler.reflection_table.select(scaler.suitable_refl_for_scaling_sel)
+
+    conv = reflections["prescaling_correction"]
+    Isum = reflections["intensity.sum.value"]
+    Vsum = reflections["intensity.sum.variance"]
+    Ipr = reflections["intensity.prf.value"]
+    Vpr = reflections["intensity.prf.variance"]
+
+    not_prf = ~reflections.get_flags(reflections.flags.integrated_prf)
+    not_sum = ~reflections.get_flags(reflections.flags.integrated_sum)
+    both = reflections.get_flags(reflections.flags.integrated, all=True)
+
     if "partiality" in reflections:
         inv_p = _determine_inverse_partiality(reflections)
-        inv_p = inv_p.select(suitable)
-    if max_key == 1:
-        if "partiality" in reflections:
-            intensity = Isum * suitable_conv * inv_p
-            variance = Vsum * flex.pow2(suitable_conv * inv_p)
-        else:
-            intensity = Isum * suitable_conv
-            variance = Vsum * suitable_conv * suitable_conv
+        sum_conv = conv * inv_p
     else:
-        Ipr = reflections["intensity.prf.value"].select(suitable)
-        Vpr = reflections["intensity.prf.variance"].select(suitable)
-        if max_key == 0:
-            intensity = Ipr * suitable_conv
-            variance = Vpr * suitable_conv * suitable_conv
+        sum_conv = conv
+
+    if max_key == 1:  # i.e. sum is best, so use sum if exists, else prf
+        intensity = Isum * sum_conv
+        variance = Vsum * sum_conv * sum_conv
+        # get not summation successful
+        intensity.set_selected(not_sum.iselection(), (Ipr * conv).select(not_sum))
+        variance.set_selected(not_sum.iselection(), (Vpr * conv * conv).select(not_sum))
+    else:
+        # first set as prf
+        intensity = Ipr * conv
+        variance = Vpr * conv * conv
+        # set those not prf successful
+        intensity.set_selected(not_prf.iselection(), (Isum * sum_conv).select(not_prf))
+        variance.set_selected(
+            not_prf.iselection(), (Vsum * sum_conv * sum_conv).select(not_prf)
+        )
+        if max_key == 0:  # done all we need to do.
+            pass
         else:
+            # calculate combined intensities, but only set for those where both prf and sum good
             if "partiality" in reflections:
                 Int, Var = _calculate_combined_raw_intensities(
                     Ipr, Isum * inv_p, Vpr, Vsum * inv_p * inv_p, max_key
@@ -248,8 +241,9 @@ def _calculate_suitable_combined_intensities(scaler, max_key):
                 Int, Var = _calculate_combined_raw_intensities(
                     Ipr, Isum, Vpr, Vsum, max_key
                 )
-            intensity = Int * suitable_conv
-            variance = Var * suitable_conv * suitable_conv
+            intensity.set_selected(both.iselection(), (Int * conv).select(both))
+            variance.set_selected(both.iselection(), (Var * conv * conv).select(both))
+
     return intensity, variance
 
 

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -493,7 +493,7 @@ def test_scale_and_filter_image_group_mode(dials_data, tmpdir):
     assert tmpdir.join("scaled.expt").check()
     assert tmpdir.join("analysis_results.json").check()
     result = get_merging_stats(tmpdir.join("unmerged.mtz").strpath)
-    assert result.overall.r_pim < 0.17  # 03/02/20 was 0.160
+    assert result.overall.r_pim < 0.175  # 12/06/20 was 0.171,
     assert result.overall.cc_one_half > 0.95  # 03/02/20 was 0.961
     assert result.overall.n_obs > 50000  # 03/02/20 was 50213
 
@@ -635,7 +635,7 @@ def test_multi_scale(dials_data, tmpdir):
     # that the new behaviour is more correct and update test accordingly.
     # Note: error optimisation currently appears to give worse results here!
     result = get_merging_stats(tmpdir.join("unmerged.mtz").strpath)
-    expected_nobs = 5411
+    expected_nobs = 5564
     print(result.overall.r_pim)
     print(result.overall.cc_one_half)
     assert abs(result.overall.n_obs - expected_nobs) < 100

--- a/algorithms/scaling/test_scaler_factory.py
+++ b/algorithms/scaling/test_scaler_factory.py
@@ -66,7 +66,8 @@ def refl_to_filter():
     reflections["intensity.sum.value"] = flex.double([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
     reflections["intensity.sum.variance"] = flex.double([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
     reflections.set_flags(
-        flex.bool([True, False, True, True, True, True]), reflections.flags.integrated
+        flex.bool([True, False, True, True, True, True]),
+        reflections.flags.integrated_sum,
     )
     return reflections
 

--- a/algorithms/scaling/test_scaling_library.py
+++ b/algorithms/scaling/test_scaling_library.py
@@ -19,7 +19,7 @@ from dials.algorithms.scaling.scaling_library import (
     create_Ih_table,
     # calculate_merging_statistics,
     # calculate_single_merging_stats,
-    choose_scaling_intensities,
+    choose_initial_scaling_intensities,
     create_auto_scaling_model,
     determine_best_unit_cell,
 )
@@ -276,26 +276,21 @@ def test_create_Ih_table(test_experiments, test_reflections):
         )
 
 
-def test_choose_scaling_intensities(test_reflections):
+def test_choose_initial_scaling_intensities(test_reflections):
     """Test for correct choice of intensities."""
     test_refl = test_reflections
     intstr = "prf"
-    new_rt = choose_scaling_intensities(test_refl, intstr)
+    new_rt = choose_initial_scaling_intensities(test_refl, intstr)
     assert list(new_rt["intensity"]) == list(test_refl["intensity.prf.value"])
     assert list(new_rt["variance"]) == list(test_refl["intensity.prf.variance"])
     intstr = "sum"  # should apply partiality correction
-    new_rt = choose_scaling_intensities(test_refl, intstr)
+    new_rt = choose_initial_scaling_intensities(test_refl, intstr)
     assert list(new_rt["intensity"]) == list(
         test_refl["intensity.sum.value"] / test_refl["partiality"]
     )
     assert list(new_rt["variance"]) == pytest.approx(
         list(test_refl["intensity.sum.variance"] / flex.pow2(test_refl["partiality"]))
     )
-    # If bad choice, currently return the prf values.
-    intstr = "bad"
-    new_rt = choose_scaling_intensities(test_refl, intstr)
-    assert list(new_rt["intensity"]) == list(test_refl["intensity.prf.value"])
-    assert list(new_rt["variance"]) == list(test_refl["intensity.prf.variance"])
 
 
 def test_auto_scaling_model():

--- a/command_line/refine_error_model.py
+++ b/command_line/refine_error_model.py
@@ -24,7 +24,7 @@ from dials.algorithms.scaling.error_model.error_model import (
     calc_deltahl,
 )
 from dials.algorithms.scaling.Ih_table import IhTable
-from dials.algorithms.scaling.scaling_library import choose_scaling_intensities
+from dials.algorithms.scaling.scaling_library import choose_initial_scaling_intensities
 from dials.algorithms.scaling.plots import (
     normal_probability_plot,
     error_model_variance_plot,
@@ -90,7 +90,7 @@ def refine_error_model(params, experiments, reflection_tables):
             table["intensity"] = I
             table["variance"] = V
         else:
-            table = choose_scaling_intensities(
+            table = choose_initial_scaling_intensities(
                 table, intensity_choice=params.intensity_choice
             )
         reflection_tables[i] = table

--- a/newsfragments/1300.bugfix
+++ b/newsfragments/1300.bugfix
@@ -1,0 +1,1 @@
+in dials.scale, don't require both prf/sum intensities to be available for intensity_choice=combine. Use only one if only one available for a given reflection.

--- a/test/util/test_filter_reflections_export.py
+++ b/test/util/test_filter_reflections_export.py
@@ -422,6 +422,8 @@ def test_SumAndPrfIntensityReducer():
     r["intensity.prf.variance"] = flex.double([0.0, 1.0, 1.0])
     r["intensity.sum.value"] = flex.double([1.0, 2.0, 3.0])
     r["intensity.sum.variance"] = flex.double([1.0, 0.0, 1.0])
+    r.set_flags(flex.bool([True, True, True]), r.flags.integrated_prf)
+    r.set_flags(flex.bool([True, True, True]), r.flags.integrated_sum)
     r = SumAndPrfIntensityReducer.filter_bad_variances(r)
     assert list(r["intensity.prf.value"]) == [3.0]
 

--- a/util/filter_reflections.py
+++ b/util/filter_reflections.py
@@ -152,11 +152,11 @@ def filter_reflection_table(reflection_table, intensity_choice, *args, **kwargs)
             intensity_choice.remove("profile")
         else:
             intensity_choice = None
-        logger.info(
-            "Attempting to reprocess with intensity choice: %s"
-            % " + ".join(i for i in intensity_choice)
-        )
         if intensity_choice:
+            logger.info(
+                "Attempting to reprocess with intensity choice: %s"
+                % " + ".join(i for i in intensity_choice)
+            )
             reflection_table = filter_reflection_table(
                 reflection_table, intensity_choice, *args, **kwargs
             )

--- a/util/filter_reflections.py
+++ b/util/filter_reflections.py
@@ -148,7 +148,10 @@ def filter_reflection_table(reflection_table, intensity_choice, *args, **kwargs)
         reflection_table = reducer.filter_for_export(reflection_table, *args, **kwargs)
     except NoProfilesException as e:
         logger.warning(e, exc_info=True)
-        intensity_choice = ["sum"]
+        if "profile" in intensity_choice:
+            intensity_choice.remove("profile")
+        else:
+            intensity_choice = None
         logger.info(
             "Attempting to reprocess with intensity choice: %s"
             % " + ".join(i for i in intensity_choice)


### PR DESCRIPTION
If using intensity_choice=combine in scaling (the default), also use reflections where only one of profile/sum intensity estimate is available. i.e. combine estimates if both available, else just use the one estimate that succeeded.
Current behaviour is that only reflections with both profile and summation estimates are used.
This bit of the scaling code could do with refactoring a bit, however leaving for now to give a clean changeset for if we want to add this to current releases.
