### PR TITLE
install IOTA from conda-forge

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -22,6 +22,7 @@ conda-forge::eigen
 conda-forge::future
 conda-forge::h5py
 conda-forge::hdf5<1.11
+conda-forge::iota
 conda-forge::jinja2
 conda-forge::jpeg
 conda-forge::matplotlib-base>=3.0.2

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -26,6 +26,7 @@ conda-forge::eigen
 conda-forge::future
 conda-forge::h5py
 conda-forge::hdf5<1.11
+conda-forge::iota
 conda-forge::jinja2
 conda-forge::jpeg
 conda-forge::matplotlib-base>=3.0.2

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -22,6 +22,7 @@ conda-forge::eigen
 conda-forge::future
 conda-forge::h5py
 conda-forge::hdf5<1.11
+conda-forge::iota
 conda-forge::jinja2
 conda-forge::jpeg
 conda-forge::matplotlib-base>=3.0.2

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -783,7 +783,6 @@ REPOSITORIES = (
     "dials/dials",
     "dials/gui_resources",
     "dials/tntbx",
-    "ssrl-px/iota",
     "xia2/xia2",
 )
 
@@ -953,7 +952,6 @@ class DIALSBuilder(object):
             "dials",
             "xia2",
             "prime",
-            "iota",
             "--skip_phenix_dispatchers",
         ] + config_flags
         result = run_command(


### PR DESCRIPTION
The iota/libtbx_refresh<->iota/setup.py adapter hack seems to have stopped working.
Since a DIALS environment doesn't need to be an IOTA development environment we should really just install a stable version from conda-forge