### PR TITLE
Only show DEBUG messages if verbosity > 1

### DIFF
--- a/newsfragments/1322.misc
+++ b/newsfragments/1322.misc
@@ -1,0 +1,1 @@
+Only show debug output with -vv. -v will give standard output plus timing information.

--- a/test/util/test_log.py
+++ b/test/util/test_log.py
@@ -6,8 +6,9 @@ import dials.util.log
 
 
 def test_LoggingContext():
+
     # configure logging
-    dials.util.log.config(verbosity=1)
+    dials.util.log.config(verbosity=2)
 
     # get some loggers
     idx_logger = logging.getLogger("dials.algorithms.indexing")

--- a/util/log.py
+++ b/util/log.py
@@ -73,7 +73,7 @@ def config(verbosity=0, logfile=None):
     dials_logger = logging.getLogger("dials")
     dials_logger.addHandler(console)
 
-    if verbosity:
+    if verbosity > 1:
         loglevel = logging.DEBUG
     else:
         loglevel = logging.INFO

--- a/util/options.py
+++ b/util/options.py
@@ -683,7 +683,11 @@ class OptionParserBase(optparse.OptionParser, object):
 
         # Set a verbosity parameter
         self.add_option(
-            "-v", action="count", default=0, dest="verbose", help="Increase verbosity"
+            "-v",
+            action="count",
+            default=0,
+            dest="verbose",
+            help="Increase verbosity (can be specified multiple times)",
         )
 
         # Add an option for PHIL file to parse - PHIL files passed as


### PR DESCRIPTION
Following 0e4ec1d, this allows for getting the normal log output plus the timing information only. Previously, you could only get the normal output only, or the DEBUG messages plus timing. Since some DEBUG messages potentially involve some expensive calculations, timing output may not be representative of normal runtime.