### PR TITLE
DIALS 2.2.9

### DIFF
--- a/doc/sphinx/documentation/tutorials/centring_vs_pseudocentring.rst
+++ b/doc/sphinx/documentation/tutorials/centring_vs_pseudocentring.rst
@@ -1,10 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/centring_vs_pseudocentring.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
-
 DPF3 Part 2: A question of centring
 ===================================
 

--- a/doc/sphinx/documentation/tutorials/correcting_poor_initial_geometry_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/correcting_poor_initial_geometry_tutorial.rst
@@ -1,10 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/correcting_poor_initial_geometry_tutorial.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
-
 DPF3 Part 1: Correcting poor initial geometry
 =============================================
 

--- a/doc/sphinx/documentation/tutorials/developer_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/developer_tutorial.rst
@@ -1,10 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/developer_tutorial.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
-
 Developer Tutorial
 ==================
 

--- a/doc/sphinx/documentation/tutorials/diamond.rst
+++ b/doc/sphinx/documentation/tutorials/diamond.rst
@@ -1,9 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/diamond.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
 
 ###################################
 Using DIALS at Diamond Light Source

--- a/doc/sphinx/documentation/tutorials/index.rst
+++ b/doc/sphinx/documentation/tutorials/index.rst
@@ -1,9 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/" class="new-documentation">
-  These tutorials require a DIALS 2.0/2.1 installation.<br/>
-  Please click here to go to the tutorials for DIALS 1.14.
-  </a>
 
 +++++++++
 Tutorials

--- a/doc/sphinx/documentation/tutorials/metrology_corrections.rst
+++ b/doc/sphinx/documentation/tutorials/metrology_corrections.rst
@@ -1,10 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/metrology_corrections.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
-
 Refining multi-tile detector metrology with DIALS
 =================================================
 

--- a/doc/sphinx/documentation/tutorials/multi_crystal_analysis.rst
+++ b/doc/sphinx/documentation/tutorials/multi_crystal_analysis.rst
@@ -1,9 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/multi_crystal_analysis.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
 
 Multi-crystal analysis with DIALS and BLEND: individual vs joint refinement
 ===========================================================================

--- a/doc/sphinx/documentation/tutorials/multi_crystal_symmetry_and_scaling.rst
+++ b/doc/sphinx/documentation/tutorials/multi_crystal_symmetry_and_scaling.rst
@@ -1,10 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/multi_crystal_symmetry_and_scaling.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
-
 Multi-crystal symmetry analysis and scaling with DIALS
 ======================================================
 

--- a/doc/sphinx/documentation/tutorials/multi_lattice_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/multi_lattice_tutorial.rst
@@ -1,10 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/multi_lattice_tutorial.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
-
 Multi-lattice Tutorial
 ======================
 

--- a/doc/sphinx/documentation/tutorials/processing_in_detail_betalactamase.rst
+++ b/doc/sphinx/documentation/tutorials/processing_in_detail_betalactamase.rst
@@ -1,10 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/processing_in_detail_betalactamase.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
-
 Processing in Detail
 ====================
 

--- a/doc/sphinx/documentation/tutorials/processing_in_detail_betalactamase_dui.rst
+++ b/doc/sphinx/documentation/tutorials/processing_in_detail_betalactamase_dui.rst
@@ -1,10 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/processing_in_detail_betalactamase_dui.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
-
 Processing in Detail with DUI
 =============================
 

--- a/doc/sphinx/documentation/tutorials/small_molecule_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/small_molecule_tutorial.rst
@@ -1,9 +1,3 @@
-.. raw:: html
-
-  <a href="https://dials.github.io/dials-1.14/documentation/tutorials/small_molecule_tutorial.html" class="new-documentation">
-  This tutorial requires a DIALS 2.0 installation.<br/>
-  Please click here to go to the tutorial for DIALS 1.14.
-  </a>
 
 Small-molecule data reduction tutorial
 ======================================

--- a/newsfragments/1375.misc
+++ b/newsfragments/1375.misc
@@ -1,0 +1,1 @@
+Fix libtbx.precommit installation error (TypeError)

--- a/precommitbx/installer.py
+++ b/precommitbx/installer.py
@@ -70,10 +70,10 @@ def clean_run(*args, **kwargs):
     )
     if stop_on_error and result.returncode:
         if result.stdout:
-            print("\n".join(result.stdout.split("\n")[-10:]))
+            print("\n".join(result.stdout.decode("latin-1").split("\n")[-10:]))
             print("---")
         if result.stderr:
-            print("\n".join(result.stderr.split("\n")[-10:]))
+            print("\n".join(result.stderr.decode("latin-1").split("\n")[-10:]))
             print("---")
         sys.exit(stop_on_error)
     return result


### PR DESCRIPTION
* read correct angles in Nexus files where angles are saved in radians (cctbx/dxtbx#192)
* fix file processing issues where `%` characters are in the path (cctbx/dxtbx#214)
* allow reading SMV ADSC format files with non-integer pedestal (cctbx/dxtbx#216)
* `libtbx.precommit`: fix setup crash on Python 3 (#1375)