### PR TITLE
dials.background: allow analysis of corrected data

### DIFF
--- a/command_line/background.py
+++ b/command_line/background.py
@@ -121,7 +121,7 @@ def run(args):
         pyplot.show()
 
 
-def background(imageset, indx, n_bins, corrected, mask_params=None):
+def background(imageset, indx, n_bins, corrected=False, mask_params=None):
     from dials.array_family import flex
     from libtbx.phil import parse
     from scitbx import matrix

--- a/command_line/background.py
+++ b/command_line/background.py
@@ -28,6 +28,9 @@ n_bins = 100
 images = None
   .type = ints
   .help = "Images on which to perform the analysis (otherwise use all images)"
+corrected = False
+  .type = bool
+  .help = "Use corrected data (i.e after applying pedestal and gain) in analysis"
 plot = False
   .type = bool
 
@@ -83,7 +86,11 @@ def run(args):
         print("For image %d:" % indx)
         indx -= first  # indices passed to imageset.get_raw_data start from zero
         d, I, sig = background(
-            imageset, indx, n_bins=params.n_bins, mask_params=params.masking
+            imageset,
+            indx,
+            n_bins=params.n_bins,
+            corrected=params.corrected,
+            mask_params=params.masking,
         )
 
         print("%8s %8s %8s" % ("d", "I", "sig"))
@@ -114,7 +121,7 @@ def run(args):
         pyplot.show()
 
 
-def background(imageset, indx, n_bins, mask_params=None):
+def background(imageset, indx, n_bins, corrected, mask_params=None):
     from dials.array_family import flex
     from libtbx.phil import parse
     from scitbx import matrix
@@ -142,7 +149,10 @@ def background(imageset, indx, n_bins, mask_params=None):
     if math.fabs(b.dot(n)) < 0.95:
         raise Sorry("Detector not perpendicular to beam")
 
-    data = imageset.get_raw_data(indx)
+    if corrected:
+        data = imageset.get_corrected_data(indx)
+    else:
+        data = imageset.get_raw_data(indx)
     assert len(data) == 1
     data = data[0]
 

--- a/newsfragments/1348.feature
+++ b/newsfragments/1348.feature
@@ -1,0 +1,1 @@
+Add corrected parameter (default False) to dials.background to allow analysis of background after accounting for any pedestal and applying gain.

--- a/newsfragments/1348.feature
+++ b/newsfragments/1348.feature
@@ -1,1 +1,1 @@
-Add corrected parameter (default False) to dials.background to allow analysis of background after accounting for any pedestal and applying gain.
+``dials.background``: Add parameter ``corrected=``  to optionally use pedestal-and-gain corrected data


### PR DESCRIPTION
The plot in Supplementary Figure 1 of https://doi.org/10.1101/2020.04.30.061895 produced with `dials.background` appears to show the output of get_corrected_data - i.e. (raw_data - pedestal)/gain. 

Even if this is not the case it would be useful to be able to plot this for detectors where a pedestal is applied. This PR adds that option. 