### PR TITLE
Improve handling of parameters for scaling model auto options.

### DIFF
--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function
 import itertools
 import logging
 import json
-from libtbx import Auto
 import time
 import gc
 from dials.array_family import flex
@@ -13,7 +12,6 @@ from dials.algorithms.scaling.scaling_library import (
     create_scaling_model,
     create_datastructures_for_structural_model,
     create_datastructures_for_target_mtz,
-    create_auto_scaling_model,
     set_image_ranges_in_scaling_models,
     scaled_data_as_miller_array,
     determine_best_unit_cell,
@@ -191,14 +189,9 @@ class ScalingAlgorithm(Subject):
 
     def _create_model_and_scaler(self):
         """Create the scaling models and scaler."""
-        if self.params.model in (None, Auto, "auto", "Auto"):
-            self.experiments = create_auto_scaling_model(
-                self.params, self.experiments, self.reflections
-            )
-        else:
-            self.experiments = create_scaling_model(
-                self.params, self.experiments, self.reflections
-            )
+        self.experiments = create_scaling_model(
+            self.params, self.experiments, self.reflections
+        )
         logger.info("\nScaling models have been initialised for all experiments.")
         logger.info("%s%s%s", "\n", "=" * 80, "\n")
 

--- a/algorithms/scaling/test_scaling_library.py
+++ b/algorithms/scaling/test_scaling_library.py
@@ -17,10 +17,7 @@ from dials.algorithms.scaling.scaling_library import (
     create_scaling_model,
     create_datastructures_for_structural_model,
     create_Ih_table,
-    # calculate_merging_statistics,
-    # calculate_single_merging_stats,
     choose_initial_scaling_intensities,
-    create_auto_scaling_model,
     determine_best_unit_cell,
 )
 from dials.algorithms.scaling.model.model import KBScalingModel, PhysicalScalingModel
@@ -294,35 +291,36 @@ def test_choose_initial_scaling_intensities(test_reflections):
 
 
 def test_auto_scaling_model():
+    """Test auto options for scaling model creation."""
     params = generated_param()
     exp = generated_exp(scan=False)
     rt = generated_refl()
     params.model = "auto"
-    new_exp = create_auto_scaling_model(params, exp, [rt])
+    new_exp = create_scaling_model(params, exp, [rt])
     assert new_exp[0].scaling_model.id_ == "KB"
 
-    params = generated_param(absorption_term=True)
+    params = generated_param(absorption_term="auto")
     exp = generated_exp(image_range=[1, 5])  # 5 degree wedge
     params.model = "auto"
-    new_exp = create_auto_scaling_model(params, exp, [rt])
+    new_exp = create_scaling_model(params, exp, [rt])
     assert new_exp[0].scaling_model.id_ == "physical"
     assert len(new_exp[0].scaling_model.components["scale"].parameters) == 5
     assert len(new_exp[0].scaling_model.components["decay"].parameters) == 3
     assert "absorption" not in new_exp[0].scaling_model.components
 
-    params = generated_param(absorption_term=True)
+    params = generated_param(absorption_term="auto")
     exp = generated_exp(image_range=[1, 20])  # 20 degree wedge
     params.model = "auto"
-    new_exp = create_auto_scaling_model(params, exp, [rt])
+    new_exp = create_scaling_model(params, exp, [rt])
     assert new_exp[0].scaling_model.id_ == "physical"
     assert len(new_exp[0].scaling_model.components["scale"].parameters) == 7
     assert len(new_exp[0].scaling_model.components["decay"].parameters) == 6
     assert "absorption" not in new_exp[0].scaling_model.components
 
-    params = generated_param(absorption_term=True)
+    params = generated_param(absorption_term="auto")
     exp = generated_exp(image_range=[1, 75])  # 20 degree wedge
     params.model = "auto"
-    new_exp = create_auto_scaling_model(params, exp, [rt])
+    new_exp = create_scaling_model(params, exp, [rt])
     assert new_exp[0].scaling_model.id_ == "physical"
     assert len(new_exp[0].scaling_model.components["scale"].parameters) == 12
     assert len(new_exp[0].scaling_model.components["decay"].parameters) == 10

--- a/newsfragments/1366.misc
+++ b/newsfragments/1366.misc
@@ -1,0 +1,1 @@
+Improve handling of parameters for auto scaling model choices


### PR DESCRIPTION
Actually use auto phil scope elements where relevant to make behaviour more obvious.

Hopefully will remove a few obscure bugs for multi-sweep scaling model creation.