### PR TITLE
Resolution analysis: set d_min=None if interpolation error

### DIFF
--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -207,7 +207,7 @@ were considered for use when refining the scaling model.
                 logger.debug(f"Resolution fit failed: {e}")
             else:
                 max_current_res = stats.bins[-1].d_min
-                if d_min - max_current_res > 0.005:
+                if d_min and d_min - max_current_res > 0.005:
                     logger.info(
                         "Resolution limit suggested from CC"
                         + "\u00BD"

--- a/algorithms/symmetry/__init__.py
+++ b/algorithms/symmetry/__init__.py
@@ -348,7 +348,6 @@ class symmetry_base(object):
 def resolution_filter_from_array(intensities, min_i_mean_over_sigma_mean, min_cc_half):
     """Run the resolution filter using miller array data format."""
     rparams = resolution_analysis.phil_defaults.extract().resolution
-    rparams.nbins = 20
     resolutionizer = resolution_analysis.Resolutionizer(intensities, rparams)
     return _resolution_filter(resolutionizer, min_i_mean_over_sigma_mean, min_cc_half)
 
@@ -358,7 +357,6 @@ def resolution_filter_from_reflections_experiments(
 ):
     """Run the resolution filter using native dials data formats."""
     rparams = resolution_analysis.phil_defaults.extract().resolution
-    rparams.nbins = 20
     resolutionizer = resolution_analysis.Resolutionizer.from_reflections_and_experiments(
         reflections, experiments, rparams
     )

--- a/algorithms/symmetry/__init__.py
+++ b/algorithms/symmetry/__init__.py
@@ -379,11 +379,12 @@ def _resolution_filter(resolutionizer, min_i_mean_over_sigma_mean, min_cc_half):
             logger.info(u"I/σ(I) resolution filter failed with the following error:")
             logger.error(e)
         else:
-            logger.info(
-                u"Resolution estimate from <I>/<σ(I)> > %.1f : %.2f",
-                min_i_mean_over_sigma_mean,
-                d_min_isigi,
-            )
+            if d_min_cc_half:
+                logger.info(
+                    u"Resolution estimate from <I>/<σ(I)> > %.1f : %.2f",
+                    min_i_mean_over_sigma_mean,
+                    d_min_isigi,
+                )
     if min_cc_half is not None:
         try:
             d_min_cc_half = resolutionizer.resolution(
@@ -393,10 +394,12 @@ def _resolution_filter(resolutionizer, min_i_mean_over_sigma_mean, min_cc_half):
             logger.info(u"CC½ resolution filter failed with the following error:")
             logger.error(e)
         else:
-            logger.info(
-                u"Resolution estimate from CC½ > %.2f: %.2f", min_cc_half, d_min_cc_half
-            )
-    valid_d_mins = list({d_min_cc_half, d_min_isigi}.difference({0}))
-    if valid_d_mins:
-        d_min = min(valid_d_mins)
-    return d_min
+            if d_min_cc_half:
+                logger.info(
+                    u"Resolution estimate from CC½ > %.2f: %.2f",
+                    min_cc_half,
+                    d_min_cc_half,
+                )
+    valid = [d for d in (d_min_cc_half, d_min_isigi) if d]
+    if valid:
+        return min(valid)

--- a/newsfragments/1378.bugfix
+++ b/newsfragments/1378.bugfix
@@ -1,0 +1,2 @@
+Resolution analysis: return d_min=None instead of defaulting to the high resolution limit of the integrated data if interpolation of the curve fit fails. Avoids using all integrated data in symmetry analysis in some cases which previously resulted in incorrect symmetry determination.
+Use 100 bins for estimation of resolution limit for symmetry determination instead of 20 bins. Leads to better results if the true resolution of the data is much lower than extent of the integrated data.

--- a/test/command_line/test_estimate_resolution.py
+++ b/test/command_line/test_estimate_resolution.py
@@ -35,7 +35,6 @@ def test_x4wide(input_files, dials_data, run_in_tmpdir, capsys):
     captured = capsys.readouterr()
     expected_output = (
         "Resolution rmerge:        1.34",
-        "Resolution completeness:  1.20",
         "Resolution cc_half:       1.56",
         "Resolution cc_ref:        1.3",
         "Resolution I/sig:         1.53",

--- a/util/resolution_analysis.py
+++ b/util/resolution_analysis.py
@@ -197,7 +197,7 @@ def resolution_fit(d_star_sq, y_obs, model, limit, sel=None):
             d_min = 1.0 / math.sqrt(interpolate_value(d_star_sq, y_fit, limit))
         except RuntimeError as e:
             logger.debug(f"Error interpolating value: {e}")
-            d_min = uctbx.d_star_sq_as_d(flex.max(d_star_sq))
+            d_min = None
 
     return ResolutionResult(d_star_sq, y_obs, y_fit, d_min)
 
@@ -636,9 +636,10 @@ class Resolutionizer(object):
             if limit:
                 result = self.resolution(metric, limit=limit)
                 pretty_name = metric_to_output.get(metric, name)
-                logger.info(
-                    f"Resolution {pretty_name}:{result.d_min:{18 - len(pretty_name)}.2f}"
-                )
+                if result.d_min:
+                    logger.info(
+                        f"Resolution {pretty_name}:{result.d_min:{18 - len(pretty_name)}.2f}"
+                    )
                 plot_d[name] = plot_result(metric, result)
         return plot_d
 

--- a/util/test_resolution_analysis.py
+++ b/util/test_resolution_analysis.py
@@ -94,6 +94,13 @@ def test_resolution_fit_from_merging_stats(merging_stats):
     assert flex.max(flex.abs(result.y_obs - result.y_fit)) < 1
 
 
+def test_resolution_fit_interpolation_error(merging_stats):
+    result = resolution_analysis.resolution_fit_from_merging_stats(
+        merging_stats, "i_over_sigma_mean", resolution_analysis.log_fit, limit=25
+    )
+    assert result.d_min is None
+
+
 def test_plot_result(merging_stats):
     result = resolution_analysis.resolution_cc_half(merging_stats, limit=0.82)
     d = resolution_analysis.plot_result("cc_half", result)


### PR DESCRIPTION
If the fitted curve doesn't intersect with the desired limit, then
the previous behaviour defaulted to setting d_min as the high
resolution limit extent of the input data. In some cases, this
would lead to all data being used in subsequent analysis. Better
instead to be explicit that we have failed to determine a resolution
estimate and set d_min=None.

Don't override default nbins for resolution analysis

20 bins is insufficient if the true resolution limit of the data
is much lower than the resolution limit to which data were integrated.
Better to stick with the default nbins=100.