### PR TITLE
dials.integrate: give option to not output unintegrated reflections

### DIFF
--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -53,6 +53,7 @@ phil_scope = parse(
 
     output_unintegrated_reflections = True
       .type = bool
+      .expert_level = 2
       .help = "Include unintegrated reflections in output file"
 
     reflections = 'integrated.refl'

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -51,6 +51,10 @@ phil_scope = parse(
       .type = str
       .help = "The experiments output filename"
 
+    copy_input_reflections = False
+      .type = bool
+      .help = "Copy input reflections to output"
+
     reflections = 'integrated.refl'
       .type = str
       .help = "The integrated output filename"
@@ -553,6 +557,16 @@ def run_integration(params, experiments, reference=None):
 
     # Integrate the reflections
     reflections = integrator.integrate()
+
+    # Remove unintegrated reflections
+    if not params.output.copy_input_reflections:
+        keep = reflections.get_flags(reflections.flags.integrated, all=False)
+        logger.info(
+            "Removing %d unintegrated reflections of %d total"
+            % (keep.count(False), keep.size())
+        )
+
+        reflections = reflections.select(keep)
 
     # Append rubbish data onto the end
     if rubbish is not None and params.output.include_bad_reference:

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -51,7 +51,7 @@ phil_scope = parse(
       .type = str
       .help = "The experiments output filename"
 
-    output_unintegrated_reflections = False
+    output_unintegrated_reflections = True
       .type = bool
       .help = "Include unintegrated reflections in output file"
 

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -51,9 +51,9 @@ phil_scope = parse(
       .type = str
       .help = "The experiments output filename"
 
-    copy_input_reflections = False
+    output_unintegrated_reflections = False
       .type = bool
-      .help = "Copy input reflections to output"
+      .help = "Include unintegrated reflections in output file"
 
     reflections = 'integrated.refl'
       .type = str
@@ -559,7 +559,7 @@ def run_integration(params, experiments, reference=None):
     reflections = integrator.integrate()
 
     # Remove unintegrated reflections
-    if not params.output.copy_input_reflections:
+    if not params.output.output_unintegrated_reflections:
         keep = reflections.get_flags(reflections.flags.integrated, all=False)
         logger.info(
             "Removing %d unintegrated reflections of %d total"
@@ -647,9 +647,7 @@ def run(args=None, phil=phil_scope):
     params, options = parser.parse_args(args=args, show_diff_phil=False)
 
     # Configure the logging
-    dials.util.log.config(
-        verbosity=options.verbose, logfile=params.output.log,
-    )
+    dials.util.log.config(verbosity=options.verbose, logfile=params.output.log)
 
     logger.info(dials_version())
 

--- a/newsfragments/1343.feature
+++ b/newsfragments/1343.feature
@@ -1,2 +1,1 @@
-dials.integrate: add option to remove unintegrated data from output reflection file, output_unintegrated_reflections=False
-
+Experimental feature in ``dials.integrate``: Specify ``output_unintegrated_reflections=False`` to discard unintegrated data from output reflection file

--- a/newsfragments/1343.feature
+++ b/newsfragments/1343.feature
@@ -1,2 +1,2 @@
-dials.integrate: by default remove unintegrated data from output reflection file, restore with output_unintegrated_reflections=True
+dials.integrate: add option to remove unintegrated data from output reflection file, output_unintegrated_reflections=False
 

--- a/newsfragments/1343.feature
+++ b/newsfragments/1343.feature
@@ -1,0 +1,2 @@
+dials.integrate: by default remove unintegrated data from output reflection file, restore with output_unintegrated_reflections=True
+

--- a/test/command_line/test_integrate.py
+++ b/test/command_line/test_integrate.py
@@ -11,7 +11,7 @@ from dials.algorithms.integration.processor import _average_bbox_size
 import procrunner
 
 
-def test2(dials_data, tmpdir):
+def test_basic_integrate(dials_data, tmpdir):
     # Call dials.integrate
 
     exp = load.experiment_list(
@@ -26,6 +26,7 @@ def test2(dials_data, tmpdir):
             "modified_input.json",
             "profile.fitting=False",
             "integration.integrator=3d",
+            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,
@@ -73,6 +74,7 @@ def test2(dials_data, tmpdir):
             "models.expt",
             "profile.fitting=False",
             "integration.integrator=3d",
+            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,
@@ -125,6 +127,7 @@ def test_integration_with_sampling(dials_data, tmpdir):
             "modified_input.json",
             "profile.fitting=False",
             "sampling.integrate_all_reflections=False",
+            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,
@@ -153,6 +156,7 @@ def test_integration_with_sample_size(dials_data, tmpdir):
             "profile.fitting=False",
             "sampling.integrate_all_reflections=False",
             "sampling.minimum_sample_size=500",
+            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,
@@ -181,7 +185,13 @@ def test_multi_sweep(dials_regression, tmpdir):
     )
 
     result = procrunner.run(
-        ["dials.integrate", "modified_input.json", refls, "prediction.padding=0"],
+        [
+            "dials.integrate",
+            "output_unintegrated_reflections=True",
+            "modified_input.json",
+            refls,
+            "prediction.padding=0",
+        ],
         working_directory=tmpdir,
     )
     assert not result.returncode and not result.stderr
@@ -236,6 +246,7 @@ def test_multi_lattice(dials_regression, tmpdir):
                 "multi_lattice",
                 "indexed.pickle",
             ),
+            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,

--- a/test/command_line/test_integrate.py
+++ b/test/command_line/test_integrate.py
@@ -113,6 +113,41 @@ def test_basic_integrate(dials_data, tmpdir):
     # assert(flex.abs(diff_Obs_P).all_lt(1e-7))
 
 
+def test_basic_integrate_output_integrated_only(dials_data, tmpdir):
+
+    exp = load.experiment_list(
+        dials_data("centroid_test_data").join("experiments.json").strpath
+    )
+    exp[0].identifier = "bar"
+    exp.as_json(tmpdir.join("modified_input.json").strpath)
+
+    result = procrunner.run(
+        [
+            "dials.integrate",
+            "modified_input.json",
+            "profile.fitting=False",
+            "integration.integrator=3d",
+            "output_unintegrated_reflections=False",
+            "prediction.padding=0",
+        ],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+
+    experiments = load.experiment_list(tmpdir.join("integrated.expt").strpath)
+    assert experiments[0].identifier == "bar"
+
+    table = flex.reflection_table.from_file(tmpdir / "integrated.refl")
+    mask = table.get_flags(table.flags.integrated, all=False)
+    assert len(table) == 1666
+    assert mask.count(False) == 0
+    assert "id" in table
+    for row in table.rows():
+        assert row["id"] == 0
+
+    assert dict(table.experiment_identifiers()) == {0: "bar"}
+
+
 def test_integration_with_sampling(dials_data, tmpdir):
 
     exp = load.experiment_list(

--- a/test/command_line/test_integrate.py
+++ b/test/command_line/test_integrate.py
@@ -26,7 +26,6 @@ def test_basic_integrate(dials_data, tmpdir):
             "modified_input.json",
             "profile.fitting=False",
             "integration.integrator=3d",
-            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,
@@ -74,7 +73,6 @@ def test_basic_integrate(dials_data, tmpdir):
             "models.expt",
             "profile.fitting=False",
             "integration.integrator=3d",
-            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,
@@ -162,7 +160,6 @@ def test_integration_with_sampling(dials_data, tmpdir):
             "modified_input.json",
             "profile.fitting=False",
             "sampling.integrate_all_reflections=False",
-            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,
@@ -191,7 +188,6 @@ def test_integration_with_sample_size(dials_data, tmpdir):
             "profile.fitting=False",
             "sampling.integrate_all_reflections=False",
             "sampling.minimum_sample_size=500",
-            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,
@@ -220,13 +216,7 @@ def test_multi_sweep(dials_regression, tmpdir):
     )
 
     result = procrunner.run(
-        [
-            "dials.integrate",
-            "output_unintegrated_reflections=True",
-            "modified_input.json",
-            refls,
-            "prediction.padding=0",
-        ],
+        ["dials.integrate", "modified_input.json", refls, "prediction.padding=0",],
         working_directory=tmpdir,
     )
     assert not result.returncode and not result.stderr
@@ -281,7 +271,6 @@ def test_multi_lattice(dials_regression, tmpdir):
                 "multi_lattice",
                 "indexed.pickle",
             ),
-            "output_unintegrated_reflections=True",
             "prediction.padding=0",
         ],
         working_directory=tmpdir,


### PR DESCRIPTION
Only output integrated reflections, using the filter `all=False` which takes any of profile fitted or summation integrated reflections. Fixes #1342. To restore previous behaviour use copy_input_reflections=True.