### PR TITLE
Update tqdm dependency

### DIFF
--- a/.conda-envs/dials_py27_linux-64.txt
+++ b/.conda-envs/dials_py27_linux-64.txt
@@ -40,6 +40,6 @@ six
 sphinx<1.9
 sqlite
 tabulate
-tqdm=4.23.4
+tqdm
 urllib3
 xz

--- a/.conda-envs/dials_py27_osx-64.txt
+++ b/.conda-envs/dials_py27_osx-64.txt
@@ -43,6 +43,6 @@ conda-forge::six
 conda-forge::sphinx<1.9
 conda-forge::sqlite
 conda-forge::tabulate
-conda-forge::tqdm=4.23.4
+conda-forge::tqdm
 conda-forge::urllib3
 conda-forge::xz

--- a/.conda-envs/dials_py36_linux-64.txt
+++ b/.conda-envs/dials_py36_linux-64.txt
@@ -39,7 +39,7 @@ conda-forge::six
 conda-forge::sphinx
 conda-forge::sqlite
 conda-forge::tabulate
-conda-forge::tqdm=4.23.4
+conda-forge::tqdm
 conda-forge::urllib3
 conda-forge::wxpython>=4.0.1
 conda-forge::xz

--- a/.conda-envs/dials_py36_osx-64.txt
+++ b/.conda-envs/dials_py36_osx-64.txt
@@ -43,7 +43,7 @@ conda-forge::six
 conda-forge::sphinx
 conda-forge::sqlite
 conda-forge::tabulate
-conda-forge::tqdm=4.23.4
+conda-forge::tqdm
 conda-forge::urllib3
 conda-forge::wxpython>=4.0.1
 conda-forge::xz

--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -45,7 +45,7 @@ conda-forge::six
 conda-forge::sphinx
 conda-forge::sqlite
 conda-forge::tabulate
-conda-forge::tqdm=4.23.4
+conda-forge::tqdm
 conda-forge::urllib3
 conda-forge::wxpython>=4.0.1
 conda-forge::xz

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -49,7 +49,7 @@ conda-forge::six
 conda-forge::sphinx
 conda-forge::sqlite
 conda-forge::tabulate
-conda-forge::tqdm=4.23.4
+conda-forge::tqdm
 conda-forge::urllib3
 conda-forge::wxpython>=4.0.1
 conda-forge::xz

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -44,7 +44,7 @@ conda-forge::six
 conda-forge::sphinx
 conda-forge::sqlite
 conda-forge::tabulate
-conda-forge::tqdm=4.23.4
+conda-forge::tqdm
 conda-forge::urllib3
 conda-forge::wxpython>=4.0.1
 conda-forge::xz


### PR DESCRIPTION
and remove version restriction.

Required for Python 3.8 support, #1236 