### PR TITLE
Make Python 3.8 the default developer version

### DIFF
--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -1094,7 +1094,7 @@ be passed separately with quotes to avoid confusion (e.g
     parser.add_argument(
         "--python",
         help="Install this minor version of Python (default: %(default)s)",
-        default="3.6",
+        default="3.8",
         choices=("3.6", "3.7", "3.8"),
     )
     parser.add_argument(

--- a/newsfragments/1373.feature
+++ b/newsfragments/1373.feature
@@ -1,0 +1,1 @@
+DIALS development environments are now running Python 3.8 by default.


### PR DESCRIPTION
As per decision in https://dials.github.io/kb/core/20200811.

I suggest merging this after the imminent DIALS 3.1 release.