### PR TITLE
fixed off by one error in output filename format

### DIFF
--- a/command_line/split_experiments.py
+++ b/command_line/split_experiments.py
@@ -125,14 +125,14 @@ class Script(object):
         experiments_template = functools.partial(
             params.output.template.format,
             prefix=params.output.experiments_prefix,
-            maxindexlength=len(str(len(experiments))),
+            maxindexlength=len(str(len(experiments) - 1)),
             extension="expt",
         )
 
         reflections_template = functools.partial(
             params.output.template.format,
             prefix=params.output.reflections_prefix,
-            maxindexlength=len(str(len(experiments))),
+            maxindexlength=len(str(len(experiments) - 1)),
             extension="refl",
         )
 


### PR DESCRIPTION
Currently, dials.split_experiments does not correctly determine the width of numerical file IDs. When splitting expt files with 10 experiments, dials.split_experiments will create 10 zero indexed files with width 2 file IDs (split_00.expt, split_01.expt, ... split_09.expt). This pull request will change the behavior so that it creates width 1 file IDs in this case. 