### PR TITLE
Plot bin centres instead of bin d_min

### DIFF
--- a/newsfragments/1323.bugfix
+++ b/newsfragments/1323.bugfix
@@ -1,0 +1,1 @@
+Plot resolution bin centres instead of bin d_min for plots vs. resolution in html reports

--- a/report/plots.py
+++ b/report/plots.py
@@ -540,7 +540,8 @@ class ResolutionPlotsAndStats(ResolutionPlotterMixin):
         self.dataset_statistics = dataset_statistics
         self.anomalous_dataset_statistics = anomalous_dataset_statistics
         self.d_star_sq_bins = [
-            (1 / bin_stats.d_min ** 2) for bin_stats in self.dataset_statistics.bins
+            0.5 * (uctbx.d_as_d_star_sq(b.d_max) + uctbx.d_as_d_star_sq(b.d_min))
+            for b in self.dataset_statistics.bins
         ]
         self.d_star_sq_tickvals, self.d_star_sq_ticktext = self._d_star_sq_to_d_ticks(
             self.d_star_sq_bins, nticks=5

--- a/report/test_plots.py
+++ b/report/test_plots.py
@@ -8,7 +8,7 @@ import random
 
 import mock as mock
 import pytest
-from cctbx import miller, crystal
+from cctbx import miller, crystal, uctbx
 from cctbx.array_family import flex
 from dials.report.plots import (
     ResolutionPlotsAndStats,
@@ -162,10 +162,17 @@ def test_ResolutionPlotsAndStats(iobs):
     )
     plotter = ResolutionPlotsAndStats(result, anom_result)
 
-    assert plotter.d_star_sq_ticktext == ["1.26", "1.19", "1.13", "1.08", "1.04"]
+    assert plotter.d_star_sq_ticktext == ["1.74", "1.53", "1.38", "1.27", "1.18"]
 
     assert plotter.d_star_sq_tickvals == pytest.approx(
-        [0.6319, 0.7055, 0.7792, 0.8528, 0.9264], 1e-4
+        [
+            0.32984033277048164,
+            0.42706274943714834,
+            0.524285166103815,
+            0.6215075827704818,
+            0.7187299994371485,
+        ],
+        1e-4,
     )
 
     tables = plotter.statistics_tables()
@@ -175,6 +182,10 @@ def test_ResolutionPlotsAndStats(iobs):
     d = plotter.cc_one_half_plot()
     assert len(d["cc_one_half"]["data"]) == 4
     assert all(len(x["x"]) == n_bins for x in d["cc_one_half"]["data"])
+    d["cc_one_half"]["data"][0]["x"] == [
+        0.5 * (uctbx.d_as_d_star_sq(b.d_max) + uctbx.d_as_d_star_sq(b.d_min))
+        for b in result.bins
+    ]
 
     d = plotter.i_over_sig_i_plot()
     assert len(d["i_over_sig_i"]["data"]) == 1


### PR DESCRIPTION
This should be more representative of the data, and avoids potentially misleading apparent differences between merging statistics calculated using significantly different resolution limits (see also xia2/xia2#480).

Resolution stats reported by `dials.report`:
`$ dials.report $(dials.data get -q x4wide_processed)/AUTOMATIC_DEFAULT_scaled.{expt,refl}`
<img width="1284" alt="Screenshot 2020-07-04 at 14 30 31" src="https://user-images.githubusercontent.com/2810624/86513577-2a2d1b80-be03-11ea-8c62-64042c6e13f9.png">

Before (i.e. plotting bin d_min):

![newplot (7)](https://user-images.githubusercontent.com/2810624/86513501-aa9f4c80-be02-11ea-9b55-7e039c80b403.png)
 ![newplot (8)](https://user-images.githubusercontent.com/2810624/86513503-ac691000-be02-11ea-8fac-7e2863119f0d.png)

After (i.e. plotting bin centres rather than d_min):
![newplot (5)](https://user-images.githubusercontent.com/2810624/86513512-bc80ef80-be02-11ea-8553-16a330fb00f1.png)
![newplot (6)](https://user-images.githubusercontent.com/2810624/86513515-bee34980-be02-11ea-8314-d250e302f41a.png)