### PR TITLE
DIALS 2.2.8

### DIFF
--- a/algorithms/scaling/boost_python/scaling_ext.cc
+++ b/algorithms/scaling/boost_python/scaling_ext.cc
@@ -18,6 +18,7 @@ namespace dials_scaling { namespace boost_python {
   void export_calc_lookup_index();
   void export_create_sph_harm_lookup_table();
   void export_gaussian_smoother_first_fixed();
+  void export_limit_outlier_weights();
 
   BOOST_PYTHON_MODULE(dials_scaling_ext) {
     export_elementwise_square();
@@ -33,6 +34,7 @@ namespace dials_scaling { namespace boost_python {
     export_calc_lookup_index();
     export_create_sph_harm_lookup_table();
     export_gaussian_smoother_first_fixed();
+    export_limit_outlier_weights();
   }
 
 }}  // namespace dials_scaling::boost_python

--- a/algorithms/scaling/boost_python/scaling_helper.cc
+++ b/algorithms/scaling/boost_python/scaling_helper.cc
@@ -59,6 +59,10 @@ namespace dials_scaling { namespace boost_python {
     def("row_multiply", &row_multiply, (arg("m"), arg("v")));
   }
 
+  void export_limit_outlier_weights() {
+    def("limit_outlier_weights", &limit_outlier_weights, (arg("weights"), arg("h_index_mat")));
+  }
+
   void export_calc_lookup_index() {
     def("calc_lookup_index",
         &calc_lookup_index,

--- a/algorithms/scaling/test_outlier_rejection.py
+++ b/algorithms/scaling/test_outlier_rejection.py
@@ -194,6 +194,30 @@ expected_target_output = [
 ]
 
 
+def test_outlier_rejection_with_small_outliers():
+
+    rt = flex.reflection_table()
+    rt["intensity"] = flex.double(
+        [3560.84231, 3433.66407, 3830.64235, 0.20552, 3786.59537]
+        + [4009.98652, 0.00000, 3578.91470, 3549.19151, 3379.58616]
+        + [3686.38610, 3913.42869, 0.00000, 3608.84869, 3681.11110]
+    )
+    rt["variance"] = flex.double(
+        [10163.98104, 9577.90389, 9702.84868, 3.77427, 8244.70685]
+        + [9142.38221, 1.51118, 9634.53782, 9870.73103, 9078.23488]
+        + [8977.26984, 8712.91360, 1.78802, 7473.26521, 10075.49862]
+    )
+    rt["inverse_scale_factor"] = flex.double(rt.size(), 1.0)
+    rt["miller_index"] = flex.miller_index([(0, 0, 1)] * rt.size())
+    expected_outliers = [3, 6, 12]
+
+    OutlierRej = NormDevOutlierRejection(IhTable([rt], space_group("P 1")), zmax=6.0)
+    OutlierRej.run()
+    outliers = OutlierRej.final_outlier_arrays
+    assert len(outliers) == 1
+    assert set(outliers[0]) == set(expected_outliers)
+
+
 def test_multi_dataset_outlier_rejection(test_sg):
     """Test outlier rejection with two datasets."""
     rt1 = flex.reflection_table()

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -582,12 +582,12 @@ def test_multi_scale(dials_data, tmpdir):
     # that the new behaviour is more correct and update test accordingly.
     # Note: error optimisation currently appears to give worse results here!
     result = get_merging_stats(tmpdir.join("unmerged.mtz").strpath)
-    expected_nobs = 5411
+    expected_nobs = 5560  # 22/06/20
     print(result.overall.r_pim)
     print(result.overall.cc_one_half)
     assert abs(result.overall.n_obs - expected_nobs) < 100
-    assert result.overall.r_pim < 0.023  # at 07/08/18, value was 0.022722
-    assert result.overall.cc_one_half > 0.9965  # at 07/08/18, value was 0.996925
+    assert result.overall.r_pim < 0.016  # at #22/06/20, value was 0.015
+    assert result.overall.cc_one_half > 0.997  # at #22/06/20, value was 0.999
 
 
 def test_multi_scale_exclude_images(dials_data, tmpdir):

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -564,7 +564,7 @@ def test_multi_scale(dials_data, tmpdir):
     # Now inspect output, check it hasn't changed drastically, or if so verify
     # that the new behaviour is more correct and update test accordingly.
     result = get_merging_stats(tmpdir.join("unmerged.mtz").strpath)
-    expected_nobs = 5460
+    expected_nobs = 5526  # 19/06/20
     assert abs(result.overall.n_obs - expected_nobs) < 30
     assert result.overall.r_pim < 0.0221  # at 22/10/18, value was 0.22037
     assert result.overall.cc_one_half > 0.9975  # at 07/08/18, value was 0.99810

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -491,10 +491,8 @@ def test_scale_and_filter_image_group_mode(dials_data, tmpdir):
         [[16, 24], 4]
     ]
     assert analysis_results["cycle_results"]["2"]["image_ranges_removed"] == [
-        [[17, 24], 3]
-    ]
-    assert analysis_results["cycle_results"]["3"]["image_ranges_removed"] == [
-        [[21, 25], 5]
+        [[17, 24], 3],
+        [[21, 25], 5],
     ]
     assert analysis_results["termination_reason"] == "max_percent_removed"
 


### PR DESCRIPTION
- `dials.scale`: Fix bug in scaling outlier rejection code, which resulted in misidentification of outliers for recursive outlier searching (`outlier_rejection=standard`).
- `dials.scale`: Fix outlier rejection formula to avoid overconfidence in spuriously low values.
- `xia2`: fix reading data from NSLS II with multiple triggers and one image per trigger (xia2/xia2#475)
- `xia2.ispyb_xml`: fix crash on Python 3 (xia2/xia2#483)