### PR TITLE
Remove any_reflection_file() calls

### DIFF
--- a/command_line/cluster_unit_cell.py
+++ b/command_line/cluster_unit_cell.py
@@ -6,8 +6,8 @@ import os
 import sys
 
 from cctbx import crystal
+import iotbx.mtz
 import iotbx.phil
-from iotbx.reflection_file_reader import any_reflection_file
 from xfel.clustering.cluster import Cluster
 from xfel.clustering.cluster_groups import unit_cell_info
 
@@ -53,18 +53,16 @@ def run(args):
     crystal_symmetries = []
 
     if len(experiments) == 0:
-        if len(args):
-            for arg in args:
-                assert os.path.isfile(arg), arg
-                reader = any_reflection_file(arg)
-                assert reader.file_type() == "ccp4_mtz"
-                arrays = reader.as_miller_arrays(
-                    merge_equivalents=False, anomalous=False
-                )
-                crystal_symmetries.append(arrays[0].crystal_symmetry())
-        else:
+        if not args:
             parser.print_help()
             exit(0)
+        for arg in args:
+            assert os.path.isfile(arg), arg
+            mtz_object = iotbx.mtz.object(file_name=arg)
+            arrays = mtz_object.as_miller_arrays(
+                merge_equivalents=False, anomalous=False
+            )
+            crystal_symmetries.append(arrays[0].crystal_symmetry())
     else:
         crystal_symmetries = [
             crystal.symmetry(

--- a/pychef/test_pychef.py
+++ b/pychef/test_pychef.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
 import dials.pychef
+import iotbx.mtz
 import pytest
 from cctbx import sgtbx
 from cctbx.array_family import flex
-from iotbx.reflection_file_reader import any_reflection_file
 from dxtbx.model import Experiment, ExperimentList, Scan
 
 
@@ -22,9 +22,8 @@ def test_observations():
 
 def test_accumulators(dials_data):
     f = dials_data("pychef").join("insulin_dials_scaled_unmerged.mtz").strpath
-    reader = any_reflection_file(f)
-    assert reader.file_type() == "ccp4_mtz"
-    arrays = reader.as_miller_arrays(merge_equivalents=False)
+    mtz_object = iotbx.mtz.object(file_name=f)
+    arrays = mtz_object.as_miller_arrays(merge_equivalents=False)
     for ma in arrays:
         if ma.info().labels == ["BATCH"]:
             batches = ma

--- a/test/test_scan_varying_integration_bug.py
+++ b/test/test_scan_varying_integration_bug.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
+import iotbx.mtz
 import procrunner
 from libtbx.test_utils import approx_equal
 from cctbx import uctbx
 
 
-def test_1(dials_data, tmpdir):
+def test(dials_data, tmpdir):
     g = [f.strpath for f in dials_data("x4wide").listdir(sort=True)]
     assert len(g) == 90
 
@@ -31,10 +32,8 @@ def test_1(dials_data, tmpdir):
 
     integrated_mtz = tmpdir.join("integrated.mtz")
     assert integrated_mtz.check(file=1)
-    from iotbx.reflection_file_reader import any_reflection_file
 
-    reader = any_reflection_file(integrated_mtz.strpath)
-    mtz_object = reader.file_content()
+    mtz_object = iotbx.mtz.object(file_name=integrated_mtz.strpath)
     assert mtz_object.column_labels()[:14] == [
         "H",
         "K",


### PR DESCRIPTION
especially in contexts where we know exactly what sort of file we are
opening.

The only potential use is in `util/resolutionizer.py`, where I guess something other than a `.mtz` could be opened, however the function name implies that it would only open `.mtz`s.
Can someone verify this?