### PR TITLE
Dependency updates: pytest

### DIFF
--- a/.conda-envs/dials_py36_linux-64.txt
+++ b/.conda-envs/dials_py36_linux-64.txt
@@ -25,7 +25,7 @@ conda-forge::numpy>=1.16,<1.17
 conda-forge::pillow>=5.4.1
 conda-forge::pip
 conda-forge::psutil
-conda-forge::pytest>=4.5,<5.0
+conda-forge::pytest>=4.5
 conda-forge::pytest-forked
 conda-forge::pytest-mock<2.0
 conda-forge::pytest-xdist

--- a/.conda-envs/dials_py36_osx-64.txt
+++ b/.conda-envs/dials_py36_osx-64.txt
@@ -29,7 +29,7 @@ conda-forge::numpy>=1.16,<1.17
 conda-forge::pillow>=5.4.1
 conda-forge::pip
 conda-forge::psutil
-conda-forge::pytest>=4.5,<5.0
+conda-forge::pytest>=4.5
 conda-forge::pytest-forked
 conda-forge::pytest-mock<2.0
 conda-forge::pytest-xdist

--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -27,7 +27,7 @@ conda-forge::numpy>=1.16,<1.17
 conda-forge::pillow>=5.4.1
 conda-forge::pip
 conda-forge::psutil
-conda-forge::pytest>=4.5,<5.0
+conda-forge::pytest>=4.5
 conda-forge::pytest-forked
 conda-forge::pytest-mock<2.0
 conda-forge::pytest-xdist

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -31,7 +31,7 @@ conda-forge::numpy>=1.16,<1.17
 conda-forge::pillow>=5.4.1
 conda-forge::pip
 conda-forge::psutil
-conda-forge::pytest>=4.5,<5.0
+conda-forge::pytest>=4.5
 conda-forge::pytest-forked
 conda-forge::pytest-mock<2.0
 conda-forge::pytest-xdist

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,6 @@ addopts = -rsxX
 filterwarnings =
     ignore:the matrix subclass is not the recommended way:PendingDeprecationWarning
     ignore:numpy.dtype size changed:RuntimeWarning
+junit_family = legacy
 markers =
     slow: Slow DIALS test


### PR DESCRIPTION
With dials-data now supporting pytest 5.0+ we can now remove the version limit.
Python 2.7 installations will stick with the 4.x branch which still enjoys some level of support.

As far as I can tell there are no sudden changes needed in the tests, so staying cross-compatible until at least September should be easy.