### PR TITLE
Remove unused module-level master_params

### DIFF
--- a/command_line/rl_csv.py
+++ b/command_line/rl_csv.py
@@ -25,8 +25,6 @@ output {
 """
 )
 
-master_params = phil_scope.fetch().extract()
-
 
 def run(args):
     usage = "dev.dials.csv [options] imported.expt strong.refl output.csv=rl.csv"

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -84,8 +84,6 @@ output {
 """
 )
 
-master_params = phil_scope.fetch().extract()
-
 
 def optimize_origin_offset_local_scope(
     experiments,


### PR DESCRIPTION
These appear to be unused, and creating a module-level `master_params` phil object would be a bad motif anyway.