### PR TITLE
Run coverage on Azure

### DIFF
--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -174,7 +174,7 @@ steps:
     . dials
     cd modules/dials
     pytest -v -ra -n auto --basetemp="$(Pipeline.Workspace)/tests" --durations=10 \
-        --cov=dials --cov-report=xml --cov-branch \
+        --cov=$(pwd) --cov-report=xml --cov-branch \
         --timeout=5400 --regression --runslow || echo "##vso[task.complete result=Failed;]Some tests failed"
   displayName: Run tests
   workingDirectory: $(Pipeline.Workspace)

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -174,13 +174,13 @@ steps:
     . dials
     cd modules/dials
     pytest -v -ra -n auto --basetemp="$(Pipeline.Workspace)/tests" --durations=10 \
-        --cov=$(pwd) --cov-report=xml --cov-branch \
+        --cov=$(pwd) --cov-report=html --cov-report=xml --cov-branch \
         --timeout=5400 --regression --runslow || echo "##vso[task.complete result=Failed;]Some tests failed"
   displayName: Run tests
   workingDirectory: $(Pipeline.Workspace)
 
 - script: |
-    bash <(curl -s https://codecov.io/bash)
+    bash <(curl -s https://codecov.io/bash) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
   displayName: 'Publish coverage stats'
   continueOnError: True
   timeoutInMinutes: 3

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -174,10 +174,17 @@ steps:
     . dials
     cd modules/dials
     pytest -v -ra -n auto --basetemp="$(Pipeline.Workspace)/tests" --durations=10 \
-        --cov=dials --cov-report=html \
+        --cov=dials \
         --timeout=5400 --regression --runslow || echo "##vso[task.complete result=Failed;]Some tests failed"
   displayName: Run tests
   workingDirectory: $(Pipeline.Workspace)
+
+- script: |
+    bash <(curl -s https://codecov.io/bash)
+  displayName: 'Publish coverage stats'
+  continueOnError: True
+  timeoutInMinutes: 3
+  workingDirectory: $(Pipeline.Workspace)/modules/dials
 
 # Recover disk space after testing
 # This is only relevant if we had cache misses, as free disk space is required to create cache archives

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -174,7 +174,7 @@ steps:
     . dials
     cd modules/dials
     pytest -v -ra -n auto --basetemp="$(Pipeline.Workspace)/tests" --durations=10 \
-        --cov=dials \
+        --cov=dials --cov-report=xml --cov-branch \
         --timeout=5400 --regression --runslow || echo "##vso[task.complete result=Failed;]Some tests failed"
   displayName: Run tests
   workingDirectory: $(Pipeline.Workspace)

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -140,7 +140,7 @@ steps:
 - bash: |
     set -e
     . dials
-    conda install -p conda_base -y dials-data pytest-azurepipelines pytest-timeout
+    conda install -p conda_base -y dials-data pytest-azurepipelines pytest-cov pytest-timeout
     dials.data info -v
     echo "##vso[task.setvariable variable=DIALS_DATA_VERSION_FULL]$(dials.data info -v | grep version.full)"
     echo "##vso[task.setvariable variable=DIALS_DATA_VERSION]$(dials.data info -v | grep version.major)"
@@ -174,6 +174,7 @@ steps:
     . dials
     cd modules/dials
     pytest -v -ra -n auto --basetemp="$(Pipeline.Workspace)/tests" --durations=10 \
+        --cov=dials --cov-report=html \
         --timeout=5400 --regression --runslow || echo "##vso[task.complete result=Failed;]Some tests failed"
   displayName: Run tests
   workingDirectory: $(Pipeline.Workspace)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/dials/dials.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dials/dials/context:python)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/dials/dials.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dials/dials/alerts/)
-[![Coverage](https://codecov.io/github/dials/dials/coverage.svg?branch=master)](https://codecov.io/github/dials/dials?branch=master)
+[![Coverage](https://codecov.io/gh/dials/dials/branch/master/graph/badge.svg)](https://codecov.io/gh/dials/dials)
 
 X-ray crystallography for structural biology has benefited greatly from a number of advances in recent years including high performance pixel array detectors, new beamlines capable of delivering micron and sub-micron focus and new light sources such as XFELs. The DIALS project is a collaborative endeavour to develop new diffraction integration software to meet the data analysis requirements presented by these recent advances. There are three end goals: to develop an extensible framework for the development of algorithms to analyse X-ray diffraction data; the implementation of algorithms within this framework and finally a set of user facing tools using these algorithms to allow integration of data from diffraction experiments on synchrotron and free electron sources.
 


### PR DESCRIPTION
Before:
https://dev.azure.com/azure-dials/dials/_build/results?buildId=333&view=results
https://github.com/dials/dials/runs/811943466

After:
https://dev.azure.com/azure-dials/dials/_build/results?buildId=361&view=results
https://github.com/dials/dials/runs/822794676
https://codecov.io/gh/dials/dials/branch/coverage

Cost appears to be somewhere between 5 and 8 minutes runtime.
Benefit is that we get coverage testing on every branch and PR (which we don't get via Jenkins)
We will lose coverage on dials_regression tests which Jenkins did have.
On the other hand we can run on Python 3. The current Jenkins job is 2.7 only.