### PR TITLE
Add option to disable timing output

### DIFF
--- a/newsfragments/1313.removal
+++ b/newsfragments/1313.removal
@@ -1,0 +1,1 @@
+log files will omit timings unless the relevant dials program was run with '-v'

--- a/util/log.py
+++ b/util/log.py
@@ -16,22 +16,22 @@ class DialsLogfileFormatter:
     """A formatter for log files that prepends messages with the elapsed time
     or messages at warning level or above with 'WARNING:'"""
 
-    def __init__(self):
+    def __init__(self, timed):
+        self.timed = timed
         self.start_time = time.time()
         self.prefix = ""
 
     def format(self, record):
-        if "NO_TIME" in os.environ:
-            prefix = ""
-        else:
+        if self.timed:
             elapsed_seconds = record.created - self.start_time
             prefix = "{:6.1f}: ".format(elapsed_seconds)
+        else:
+            prefix = ""
         indent = len(prefix)
         msg = record.getMessage()
 
         if record.levelno >= logging.WARNING:
-            prefix = "WARN: "
-            prefix = (indent - len(prefix)) * " " + prefix
+            prefix = "{prefix:>{indent}s}".format(indent=indent, prefix="WARN: ")
 
         msg = msg.replace("\n", "\n" + " " * indent)
         if prefix == self.prefix:
@@ -81,7 +81,7 @@ def config(verbosity=0, logfile=None):
     if logfile:
         fh = logging.FileHandler(filename=logfile, mode="w")
         fh.setLevel(loglevel)
-        fh.setFormatter(DialsLogfileFormatter())
+        fh.setFormatter(DialsLogfileFormatter(timed=verbosity))
         dials_logger.addHandler(fh)
 
     dials_logger.setLevel(loglevel)

--- a/util/log.py
+++ b/util/log.py
@@ -21,8 +21,11 @@ class DialsLogfileFormatter:
         self.prefix = ""
 
     def format(self, record):
-        elapsed_seconds = record.created - self.start_time
-        prefix = "{:6.1f}: ".format(elapsed_seconds)
+        if "NO_TIME" in os.environ:
+            prefix = ""
+        else:
+            elapsed_seconds = record.created - self.start_time
+            prefix = "{:6.1f}: ".format(elapsed_seconds)
         indent = len(prefix)
         msg = record.getMessage()
 


### PR DESCRIPTION
I find myself typing `| cut -c 9-` many times per day to remove timing info I don't want - so adding an option to not have it there following NO_COLOR.