### PR TITLE
Integration output improvements

### DIFF
--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -637,13 +637,13 @@ class ProfileModellerExecutor(Executor):
 
         # Print a histogram of reflections on frames
         if frame1 - frame0 > 1:
-            logger.info(
+            logger.debug(
                 " The following histogram shows the number of reflections predicted"
             )
-            logger.info(" to have all or part of their intensity on each frame.")
-            logger.info("")
-            logger.info(frame_hist(reflections["bbox"], prefix=" ", symbol="*"))
-            logger.info("")
+            logger.debug(" to have all or part of their intensity on each frame.")
+            logger.debug("")
+            logger.debug(frame_hist(reflections["bbox"], prefix=" ", symbol="*"))
+            logger.debug("")
 
     def process(self, frame, reflections):
         """
@@ -738,13 +738,13 @@ class ProfileValidatorExecutor(Executor):
 
         # Print a histogram of reflections on frames
         if frame1 - frame0 > 1:
-            logger.info(
+            logger.debug(
                 " The following histogram shows the number of reflections predicted"
             )
-            logger.info(" to have all or part of their intensity on each frame.")
-            logger.info("")
-            logger.info(frame_hist(reflections["bbox"], prefix=" ", symbol="*"))
-            logger.info("")
+            logger.debug(" to have all or part of their intensity on each frame.")
+            logger.debug("")
+            logger.debug(frame_hist(reflections["bbox"], prefix=" ", symbol="*"))
+            logger.debug("")
 
         self.results = None
 
@@ -844,13 +844,13 @@ class IntegratorExecutor(Executor):
 
         # Print a histogram of reflections on frames
         if frame1 - frame0 > 1:
-            logger.info(
+            logger.debug(
                 " The following histogram shows the number of reflections predicted"
             )
-            logger.info(" to have all or part of their intensity on each frame.")
-            logger.info("")
-            logger.info(frame_hist(reflections["bbox"], prefix=" ", symbol="*"))
-            logger.info("")
+            logger.debug(" to have all or part of their intensity on each frame.")
+            logger.debug("")
+            logger.debug(frame_hist(reflections["bbox"], prefix=" ", symbol="*"))
+            logger.debug("")
 
         # Find any overlaps
         self.overlaps = reflections.find_overlaps(self.experiments)

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -1477,7 +1477,9 @@ class Integrator3DThreaded(object):
                 scan = self._experiments[expr[0]].scan
                 p0 = scan.get_angle_from_array_index(f0)
                 p1 = scan.get_angle_from_array_index(f1)
-                rows.append([str(i), str(group), str(f0), str(f1), str(p0), str(p1)])
+                rows.append(
+                    [str(i), str(group), str(f0 + 1), str(f1), str(p0), str(p1)]
+                )
         else:
             raise RuntimeError("Experiments must be all sequences or all stills")
         return tabulate(rows, headers="firstrow")

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -624,8 +624,8 @@ class ProfileModellerExecutor(Executor):
         ntot = len(reflections)
 
         # Write some output
-        logger.info("")
-        logger.info(" Beginning modelling job %d" % job.index)
+        logger.debug("")
+        logger.debug(" Beginning modelling job %d" % job.index)
         logger.info("")
         logger.info(" Frames: %d -> %d" % (frame0 + 1, frame1))
         logger.info("")
@@ -726,8 +726,8 @@ class ProfileValidatorExecutor(Executor):
         ntot = len(reflections)
 
         # Write some output
-        logger.info("")
-        logger.info(" Beginning modelling job %d" % job.index)
+        logger.debug("")
+        logger.debug(" Beginning modelling job %d" % job.index)
         logger.info("")
         logger.info(" Frames: %d -> %d" % (frame0, frame1))
         logger.info("")
@@ -832,8 +832,8 @@ class IntegratorExecutor(Executor):
         ntot = len(reflections)
 
         # Write some output
-        logger.info("")
-        logger.info(" Beginning integration job %d" % job.index)
+        logger.debug("")
+        logger.debug(" Beginning integration job %d" % job.index)
         logger.info("")
         logger.info(" Frames: %d -> %d" % (frame0, frame1))
         logger.info("")

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -913,7 +913,7 @@ class IntegratorExecutor(Executor):
         reflections["num_pixels.foreground"] = sbox.count_mask_values(code4)
 
         # Print some info
-        fmt = " Integrated % 5d (sum) + % 5d (prf) /% 5d reflections on image %d"
+        fmt = " Integrated % 5d (sum) + % 5d (prf) / %5d reflections on image %d"
         nsum = reflections.get_flags(reflections.flags.integrated_sum).count(True)
         nprf = reflections.get_flags(reflections.flags.integrated_prf).count(True)
         ntot = len(reflections)

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -626,7 +626,7 @@ class ProfileModellerExecutor(Executor):
         # Write some output
         logger.info(" Beginning modelling job %d" % job.index)
         logger.info("")
-        logger.info(" Frames: %d -> %d" % (frame0, frame1))
+        logger.info(" Frames: %d -> %d" % (frame0 + 1, frame1))
         logger.info("")
         logger.info(" Number of reflections")
         logger.info("  Partial:     %d" % npart)
@@ -917,7 +917,7 @@ class IntegratorExecutor(Executor):
         nsum = reflections.get_flags(reflections.flags.integrated_sum).count(True)
         nprf = reflections.get_flags(reflections.flags.integrated_prf).count(True)
         ntot = len(reflections)
-        logger.info(fmt % (nsum, nprf, ntot, frame))
+        logger.info(fmt % (nsum, nprf, ntot, frame + 1))
 
     def finalize(self):
         """
@@ -1243,7 +1243,9 @@ class Integrator(object):
                 scan = self._experiments[expr[0]].scan
                 p0 = scan.get_angle_from_array_index(f0)
                 p1 = scan.get_angle_from_array_index(f1)
-                rows.append([str(i), str(group), str(f0), str(f1), str(p0), str(p1)])
+                rows.append(
+                    [str(i), str(group), str(f0 + 1), str(f1), str(p0), str(p1)]
+                )
         else:
             raise RuntimeError("Experiments must be all sequences or all stills")
         return tabulate(rows, headers="firstrow")

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -917,7 +917,7 @@ class IntegratorExecutor(Executor):
         nsum = reflections.get_flags(reflections.flags.integrated_sum).count(True)
         nprf = reflections.get_flags(reflections.flags.integrated_prf).count(True)
         ntot = len(reflections)
-        logger.info(fmt % (nsum, nprf, ntot, frame + 1))
+        logger.info(fmt % (nsum, nprf, ntot, frame))
 
     def finalize(self):
         """

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -878,29 +878,6 @@ class IntegratorExecutor(Executor):
         if self.profile_fitter:
             reflections.compute_fitted_intensity(self.profile_fitter)
 
-        # from matplotlib import pylab
-        # from dials.array_family import flex
-        # I = reflections['intensity.sum.value']
-        # F = reflections.get_flags(reflections.flags.integrated_sum)
-        # A = flex.size_t(range(len(reflections)))
-        # A = A.select(F)
-        # I = I.select(F)
-        # index = flex.max_index(I)
-        # index = A[index]
-        # sbox = reflections['shoebox'][index]
-        # zmin, zmax = sbox.bbox[4:6]
-        # zind = int((zmin + zmax) / 2)
-        # image1 = sbox.background.as_numpy_array().sum(axis=0)
-        # image2 = sbox.data.as_numpy_array().sum(axis=0)
-        # vmin=image1.min()#min([image1.min(), image2.min()])
-        # vmax=image1.max()#min([image1.max(), image2.max()])
-        # print image1.min(), image1.max(), image2.min(), image2.max()
-        # pylab.subplot(121)
-        # pylab.imshow(image1, interpolation='none', vmin=vmin, vmax=vmax)
-        # pylab.subplot(122)
-        # pylab.imshow(image2, interpolation='none', vmin=vmin, vmax=vmax)
-        # pylab.show()
-
         # Compute the number of background/foreground pixels
         sbox = reflections["shoebox"]
         code1 = MaskCode.Valid

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -624,6 +624,7 @@ class ProfileModellerExecutor(Executor):
         ntot = len(reflections)
 
         # Write some output
+        logger.info("")
         logger.info(" Beginning modelling job %d" % job.index)
         logger.info("")
         logger.info(" Frames: %d -> %d" % (frame0 + 1, frame1))
@@ -670,7 +671,7 @@ class ProfileModellerExecutor(Executor):
         fmt = " Modelled % 5d / % 5d reflection profiles on image %d"
         nmod = reflections.get_flags(reflections.flags.used_in_modelling).count(True)
         ntot = len(reflections)
-        logger.info(fmt % (nmod, ntot, frame))
+        logger.debug(fmt % (nmod, ntot, frame + 1))
 
     def finalize(self):
         """
@@ -725,6 +726,7 @@ class ProfileValidatorExecutor(Executor):
         ntot = len(reflections)
 
         # Write some output
+        logger.info("")
         logger.info(" Beginning modelling job %d" % job.index)
         logger.info("")
         logger.info(" Frames: %d -> %d" % (frame0, frame1))
@@ -773,7 +775,7 @@ class ProfileValidatorExecutor(Executor):
         fmt = " Validated % 5d / % 5d reflection profiles on image %d"
         nmod = reflections.get_flags(reflections.flags.used_in_modelling).count(True)
         ntot = len(reflections)
-        logger.info(fmt % (nmod, ntot, frame))
+        logger.debug(fmt % (nmod, ntot, frame + 1))
 
     def finalize(self):
         """
@@ -830,6 +832,7 @@ class IntegratorExecutor(Executor):
         ntot = len(reflections)
 
         # Write some output
+        logger.info("")
         logger.info(" Beginning integration job %d" % job.index)
         logger.info("")
         logger.info(" Frames: %d -> %d" % (frame0, frame1))
@@ -894,7 +897,7 @@ class IntegratorExecutor(Executor):
         nsum = reflections.get_flags(reflections.flags.integrated_sum).count(True)
         nprf = reflections.get_flags(reflections.flags.integrated_prf).count(True)
         ntot = len(reflections)
-        logger.info(fmt % (nsum, nprf, ntot, frame + 1))
+        logger.debug(fmt % (nsum, nprf, ntot, frame + 1))
 
     def finalize(self):
         """

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -917,7 +917,7 @@ class IntegratorExecutor(Executor):
         nsum = reflections.get_flags(reflections.flags.integrated_sum).count(True)
         nprf = reflections.get_flags(reflections.flags.integrated_prf).count(True)
         ntot = len(reflections)
-        logger.info(fmt % (nsum, nprf, ntot, frame))
+        logger.info(fmt % (nsum, nprf, ntot, frame + 1))
 
     def finalize(self):
         """

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -909,7 +909,7 @@ class _Manager(object):
                 p1 = scan.get_angle_from_array_index(f1)
                 n = self.manager.num_reflections(i)
                 rows.append(
-                    [str(i), str(group), str(f0), str(f1), str(p0), str(p1), str(n)]
+                    [str(i), str(group), str(f0), str(f1 + 1), str(p0), str(p1), str(n)]
                 )
         else:
             raise RuntimeError("Experiments must be all sequences or all stills")

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -909,7 +909,7 @@ class _Manager(object):
                 p1 = scan.get_angle_from_array_index(f1)
                 n = self.manager.num_reflections(i)
                 rows.append(
-                    [str(i), str(group), str(f0), str(f1 + 1), str(p0), str(p1), str(n)]
+                    [str(i), str(group), str(f0 + 1), str(f1), str(p0), str(p1), str(n)]
                 )
         else:
             raise RuntimeError("Experiments must be all sequences or all stills")

--- a/algorithms/integration/report.py
+++ b/algorithms/integration/report.py
@@ -339,7 +339,7 @@ class IntegrationReport(Report):
                 table.rows.append(
                     [
                         "%d" % j,
-                        "%d" % report["bins"][i],
+                        "%d" % (report["bins"][i] + 1),
                         "%d" % report["n_full"][i],
                         "%d" % report["n_partial"][i],
                         "%d" % report["n_overload"][i],

--- a/algorithms/integration/report.py
+++ b/algorithms/integration/report.py
@@ -339,7 +339,7 @@ class IntegrationReport(Report):
                 table.rows.append(
                     [
                         "%d" % j,
-                        "%d" % (report["bins"][i] + 1),
+                        "%d" % report["bins"][i],
                         "%d" % report["n_full"][i],
                         "%d" % report["n_partial"][i],
                         "%d" % report["n_overload"][i],

--- a/newsfragments/1319.feature
+++ b/newsfragments/1319.feature
@@ -1,0 +1,1 @@
+dials.integrate: reduce volume of output by moving histograms etc. to debug output - use "-vv" on command-line to restore. 


### PR DESCRIPTION
- move a lot of the output from `dials.integrate` to debug
- fix a lot of off-by-one errors

In example of 2,400 image scan reduced output length by 68% [1] without reducing the amount of signal in the output. 

[1]  ->

```
Grey-Area original :) $ wc -l dials.integrate.log 
   24945 dials.integrate.log
Grey-Area reduced :) $ wc -l dials.integrate.log 
    8100 dials.integrate.log
```