### PR TITLE
Determine scaling error model using anomalous groups.

### DIFF
--- a/algorithms/scaling/scaler.py
+++ b/algorithms/scaling/scaler.py
@@ -204,9 +204,8 @@ class ScalerBase(Subject):
     @Subject.notify_event(event="performed_error_analysis")
     def perform_error_optimisation(self, update_Ih=True):
         """Perform an optimisation of the sigma values."""
-        Ih_table = self.global_Ih_table
-        Ih_table.reset_error_model()
-        Ih_table.calc_Ih()
+        # error model should be determined using anomalous groups
+        Ih_table, _ = self._create_global_Ih_table(anomalous=True, remove_outliers=True)
         try:
             model = run_error_model_refinement(
                 self.params.weighting.error_model, Ih_table
@@ -733,6 +732,41 @@ attempting to use all reflections for minimisation."""
             new_vars = self.error_model.update_variances(variance, intensity)
             self._Ih_table.update_data_in_blocks(new_vars, 0, column="variance")
 
+    def _create_global_Ih_table(
+        self, free_set_percentage=0, anomalous=False, remove_outliers=False
+    ):
+        sel_reflections = self.get_valid_reflections()
+        if remove_outliers:
+            sel_reflections = sel_reflections.select(~self.outliers)
+        free_Ih_table = None
+        global_Ih_table = IhTable(
+            [sel_reflections],
+            self.experiment.crystal.get_space_group(),
+            nblocks=1,
+            free_set_percentage=free_set_percentage,
+            free_set_offset=self.params.scaling_options.free_set_offset,
+            anomalous=anomalous,
+        )
+        if free_set_percentage:
+            loc_indices = global_Ih_table.blocked_data_list[-1].Ih_table["loc_indices"]
+            self.free_set_selection = flex.bool(self.n_suitable_refl, False)
+            self.free_set_selection.set_selected(loc_indices, True)
+            global_Ih_table = IhTable(
+                [sel_reflections.select(~self.free_set_selection)],
+                self.experiment.crystal.get_space_group(),
+                [(~self.free_set_selection).iselection()],
+                nblocks=1,
+                anomalous=anomalous,
+            )
+            free_Ih_table = IhTable(
+                [sel_reflections.select(self.free_set_selection)],
+                self.experiment.crystal.get_space_group(),
+                [self.free_set_selection.iselection()],
+                nblocks=1,
+                anomalous=anomalous,
+            )
+        return global_Ih_table, free_Ih_table
+
     def _configure_model_and_datastructures(self, for_multi=False):
         """
         Store the relevant data in the scaling model components.
@@ -750,34 +784,9 @@ attempting to use all reflections for minimisation."""
         free_set_percentage = 0
         if self.params.scaling_options.use_free_set and not for_multi:
             free_set_percentage = self.params.scaling_options.free_set_percentage
-        self._global_Ih_table = IhTable(
-            [sel_reflections],
-            self.experiment.crystal.get_space_group(),
-            nblocks=1,
-            free_set_percentage=free_set_percentage,
-            free_set_offset=self.params.scaling_options.free_set_offset,
-            anomalous=self.params.anomalous,
+        self._global_Ih_table, self._free_Ih_table = self._create_global_Ih_table(
+            free_set_percentage=free_set_percentage, anomalous=self.params.anomalous
         )
-        if free_set_percentage:
-            loc_indices = self.global_Ih_table.blocked_data_list[-1].Ih_table[
-                "loc_indices"
-            ]
-            self.free_set_selection = flex.bool(self.n_suitable_refl, False)
-            self.free_set_selection.set_selected(loc_indices, True)
-            self._global_Ih_table = IhTable(
-                [sel_reflections.select(~self.free_set_selection)],
-                self.experiment.crystal.get_space_group(),
-                [(~self.free_set_selection).iselection()],
-                nblocks=1,
-                anomalous=self.params.anomalous,
-            )
-            self._free_Ih_table = IhTable(
-                [sel_reflections.select(self.free_set_selection)],
-                self.experiment.crystal.get_space_group(),
-                [self.free_set_selection.iselection()],
-                nblocks=1,
-                anomalous=self.params.anomalous,
-            )
         rows = [[key, str(val.n_params)] for key, val in six.iteritems(self.components)]
         logger.info("The following corrections will be applied to this dataset: \n")
         logger.info(tabulate(rows, ["correction", "n_parameters"]))
@@ -954,20 +963,27 @@ class MultiScalerBase(ScalerBase):
             for component in scaler.components.values():
                 component.update_reflection_data(block_selections=block_selections)
 
-    def _create_global_Ih_table(self):
-        tables = [s.get_valid_reflections() for s in self.active_scalers]
+    def _create_global_Ih_table(self, anomalous=False, remove_outliers=False):
+        if remove_outliers:
+            tables = [
+                s.get_valid_reflections().select(~s.outliers)
+                for s in self.active_scalers
+            ]
+        else:
+            tables = [s.get_valid_reflections() for s in self.active_scalers]
         free_set_percentage = 0.0
+        free_Ih_table = None
         if self.params.scaling_options.use_free_set:
             free_set_percentage = self.params.scaling_options.free_set_percentage
         space_group = self.active_scalers[0].experiment.crystal.get_space_group()
-        self._global_Ih_table = IhTable(
+        global_Ih_table = IhTable(
             tables,
             space_group,
             nblocks=1,
             additional_cols=["partiality"],
             free_set_percentage=free_set_percentage,
             free_set_offset=self.params.scaling_options.free_set_offset,
-            anomalous=self.params.anomalous,
+            anomalous=anomalous,
         )
         if free_set_percentage:
             # need to set free_set_selection in individual scalers
@@ -976,10 +992,8 @@ class MultiScalerBase(ScalerBase):
             indices_list = []
             free_indices_list = []
             for i, scaler in enumerate(self.active_scalers):
-                sel = (
-                    self.global_Ih_table.Ih_table_blocks[-1].Ih_table["dataset_id"] == i
-                )
-                indiv_Ih_block = self.global_Ih_table.Ih_table_blocks[-1].select(sel)
+                sel = global_Ih_table.Ih_table_blocks[-1].Ih_table["dataset_id"] == i
+                indiv_Ih_block = global_Ih_table.Ih_table_blocks[-1].select(sel)
                 loc_indices = indiv_Ih_block.Ih_table["loc_indices"]
                 scaler.free_set_selection = flex.bool(scaler.n_suitable_refl, False)
                 scaler.free_set_selection.set_selected(loc_indices, True)
@@ -987,20 +1001,17 @@ class MultiScalerBase(ScalerBase):
                 free_tables.append(scaler.get_free_set_reflections())
                 free_indices_list.append(scaler.free_set_selection.iselection())
                 indices_list.append((~scaler.free_set_selection).iselection())
-            self._global_Ih_table = IhTable(
-                tables,
-                space_group,
-                indices_list,
-                nblocks=1,
-                anomalous=self.params.anomalous,
+            global_Ih_table = IhTable(
+                tables, space_group, indices_list, nblocks=1, anomalous=anomalous,
             )
-            self._free_Ih_table = IhTable(
+            free_Ih_table = IhTable(
                 free_tables,
                 space_group,
                 free_indices_list,
                 nblocks=1,
-                anomalous=self.params.anomalous,
+                anomalous=anomalous,
             )
+        return global_Ih_table, free_Ih_table
 
     def _create_Ih_table(self):
         """Create a new Ih table from the reflection tables."""
@@ -1059,7 +1070,9 @@ class MultiScalerBase(ScalerBase):
         """
         assert self.active_scalers is not None
         if not self.global_Ih_table:
-            self._create_global_Ih_table()
+            self._global_Ih_table, self._free_Ih_table = self._create_global_Ih_table(
+                anomalous=self.params.anomalous
+            )
         if self.params.scaling_options.outlier_rejection:
             outlier_index_arrays = determine_outlier_index_arrays(
                 self.global_Ih_table,
@@ -1345,7 +1358,9 @@ class MultiScaler(MultiScalerBase):
         super(MultiScaler, self).__init__(single_scalers)
         logger.info("Determining symmetry equivalent reflections across datasets.\n")
         self._active_scalers = self.single_scalers
-        self._create_global_Ih_table()
+        self._global_Ih_table, self._free_Ih_table = self._create_global_Ih_table(
+            self.params.anomalous
+        )
         # now select reflections from across the datasets
         self._select_reflections_for_scaling()
         self._create_Ih_table()
@@ -1446,7 +1461,9 @@ class TargetScaler(MultiScalerBase):
         logger.info("Determining symmetry equivalent reflections across datasets.\n")
         self.unscaled_scalers = unscaled_scalers
         self._active_scalers = unscaled_scalers
-        self._create_global_Ih_table()
+        self._global_Ih_table, self._free_Ih_table = self._create_global_Ih_table(
+            self.params.anomalous
+        )
         self._select_reflections_for_scaling()
         tables = [
             s.reflection_table.select(s.suitable_refl_for_scaling_sel).select(

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -323,11 +323,11 @@ def vmxi_protk_reindexed(dials_data, tmpdir):
         (["error_model=None"], None, None),
         (
             ["error_model=basic", "basic.minimisation=individual"],
-            (0.73711, 0.04720),
+            (0.61, 0.049),
             (0.05, 0.005),
         ),
-        (["error_model.basic.a=0.73711"], (0.73711, 0.04720), (1e-6, 0.005)),
-        (["error_model.basic.b=0.04720"], (0.73711, 0.04720), (0.05, 1e-6)),
+        (["error_model.basic.a=0.61"], (0.61, 0.049), (1e-6, 0.005)),
+        (["error_model.basic.b=0.049"], (0.61, 0.049), (0.05, 1e-6)),
         (
             ["error_model.basic.b=0.02", "error_model.basic.a=1.5"],
             (1.50, 0.02),

--- a/command_line/refine_error_model.py
+++ b/command_line/refine_error_model.py
@@ -95,7 +95,9 @@ def refine_error_model(params, experiments, reflection_tables):
             )
         reflection_tables[i] = table
     space_group = experiments[0].crystal.get_space_group()
-    Ih_table = IhTable(reflection_tables, space_group, additional_cols=["partiality"])
+    Ih_table = IhTable(
+        reflection_tables, space_group, additional_cols=["partiality"], anomalous=True
+    )
 
     # now do the error model refinement
     try:

--- a/newsfragments/1332.feature
+++ b/newsfragments/1332.feature
@@ -1,0 +1,1 @@
+Separate anomalous pairs during error model analysis in dials.scale


### PR DESCRIPTION
While investigating anomalous signal in DIALS processing #1215 , I have realised that anomalous pairs should be separated for error model determination in scaling. 

Consider a low resolution reflection with a large anomalous difference measured many times. The I+ reflections should be normally distributed around I+, and the I- around I-. If the separation is large, then it is clearly wrong to consider that they should be normally distributed around Imean (which is the current assumption underlying the error model minimisation); and doing so should lead to an overinflation of the errors (larger error model parameters) and hence reduction in metrics such as dI/s(dI). I believe it is correct therefore that anomalous data should always be separated for error modelling, regardless of whether anomalous data is separate for scaling model determination.

I have tested this change on a selection of test datasets: In summary, the change in refined error model parameters leads to an overall increase in I/sigma,  dI/s and anomalous slope, with some datasets affected more than others. The effect on anomalous correlation seems variable.

**Beta-lactamase**

|  | Master	|	PR |
| -------| -------| -------|
|Anomalous correlation      |       0.312 		|	0.358 |
|Anomalous slope             |          0.805	|		1.097|
|dI/s(dI)                        |                 0.956	|		1.265|
|Error model a, b	|	0.975, 0.035	|	0.711, 0.038|

**x4-wide**

|  | Master	|	PR |
| -------| -------| -------|
|Anomalous correlation      |       0.320 		|	0.280 |
|Anomalous slope             |          0.163	|		0.280|
|dI/s(dI)                        |                 0.293	|		0.418|
|Error model a, b	|	4.306, 0.003	|	2.484, 0.003|

**Insulin** (dataset 5, issue #1215)

| | Master	|	PR |
| -------| -------| -------|
|Anomalous correlation      |       0.173 		|	0.161 |
|Anomalous slope             |          1.371	|		1.712|
|dI/s(dI)                        |                 1.150	|		1.366|
|Error model a, b	|	1.149, 0.051	|	0.853, 0.056|

**Thaumatin** (dataset 10, issue #1215) Less affected

|  | Master	|	PR |
| -------| -------| -------|
|Anomalous correlation      |       0.436 		|	0.443 |
|Anomalous slope             |          0.283	|		0.301 |
|dI/s(dI)                        |                 0.477	|		0.498|
|Error model a, b	|	2.465, 0.014	|	2.309, 0.015 |

**weak thermolysin**. Less affected

|  | Master	|	PR |
| -------| -------| -------|
|Anomalous correlation      |       0.367 		|	0.363 |
|Anomalous slope             |          0.532	|		0.552|
|dI/s(dI)                        |                 0.606	|		0.631|
|Error model a, b	|	1.065, 0.035	|	1.033, 0.036|


