### PR TITLE
deltacchalf filtering: allow image_group mode on single data set

### DIFF
--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -350,11 +350,14 @@ scaling from this point for an improved model.""",
 class ScaleAndFilterAlgorithm(ScalingAlgorithm):
     def __init__(self, params, experiments, reflections):
         super(ScaleAndFilterAlgorithm, self).__init__(params, experiments, reflections)
-        if self.scaler.id_ != "multi":
+        if (
+            params.filtering.deltacchalf.mode == "dataset"
+            and self.scaler.id_ != "multi"
+        ):
             raise ValueError(
-                """
-Scaling and filtering can only be performed in multi-dataset scaling mode
-(not single dataset or scaling against a reference)"""
+                """\
+Whole dataset deltacchalf scaling and filtering can only be performed in
+multi-dataset scaling mode (not single dataset or scaling against a reference)"""
             )
 
     @Subject.notify_event(event="run_scale_and_filter")

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -512,6 +512,34 @@ def test_scale_and_filter_image_group_mode(dials_data, tmpdir):
     assert analysis_results["termination_reason"] == "max_percent_removed"
 
 
+def test_scale_and_filter_image_group_single_dataset(dials_data, tmpdir):
+    """Test the scale and filter deltacchalf.mode=image_group on a
+       single data set."""
+    data_dir = dials_data("l_cysteine_dials_output")
+    command = [
+        "dials.scale",
+        data_dir / "20_integrated.pickle",
+        data_dir / "20_integrated_experiments.json",
+        "filtering.method=deltacchalf",
+        "stdcutoff=3.0",
+        "mode=image_group",
+        "max_cycles=1",
+        "scale_and_filter_results=analysis_results.json",
+        "error_model=None",
+    ]
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("scaled.refl").check()
+    assert tmpdir.join("scaled.expt").check()
+    assert tmpdir.join("analysis_results.json").check()
+
+    with open(tmpdir.join("analysis_results.json").strpath) as f:
+        analysis_results = json.load(f)
+    assert analysis_results["cycle_results"]["1"]["image_ranges_removed"] == []
+    assert len(analysis_results["cycle_results"].keys()) == 1
+    assert analysis_results["termination_reason"] == "no_more_removed"
+
+
 def test_scale_dose_decay_model(dials_data, tmpdir):
     """Test the scale and filter command line program."""
     location = dials_data("multi_crystal_proteinase_k")

--- a/newsfragments/1334.feature
+++ b/newsfragments/1334.feature
@@ -1,0 +1,1 @@
+dials.scale: allow image_group mode of deltacchalf filtering on a single data set


### PR DESCRIPTION
It works, and seems to be a valid thing to do, so don't prohibit it. Only catch whole data set deltacchalf mode, which won't work on a single data set (obviously).

Fixes #1161