### PR TITLE
Cosym: filter out experiments with inconsistent unit cells

### DIFF
--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import collections
 import copy
 import json
 import logging
@@ -8,12 +9,13 @@ import random
 import sys
 from dials.util import tabulate
 
-from cctbx import crystal, sgtbx, uctbx
+from cctbx import sgtbx, uctbx
 from cctbx.sgtbx.bravais_types import bravais_lattice
 from cctbx.sgtbx.lattice_symmetry import metric_subgroups
 from libtbx import Auto
 import iotbx.phil
 
+from dxtbx.model import ExperimentList
 from dials.array_family import flex
 from dials.util import log, show_mail_on_error
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
@@ -176,12 +178,19 @@ def change_of_basis_ops_to_minimum_cell(
         cb_op_best_to_min = group["best_subsym"].change_of_basis_op_to_minimum_cell()
         cb_ops = [cb_op_best_to_min * group["cb_op_inp_best"]] * len(experiments)
     else:
-        target_group = metric_subgroups(
-            crystal.symmetry(unit_cell=median_cell, space_group=sgtbx.space_group()),
-            max_delta,
-            best_monoclinic_beta=False,
-            enforce_max_delta_for_generated_two_folds=True,
-        ).result_groups[0]
+        groups = [
+            metric_subgroups(
+                expt.crystal.get_crystal_symmetry(),
+                max_delta,
+                best_monoclinic_beta=False,
+                enforce_max_delta_for_generated_two_folds=True,
+            )
+            for expt in experiments
+        ]
+        counter = collections.Counter(
+            g.result_groups[0]["best_subsym"].space_group() for g in groups
+        )
+        target_group = counter.most_common()[0][0]
         cb_ops = []
         for expt in experiments:
             groups = metric_subgroups(
@@ -192,24 +201,27 @@ def change_of_basis_ops_to_minimum_cell(
             )
             group = None
             for g in groups.result_groups:
-                if (
-                    g["ref_subsym"].space_group()
-                    == target_group["ref_subsym"].space_group()
-                ):
+                if g["best_subsym"].space_group() == target_group:
                     group = g
-            if group is not None:
+            if group:
                 cb_ops.append(group["cb_op_inp_best"])
             else:
                 cb_ops.append(None)
                 logger.info(
                     f"Couldn't match unit cell to target symmetry:\n"
                     f"{expt.crystal.get_crystal_symmetry()}\n"
-                    f"{target_group['ref_subsym']}"
+                    f"{target_group}"
                 )
-        cb_op_ref_min = target_group["ref_subsym"].change_of_basis_op_to_minimum_cell()
-        cb_ops = [
-            cb_op_ref_min * cb_op if cb_op is not None else None for cb_op in cb_ops
-        ]
+        ref_expts = ExperimentList(
+            [expt for expt, cb_op in zip(experiments, cb_ops) if cb_op]
+        ).change_basis(list(filter(None, cb_ops)))
+        cb_op_ref_min = (
+            ref_expts[0]
+            .crystal.get_crystal_symmetry()
+            .customized_copy(unit_cell=median_unit_cell(ref_expts))
+            .change_of_basis_op_to_minimum_cell()
+        )
+        cb_ops = [cb_op_ref_min * cb_op if cb_op else None for cb_op in cb_ops]
     return cb_ops
 
 

--- a/test/command_line/test_symmetry.py
+++ b/test/command_line/test_symmetry.py
@@ -405,6 +405,57 @@ def test_change_of_basis_ops_to_minimum_cell_mpro():
     )
 
 
+from cctbx import crystal
+
+
+def test_change_of_basis_ops_to_minimum_cell_with_outlier():
+    symmetries = [
+        crystal.symmetry(unit_cell=uc, space_group="P1")
+        for uc in (
+            (52.8868, 52.8868, 333.522, 90, 90, 120),
+            (52.6503, 53.0292, 333.783, 89.9872, 89.2247, 60.8078),
+            (52.9571, 53.0005, 334.255, 90.0493, 90.0042, 119.893),
+            (
+                54.4465,
+                56.5677,
+                355.775,
+                93.4376,
+                90.0999,
+                118.256,
+            ),  # This is an outlier
+            (52.9235, 52.9235, 335.296, 90, 90, 120),
+            (53.4531, 53.4531, 322.909, 90, 90, 120),
+        )
+    ]
+
+    # Setup the input experiments and reflection tables
+    expts = ExperimentList()
+    for cs in symmetries:
+        B = scitbx.matrix.sqr(cs.unit_cell().fractionalization_matrix()).transpose()
+        expts.append(
+            Experiment(
+                crystal=Crystal(B, space_group=cs.space_group(), reciprocal=True)
+            )
+        )
+
+    # Actually run the method we are testing
+    cb_ops = change_of_basis_ops_to_minimum_cell(
+        expts, max_delta=5, relative_length_tolerance=0.05, absolute_angle_tolerance=2
+    )
+    assert cb_ops.count(None) == 1
+    assert cb_ops[3] is None
+    expts = ExperimentList([expt for expt, cb_op in zip(expts, cb_ops) if cb_op])
+    cb_ops = [cb_op for cb_op in cb_ops if cb_op]
+
+    expts.change_basis(cb_ops, in_place=True)
+    assert symmetry.unit_cells_are_similar_to(
+        expts,
+        median_unit_cell(expts),
+        relative_length_tolerance=0.05,
+        absolute_angle_tolerance=2,
+    )
+
+
 def test_median_cell():
     unit_cells = [
         uctbx.unit_cell(uc)


### PR DESCRIPTION
Fix occassional issue in cosym/multiplex where a given unit cell passes through the initial unit cell clustering, but the `change_of_basis_ops_to_minimum_cell()` function isn't able to identify consistent cb_ops to minimum cell because the input unit cells don't map to the same highest symmetry subgroup.

New algorithm for `change_of_basis_ops_to_minimum_cell()`:

1. Compute `metric_subgroups` for all experiments
2. Choose as target space group the most common highest symmetry subgroup compatible with each experiment
3. If no compatible subgroup exists for a given experiment then set the returned cb_op for this experiment as `None`
4. In cosym, filter out experiments with a cb_op of `None`