### PR TITLE
Add assertion to check for bad input to gaussian_smoother.

### DIFF
--- a/algorithms/refinement/gaussian_smoother.h
+++ b/algorithms/refinement/gaussian_smoother.h
@@ -93,6 +93,7 @@ namespace dials { namespace refinement {
 
       // smoothing spacing
       spacing_ = (x_range[1] - x_range[0]) / (double)nsample;
+      DIALS_ASSERT(spacing_ > 0);
 
       // positions of the smoother parameters
       if (nvalues < 4) {

--- a/algorithms/refinement/gaussian_smoother_2D.h
+++ b/algorithms/refinement/gaussian_smoother_2D.h
@@ -51,6 +51,8 @@ namespace dials { namespace refinement {
       // smoothing spacing
       x_spacing_ = (x_range[1] - x_range[0]) / (double)nxsample;
       y_spacing_ = (y_range[1] - y_range[0]) / (double)nysample;
+      DIALS_ASSERT(x_spacing_ > 0);
+      DIALS_ASSERT(y_spacing_ > 0);
 
       // positions of the smoother parameters
       if (nxvalues < 4) {

--- a/algorithms/refinement/gaussian_smoother_3D.h
+++ b/algorithms/refinement/gaussian_smoother_3D.h
@@ -65,6 +65,9 @@ namespace dials { namespace refinement {
       x_spacing_ = (x_range[1] - x_range[0]) / (double)nxsample;
       y_spacing_ = (y_range[1] - y_range[0]) / (double)nysample;
       z_spacing_ = (z_range[1] - z_range[0]) / (double)nzsample;
+      DIALS_ASSERT(x_spacing_ > 0);
+      DIALS_ASSERT(y_spacing_ > 0);
+      DIALS_ASSERT(z_spacing_ > 0);
 
       // positions of the smoother parameters
       if (nxvalues < 4) {

--- a/algorithms/scaling/model/components/smooth_scale_components.py
+++ b/algorithms/scaling/model/components/smooth_scale_components.py
@@ -217,7 +217,7 @@ class SmoothScaleComponent1D(ScaleComponentBase, SmoothMixin):
         normalised_values = normalised_values - flex.min(normalised_values)
         phi_range_deg = [
             floor(round(flex.min(normalised_values), 10)),
-            ceil(round(flex.max(normalised_values), 10)),
+            max(ceil(round(flex.max(normalised_values), 10)), 1),
         ]
         self._smoother = GaussianSmoother1D(
             phi_range_deg, self.nparam_to_val(self._n_params)
@@ -414,11 +414,11 @@ class SmoothScaleComponent2D(ScaleComponentBase, SmoothMixin):
         normalised_y_values = normalised_y_values - flex.min(normalised_y_values)
         x_range = [
             floor(round(flex.min(normalised_x_values), 10)),
-            ceil(round(flex.max(normalised_x_values), 10)),
+            max(ceil(round(flex.max(normalised_x_values), 10)), 1),
         ]
         y_range = [
             floor(round(flex.min(normalised_y_values), 10)),
-            ceil(round(flex.max(normalised_y_values), 10)),
+            max(ceil(round(flex.max(normalised_y_values), 10)), 1),
         ]
         self._smoother = GaussianSmoother2D(
             x_range,
@@ -569,15 +569,15 @@ class SmoothScaleComponent3D(ScaleComponentBase, SmoothMixin):
         normalised_z_values = normalised_z_values - flex.min(normalised_z_values)
         x_range = [
             floor(round(flex.min(normalised_x_values), 10)),
-            ceil(round(flex.max(normalised_x_values), 10)),
+            max(ceil(round(flex.max(normalised_x_values), 10)), 1),
         ]
         y_range = [
             floor(round(flex.min(normalised_y_values), 10)),
-            ceil(round(flex.max(normalised_y_values), 10)),
+            max(ceil(round(flex.max(normalised_y_values), 10)), 1),
         ]
         z_range = [
             floor(round(flex.min(normalised_z_values), 10)),
-            ceil(round(flex.max(normalised_z_values), 10)),
+            max(ceil(round(flex.max(normalised_z_values), 10)), 1),
         ]
         self._smoother = GaussianSmoother3D(
             x_range,

--- a/newsfragments/1370.bugfix
+++ b/newsfragments/1370.bugfix
@@ -1,0 +1,1 @@
+Add assertion check to gaussian smoother code


### PR DESCRIPTION
In the gaussian smoothers, used in refinement and scaling, the `spacing_` parameter must not be zero, as later this is used as a divisor. Therefore an assertion should be added to check this when initialising the smoothers. Requesting confirmation from @dagewa that this is sensible.

This was highlighted by a crash in scaling (#1245), so fix the smoother creation in the scaling code (should only affect the very-unusual edge case where there is only one reflection). Fixes #1245

