### PR TITLE
Update boost.python → boost_adaptbx.boost.python

### DIFF
--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -10,7 +10,7 @@ from time import time
 
 import psutil
 
-import boost.python
+import boost_adaptbx.boost.python
 import libtbx
 
 import dials.algorithms.integration
@@ -78,7 +78,7 @@ def _average_bbox_size(reflections):
     return xsize, ysize, zsize
 
 
-@boost.python.inject_into(Executor)
+@boost_adaptbx.boost.python.inject_into(Executor)
 class _(object):
     @staticmethod
     def __getinitargs__():

--- a/algorithms/rs_mapper/__init__.py
+++ b/algorithms/rs_mapper/__init__.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
 try:
-    import boost.python
+    import boost_adaptbx.boost.python
 except Exception:
     ext = None
 else:
-    ext = boost.python.import_ext("recviewer_ext", optional=False)
+    ext = boost_adaptbx.boost.python.import_ext("recviewer_ext", optional=False)
 
 if ext is not None:
     from recviewer_ext import *

--- a/algorithms/scaling/combine_intensities.py
+++ b/algorithms/scaling/combine_intensities.py
@@ -6,12 +6,12 @@ from __future__ import absolute_import, division, print_function
 import logging
 from dials.util import tabulate
 
-import boost.python
+import boost_adaptbx.boost.python
 from cctbx import miller, crystal
 from dials.algorithms.scaling.scaling_utilities import DialsMergingStatisticsError
 from dials.array_family import flex
 
-miller_ext = boost.python.import_ext("cctbx_miller_ext")
+miller_ext = boost_adaptbx.boost.python.import_ext("cctbx_miller_ext")
 logger = logging.getLogger("dials")
 
 

--- a/array_family/flex_ext.py
+++ b/array_family/flex_ext.py
@@ -13,7 +13,7 @@ import logging
 import operator
 import os
 
-import boost.python
+import boost_adaptbx.boost.python
 import cctbx.array_family.flex
 import cctbx.miller
 import dials_array_family_flex_ext
@@ -42,7 +42,7 @@ else:
     raise TypeError('unknown "real" type')
 
 
-@boost.python.inject_into(dials_array_family_flex_ext.reflection_table)
+@boost_adaptbx.boost.python.inject_into(dials_array_family_flex_ext.reflection_table)
 class _(object):
     """
     An injector class to add additional methods to the reflection table.

--- a/model/data/__init__.py
+++ b/model/data/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-import boost.python
+import boost_adaptbx.boost.python
 
-ext = boost.python.import_ext("dials_model_data_ext")
+ext = boost_adaptbx.boost.python.import_ext("dials_model_data_ext")
 
 from dials_model_data_ext import *  # noqa: F403; lgtm
 

--- a/newsfragments/1379.misc
+++ b/newsfragments/1379.misc
@@ -1,0 +1,1 @@
+Update boost.python → boost_adaptbx.boost.python

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -17,7 +17,7 @@ from ..rstbx_frame import EVT_EXTERNAL_UPDATE
 from ..rstbx_frame import XrayFrame as XFBaseClass
 from rstbx.viewer import settings as rv_settings, image as rv_image
 from wxtbx import bitmaps
-from boost.python import c_sizeof
+from boost_adaptbx.boost.python import c_sizeof
 from rstbx.viewer.frame import SettingsFrame
 
 pyslip._Tiles = tile_generation._Tiles

--- a/util/test_python_streambuf.py
+++ b/util/test_python_streambuf.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-import boost.python
+import boost_adaptbx.boost.python
 import mock
 import pytest
 import six
 from dials.util.ext import streambuf, ostream
 
-ext = boost.python.import_ext("dials_util_streambuf_test_ext")
+ext = boost_adaptbx.boost.python.import_ext("dials_util_streambuf_test_ext")
 
 
 class io_test_case(object):


### PR DESCRIPTION
This is to reflect changes added in a series of commits merged in pull cctbx/cctbx_project#516. When the cctbx repository next becomes stable, this will break the dials tests that relied tests with no stderr output, because a warning is printed.

This also relies on cctbx/dxtbx#212, because that fixes a whole set of cases where dxtbx also causes the warning, and the dials tests depends on that.

This pull request will fix those tests once those commits are used for testing, and once cctbx/dxtbx#212 is merged.