### PR TITLE
Officially support Python 3.7 and 3.8

### DIFF
--- a/.azure-pipelines/azure-pipelines-mac.yml
+++ b/.azure-pipelines/azure-pipelines-mac.yml
@@ -13,8 +13,8 @@ jobs:
         PYTHON_VERSION: 3.6
       python37:
         PYTHON_VERSION: 3.7
-#     python38:
-#       PYTHON_VERSION: 3.8
+      python38:
+        PYTHON_VERSION: 3.8
   timeoutInMinutes: 150
 
   steps:

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -91,14 +91,6 @@ def install_miniconda(location):
 
 
 def install_conda(python):
-    if python in ("3.7", "3.8") and not sys.platform.startswith("linux"):
-        print(
-            "\n",
-            "*" * 80 + "\n",
-            " Python version {python} is not supported yet.\n".format(python=python),
-            "*" * 80 + "\n\n",
-        )
-
     # Find relevant conda base installation
     conda_base = os.path.realpath("miniconda")
     if os.name == "nt":

--- a/newsfragments/1236.feature
+++ b/newsfragments/1236.feature
@@ -1,0 +1,1 @@
+DIALS now supports Python 3.7 and 3.8

--- a/test/command_line/test_find_spots_server_client.py
+++ b/test/command_line/test_find_spots_server_client.py
@@ -16,7 +16,7 @@ def start_server(server_command, working_directory):
 
 def test_find_spots_server_client(dials_data, tmpdir):
     if sys.hexversion >= 0x3080000 and sys.platform == "darwin":
-        pytest.skip("find_sports server known to be broken on MacOS with Python 3.8+")
+        pytest.skip("find_spots server known to be broken on MacOS with Python 3.8+")
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind(("", 0))

--- a/test/command_line/test_find_spots_server_client.py
+++ b/test/command_line/test_find_spots_server_client.py
@@ -4,6 +4,7 @@ import multiprocessing
 import procrunner
 import pytest
 import socket
+import sys
 import time
 import timeit
 from xml.dom import minidom
@@ -14,6 +15,9 @@ def start_server(server_command, working_directory):
 
 
 def test_find_spots_server_client(dials_data, tmpdir):
+    if sys.hexversion >= 0x3080000 and sys.platform == "darwin":
+        pytest.skip("find_sports server known to be broken on MacOS with Python 3.8+")
+
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind(("", 0))
     port = s.getsockname()[1]


### PR DESCRIPTION
Closes #1236 

Disables `find_spots_server` test on MacOS+Python 3.8+ as described in https://github.com/dials/dials/issues/1236#issuecomment-655183518
