### PR TITLE
No more abc

### DIFF
--- a/algorithms/indexing/assign_indices.py
+++ b/algorithms/indexing/assign_indices.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import abc
-
 from cctbx.array_family import flex
 import dials_algorithms_indexing_ext as ext
 
@@ -9,15 +7,11 @@ from dials.algorithms.indexing import DialsIndexError
 
 
 class AssignIndicesStrategy(object):
-
-    __metaclass__ = abc.ABCMeta
-
     def __init__(self, d_min=None):
         self._d_min = d_min
 
-    @abc.abstractmethod
     def __call__(self, reciprocal_lattice_vectors):
-        pass
+        raise NotImplementedError()
 
 
 class AssignIndicesGlobal(AssignIndicesStrategy):

--- a/algorithms/indexing/model_evaluation.py
+++ b/algorithms/indexing/model_evaluation.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import abc
 import collections
 import copy
 import logging
@@ -76,9 +75,6 @@ def filter_doubled_cell(solutions):
 
 
 class ModelRank(object):
-
-    __metaclass__ = abc.ABCMeta
-
     def __init__(self):
         self.all_solutions = []
 
@@ -88,13 +84,11 @@ class ModelRank(object):
     def extend(self, items):
         self.all_solutions.extend(items)
 
-    @abc.abstractmethod
     def best_model(self):
-        pass
+        raise NotImplementedError()
 
-    @abc.abstractmethod
     def __str__(self):
-        pass
+        raise NotImplementedError()
 
 
 # Tracker for solutions based on code in rstbx/dps_core/basis_choice.py
@@ -308,12 +302,8 @@ class ModelRankWeighted(ModelRank):
 
 
 class Strategy(object):
-
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
     def evaluate(self, experiments, reflections):
-        pass
+        raise NotImplementedError()
 
 
 class ModelEvaluation(Strategy):

--- a/algorithms/refinement/parameterisation/model_parameters.py
+++ b/algorithms/refinement/parameterisation/model_parameters.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from scitbx.array_family import flex
-import abc
 
 
 class Parameter(object):
@@ -121,8 +120,6 @@ class ModelParameterisation(object):
     all states and calculate all derivatives of these states.
     """
 
-    __metaclass__ = abc.ABCMeta
-
     def __init__(
         self, model, initial_state, param_list, experiment_ids, is_multi_state=False
     ):
@@ -179,7 +176,6 @@ class ModelParameterisation(object):
         """Get the model that is parameterised"""
         return self._model
 
-    @abc.abstractmethod
     def compose(self):
         """Compose the current model state.
 
@@ -190,7 +186,7 @@ class ModelParameterisation(object):
         """
 
         # Specific methods for each model are defined by derived classes.
-        pass
+        raise NotImplementedError()
 
     def get_params(self, only_free=True):
         """Get the internal list of parameters. It is intended that this function
@@ -304,7 +300,6 @@ class ModelParameterisation(object):
 
         return
 
-    @abc.abstractmethod
     def get_state(self, multi_state_elt=None):
         """Get the current state of the model under parameterisation.
 
@@ -321,7 +316,7 @@ class ModelParameterisation(object):
         # of the model under parameterisation is considered its state. The
         # type of this result should match the type of one element of the return
         # value of get_ds_dp.
-        pass
+        raise NotImplementedError()
 
     def get_ds_dp(self, only_free=True, multi_state_elt=None, use_none_as_null=False):
         """Get a list of derivatives of the state wrt each parameter.
@@ -426,4 +421,4 @@ class ModelParameterisation(object):
 
         # To be implemented by the derived class, where it is clear what aspect
         # of the model under parameterisation is considered its state.
-        pass
+        raise NotImplementedError()

--- a/algorithms/refinement/parameterisation/model_parameters.py
+++ b/algorithms/refinement/parameterisation/model_parameters.py
@@ -421,4 +421,4 @@ class ModelParameterisation(object):
 
         # To be implemented by the derived class, where it is clear what aspect
         # of the model under parameterisation is considered its state.
-        raise NotImplementedError()
+        pass

--- a/algorithms/refinement/parameterisation/scan_varying_model_parameters.py
+++ b/algorithms/refinement/parameterisation/scan_varying_model_parameters.py
@@ -3,7 +3,6 @@ from dials.algorithms.refinement.parameterisation.model_parameters import (
     Parameter,
     ModelParameterisation,
 )
-import abc
 from scitbx.array_family import flex
 from dials_refinement_helpers_ext import GaussianSmoother as GS
 
@@ -129,8 +128,6 @@ class ScanVaryingModelParameterisation(ModelParameterisation):
     # time static version of the parameterisation, as it is assumed that we
     # start with a flat model wrt rotation angle.
 
-    __metaclass__ = abc.ABCMeta
-
     def __init__(
         self,
         model,
@@ -182,7 +179,6 @@ class ScanVaryingModelParameterisation(ModelParameterisation):
         """the number of parameter sets"""
         return self._num_sets
 
-    @abc.abstractmethod
     def compose(self, t):
         """compose the model state at image number t from its initial state and
         its parameter list. Also calculate the derivatives of the state wrt
@@ -191,7 +187,7 @@ class ScanVaryingModelParameterisation(ModelParameterisation):
         Unlike ModelParameterisation, does not automatically update the actual
         model class. This should be done once refinement is complete."""
 
-        pass
+        raise NotImplementedError()
 
     def get_param_vals(self, only_free=True):
         """export the values of the internal list of parameters as a

--- a/algorithms/refinement/target.py
+++ b/algorithms/refinement/target.py
@@ -4,7 +4,6 @@ principally Target and ReflectionManager."""
 # python and cctbx imports
 from __future__ import absolute_import, division, print_function
 
-import abc
 import math
 
 from scitbx.array_family import flex
@@ -131,7 +130,6 @@ class Target(object):
     This should all be set by a derived class.
     """
 
-    __metaclass__ = abc.ABCMeta
     _grad_names = ["dX_dp", "dY_dp", "dphi_dp"]
     rmsd_names = ["RMSD_X", "RMSD_Y", "RMSD_Phi"]
     rmsd_units = ["mm", "mm", "rad"]
@@ -488,7 +486,6 @@ class Target(object):
         return result
 
     @staticmethod
-    @abc.abstractmethod
     def _extract_residuals_and_weights(matches):
         """extract vector of residuals and corresponding weights. The space the
         residuals are measured in (e.g. X, Y and Phi) and the order they are
@@ -496,7 +493,6 @@ class Target(object):
         raise NotImplementedError()
 
     @staticmethod
-    @abc.abstractmethod
     def _extract_squared_residuals(matches):
         """extract vector of squared residuals. The space the residuals are measured
         in (e.g. X, Y and Phi) and the order they are returned is determined by a
@@ -546,7 +542,6 @@ class Target(object):
         rmsds = self._rmsds_core(self._matches.select(sel))
         return rmsds
 
-    @abc.abstractmethod
     def achieved(self):
         """return True to terminate the refinement."""
         raise NotImplementedError()

--- a/newsfragments/1356.removal
+++ b/newsfragments/1356.removal
@@ -1,0 +1,3 @@
+No longer use the ``abc`` module for abstract base classes. Until more
+sophisticated behaviour is required, simply raise ``NotImplementedError`` where
+methods are not implemented.


### PR DESCRIPTION
There were 6 instances of `__metaclass__ = abc.ABCMeta` remaining in DIALS. This PR removes these and the associated decorators on abstract methods. It is easier to see what is going on if base class methods simply raise `NotImplementedError` rather than using obscure metaclass trickery and decorators. As pointed out in #1364, this was also not doing anything useful on Python 3.