### PR TITLE
DIALS 2.2.7

### DIFF
--- a/algorithms/integration/parallel_integrator.py
+++ b/algorithms/integration/parallel_integrator.py
@@ -303,12 +303,7 @@ def assert_enough_memory(required_memory, max_memory_usage):
             % (total_memory / 1e9, limit_memory / 1e9, required_memory / 1e9)
         )
     else:
-        logger.info("")
-        logger.info(" Memory usage:")
-        logger.info("  Total system memory: %g GB" % (total_memory / 1e9))
-        logger.info("  Limit image memory: %g GB" % (limit_memory / 1e9))
-        logger.info("  Required image memory: %g GB" % (required_memory / 1e9))
-        logger.info("")
+        logger.info("Allocating %.1f MB memory", required_memory / 1e6)
 
 
 class Result(object):

--- a/command_line/refine_bravais_settings.py
+++ b/command_line/refine_bravais_settings.py
@@ -181,6 +181,10 @@ def run(args=None):
     assert len(reflections) == 1
     reflections = reflections[0]
 
+    # Reduce what we pickle and send to workers by removing unused data
+    if "shoebox" in reflections:
+        del reflections["shoebox"]
+
     if len(experiments) == 0:
         parser.print_help()
         return

--- a/newsfragments/1274.bugfix
+++ b/newsfragments/1274.bugfix
@@ -1,0 +1,1 @@
+dials.refine_bravais_settings: Fix crash with large (>2gb) reflection tables and reduce memory use


### PR DESCRIPTION
* `dials.refine_bravais_settings`: Fix crash with large (>2gb) reflection tables and reduce memory use
* `dials.integrate`: Reduce log noise levels