### PR TITLE
Dependency updates: scipy

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -33,7 +33,7 @@ conda-forge::pytest-mock<2.0
 conda-forge::pytest-xdist
 conda-forge::requests
 conda-forge::scikit-learn
-conda-forge::scipy<1.6
+conda-forge::scipy
 conda-forge::scons
 conda-forge::setuptools
 conda-forge::six

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -37,7 +37,7 @@ conda-forge::pytest-mock<2.0
 conda-forge::pytest-xdist
 conda-forge::requests
 conda-forge::scikit-learn
-conda-forge::scipy<1.6
+conda-forge::scipy
 conda-forge::scons
 conda-forge::setuptools
 conda-forge::six

--- a/command_line/anvil_correction.py
+++ b/command_line/anvil_correction.py
@@ -132,12 +132,20 @@ def goniometer_rotation(experiment, reflections):
     # Get the setting rotation.
     # In the notation of dxtbx/model/goniometer.h, this is S.
     set_rotation = np.array(experiment.goniometer.get_setting_rotation()).reshape(3, 3)
-    set_rotation = Rotation.from_dcm(set_rotation)
+    if hasattr(Rotation, "from_matrix"):
+        set_rotation = Rotation.from_matrix(set_rotation)
+    else:
+        # SciPy < 1.4.0. Can be removed after 15th of September 2020
+        set_rotation = Rotation.from_dcm(set_rotation)
 
     # Create a rotation operator for those axes that are fixed throughout the scan.
     # In the notation of dxtbx/model/goniometer.h, this is F.
     fixed_rotation = np.array(experiment.goniometer.get_fixed_rotation()).reshape(3, 3)
-    fixed_rotation = Rotation.from_dcm(fixed_rotation)
+    if hasattr(Rotation, "from_matrix"):
+        fixed_rotation = Rotation.from_matrix(fixed_rotation)
+    else:
+        # SciPy < 1.4.0. Can be removed after 15th of September 2020
+        fixed_rotation = Rotation.from_dcm(fixed_rotation)
 
     # Calculate the rotation operator representing the goniometer orientation for each
     # reflection.  In the notation of dxtbx/model/goniometer.h this is S × R × F.

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,9 @@ import warnings
 import pytest
 import six
 
+# https://stackoverflow.com/a/40846742
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 
 collect_ignore = []
 if six.PY2:


### PR DESCRIPTION
Remove the scipy version limit, retain compatibility with the Python 2.7 version for now (fixes #1296), and resolve those annoying numpy object size warnings.