### PR TITLE
Remove observer pattern from scaling code

### DIFF
--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -31,9 +31,7 @@ from dials.util.exclude_images import (
     exclude_image_ranges_for_scaling,
     get_valid_image_ranges,
 )
-from dials.util.observer import Subject
 from dials.algorithms.scaling.observers import (
-    register_scaler_observers,
     ScalingSummaryContextManager,
     ScalingHTMLContextManager,
 )
@@ -174,9 +172,8 @@ def prepare_input(params, experiments, reflections):
     return params, experiments, reflections
 
 
-class ScalingAlgorithm(Subject):
+class ScalingAlgorithm(object):
     def __init__(self, params, experiments, reflections):
-        super(ScalingAlgorithm, self).__init__(events=["merging_statistics"])
         self.scaler = None
         self.scaled_miller_array = None
         self.merging_statistics_result = None
@@ -277,7 +274,6 @@ class ScalingAlgorithm(Subject):
         if n > 0:
             logger.info("%s reflections excluded: scale factor < 0.001", n)
 
-    # @Subject.notify_event(event="merging_statistics")
     def calculate_merging_stats(self):
         try:
             (
@@ -458,7 +454,6 @@ multi-dataset scaling mode (not single dataset or scaling against a reference)""
 
                 # If not finished then need to create new scaler to try again
                 self._create_model_and_scaler()
-                register_scaler_observers(self.scaler)
             self.filtering_results = results
             # Print summary of results
             logger.info(results)
@@ -491,7 +486,6 @@ multi-dataset scaling mode (not single dataset or scaling against a reference)""
 
     def _run_final_scale_cycle(self, results):
         self._create_model_and_scaler()
-        register_scaler_observers(self.scaler)
         super(ScaleAndFilterAlgorithm, self).run()
         results.add_final_stats(self.merging_statistics_result)
         return results

--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -277,7 +277,7 @@ class ScalingAlgorithm(Subject):
         if n > 0:
             logger.info("%s reflections excluded: scale factor < 0.001", n)
 
-    @Subject.notify_event(event="merging_statistics")
+    # @Subject.notify_event(event="merging_statistics")
     def calculate_merging_stats(self):
         try:
             (

--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -35,6 +35,7 @@ from dials.util.observer import Subject
 from dials.algorithms.scaling.observers import (
     register_scaler_observers,
     ScalingSummaryContextManager,
+    ScalingHTMLContextManager,
 )
 from dials.algorithms.scaling.scale_and_filter import AnalysisResults, log_cycle_results
 from dials.command_line.cosym import cosym
@@ -176,7 +177,7 @@ def prepare_input(params, experiments, reflections):
 class ScalingAlgorithm(Subject):
     def __init__(self, params, experiments, reflections):
         super(ScalingAlgorithm, self).__init__(
-            events=["merging_statistics", "run_script", "run_scale_and_filter"]
+            events=["merging_statistics", "run_scale_and_filter"]
         )
         self.scaler = None
         self.scaled_miller_array = None
@@ -202,10 +203,9 @@ class ScalingAlgorithm(Subject):
 
         self.scaler = create_scaler(self.params, self.experiments, self.reflections)
 
-    @Subject.notify_event(event="run_script")
     def run(self):
         """Run the scaling script."""
-        with ScalingSummaryContextManager(self):
+        with ScalingSummaryContextManager(self), ScalingHTMLContextManager(self):
             start_time = time.time()
             self.scale()
             self.remove_bad_data()
@@ -359,117 +359,122 @@ multi-dataset scaling mode (not single dataset or scaling against a reference)""
     @Subject.notify_event(event="run_scale_and_filter")
     def run(self):
         """Run cycles of scaling and filtering."""
-        start_time = time.time()
-        results = AnalysisResults()
+        with ScalingHTMLContextManager(self):
+            start_time = time.time()
+            results = AnalysisResults()
 
-        for counter in range(1, self.params.filtering.deltacchalf.max_cycles + 1):
-            self.run_scaling_cycle()
+            for counter in range(1, self.params.filtering.deltacchalf.max_cycles + 1):
+                self.run_scaling_cycle()
 
-            if counter == 1:
-                results.initial_expids_and_image_ranges = [
-                    (exp.identifier, exp.scan.get_image_range()) if exp.scan else None
-                    for exp in self.experiments
+                if counter == 1:
+                    results.initial_expids_and_image_ranges = [
+                        (exp.identifier, exp.scan.get_image_range())
+                        if exp.scan
+                        else None
+                        for exp in self.experiments
+                    ]
+
+                delta_cc_params = deltacc_phil_scope.extract()
+                delta_cc_params.mode = self.params.filtering.deltacchalf.mode
+                delta_cc_params.group_size = (
+                    self.params.filtering.deltacchalf.group_size
+                )
+                delta_cc_params.stdcutoff = self.params.filtering.deltacchalf.stdcutoff
+                logger.info("\nPerforming a round of filtering.\n")
+
+                # need to reduce to single table.
+                joined_reflections = flex.reflection_table()
+                for table in self.reflections:
+                    joined_reflections.extend(table)
+
+                script = deltaccscript(
+                    delta_cc_params, self.experiments, joined_reflections
+                )
+                script.run()
+
+                valid_image_ranges = get_valid_image_ranges(self.experiments)
+                results.expids_and_image_ranges = [
+                    (exp.identifier, valid_image_ranges[i]) if exp.scan else None
+                    for i, exp in enumerate(self.experiments)
                 ]
 
-            delta_cc_params = deltacc_phil_scope.extract()
-            delta_cc_params.mode = self.params.filtering.deltacchalf.mode
-            delta_cc_params.group_size = self.params.filtering.deltacchalf.group_size
-            delta_cc_params.stdcutoff = self.params.filtering.deltacchalf.stdcutoff
-            logger.info("\nPerforming a round of filtering.\n")
+                self.experiments = script.experiments
+                self.params.dataset_selection.use_datasets = None
+                self.params.dataset_selection.exclude_datasets = None
 
-            # need to reduce to single table.
-            joined_reflections = flex.reflection_table()
-            for table in self.reflections:
-                joined_reflections.extend(table)
-
-            script = deltaccscript(
-                delta_cc_params, self.experiments, joined_reflections
-            )
-            script.run()
-
-            valid_image_ranges = get_valid_image_ranges(self.experiments)
-            results.expids_and_image_ranges = [
-                (exp.identifier, valid_image_ranges[i]) if exp.scan else None
-                for i, exp in enumerate(self.experiments)
-            ]
-
-            self.experiments = script.experiments
-            self.params.dataset_selection.use_datasets = None
-            self.params.dataset_selection.exclude_datasets = None
-
-            results = log_cycle_results(results, self, script)
-            logger.info(
-                "Cycle %s of filtering, n_reflections removed this cycle: %s",
-                counter,
-                results.get_last_cycle_results()["n_removed"],
-            )
-
-            # Test termination conditions
-            latest_results = results.get_last_cycle_results()
-            if latest_results["n_removed"] == 0:
+                results = log_cycle_results(results, self, script)
                 logger.info(
-                    "Finishing scaling and filtering as no data removed in this cycle."
+                    "Cycle %s of filtering, n_reflections removed this cycle: %s",
+                    counter,
+                    results.get_last_cycle_results()["n_removed"],
                 )
-                if self.params.scaling_options.full_matrix:
-                    self.reflections = parse_multiple_datasets(
-                        [script.filtered_reflection_table]
-                    )
-                    results = self._run_final_scale_cycle(results)
-                else:
-                    self.reflections = [script.filtered_reflection_table]
-                results.finish(termination_reason="no_more_removed")
-                break
 
-            # Need to split reflections for further processing.
-            self.reflections = parse_multiple_datasets(
-                [script.filtered_reflection_table]
-            )
-
-            if (
-                latest_results["cumul_percent_removed"]
-                > self.params.filtering.deltacchalf.max_percent_removed
-            ):
-                logger.info(
-                    "Finishing scale and filtering as have now removed more than the limit."
-                )
-                results = self._run_final_scale_cycle(results)
-                results.finish(termination_reason="max_percent_removed")
-                break
-
-            if self.params.filtering.deltacchalf.min_completeness:
-                if (
-                    latest_results["merging_stats"]["completeness"]
-                    < self.params.filtering.deltacchalf.min_completeness
-                ):
+                # Test termination conditions
+                latest_results = results.get_last_cycle_results()
+                if latest_results["n_removed"] == 0:
                     logger.info(
-                        "Finishing scaling and filtering as completeness now below cutoff."
+                        "Finishing scaling and filtering as no data removed in this cycle."
                     )
-                    results = self._run_final_scale_cycle(results)
-                    results.finish(termination_reason="below_completeness_limit")
+                    if self.params.scaling_options.full_matrix:
+                        self.reflections = parse_multiple_datasets(
+                            [script.filtered_reflection_table]
+                        )
+                        results = self._run_final_scale_cycle(results)
+                    else:
+                        self.reflections = [script.filtered_reflection_table]
+                    results.finish(termination_reason="no_more_removed")
                     break
 
-            if counter == self.params.filtering.deltacchalf.max_cycles:
-                logger.info("Finishing as reached max number of cycles.")
-                results = self._run_final_scale_cycle(results)
-                results.finish(termination_reason="max_cycles")
-                break
+                # Need to split reflections for further processing.
+                self.reflections = parse_multiple_datasets(
+                    [script.filtered_reflection_table]
+                )
 
-            # If not finished then need to create new scaler to try again
-            self._create_model_and_scaler()
-            register_scaler_observers(self.scaler)
-        self.filtering_results = results
-        # Print summary of results
-        logger.info(results)
-        with open(self.params.filtering.output.scale_and_filter_results, "w") as f:
-            json.dump(self.filtering_results.to_dict(), f, indent=2)
-        # All done!
-        logger.info("\nTotal time taken: {:.4f}s ".format(time.time() - start_time))
-        logger.info("%s%s%s", "\n", "=" * 80, "\n")
+                if (
+                    latest_results["cumul_percent_removed"]
+                    > self.params.filtering.deltacchalf.max_percent_removed
+                ):
+                    logger.info(
+                        "Finishing scale and filtering as have now removed more than the limit."
+                    )
+                    results = self._run_final_scale_cycle(results)
+                    results.finish(termination_reason="max_percent_removed")
+                    break
 
-    @Subject.notify_event(event="run_script")
+                if self.params.filtering.deltacchalf.min_completeness:
+                    if (
+                        latest_results["merging_stats"]["completeness"]
+                        < self.params.filtering.deltacchalf.min_completeness
+                    ):
+                        logger.info(
+                            "Finishing scaling and filtering as completeness now below cutoff."
+                        )
+                        results = self._run_final_scale_cycle(results)
+                        results.finish(termination_reason="below_completeness_limit")
+                        break
+
+                if counter == self.params.filtering.deltacchalf.max_cycles:
+                    logger.info("Finishing as reached max number of cycles.")
+                    results = self._run_final_scale_cycle(results)
+                    results.finish(termination_reason="max_cycles")
+                    break
+
+                # If not finished then need to create new scaler to try again
+                self._create_model_and_scaler()
+                register_scaler_observers(self.scaler)
+            self.filtering_results = results
+            # Print summary of results
+            logger.info(results)
+            with open(self.params.filtering.output.scale_and_filter_results, "w") as f:
+                json.dump(self.filtering_results.to_dict(), f, indent=2)
+            # All done!
+            logger.info("\nTotal time taken: {:.4f}s ".format(time.time() - start_time))
+            logger.info("%s%s%s", "\n", "=" * 80, "\n")
+
     def run_scaling_cycle(self):
         """Do a round of scaling for scaling and filtering."""
         # Turn off the full matrix round, all else is the same.
+
         initial_full_matrix = self.params.scaling_options.full_matrix
         self.scaler.params.scaling_options.full_matrix = False
         self.scaler = scaling_algorithm(self.scaler)

--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -176,9 +176,7 @@ def prepare_input(params, experiments, reflections):
 
 class ScalingAlgorithm(Subject):
     def __init__(self, params, experiments, reflections):
-        super(ScalingAlgorithm, self).__init__(
-            events=["merging_statistics", "run_scale_and_filter"]
-        )
+        super(ScalingAlgorithm, self).__init__(events=["merging_statistics"])
         self.scaler = None
         self.scaled_miller_array = None
         self.merging_statistics_result = None
@@ -356,7 +354,6 @@ Whole dataset deltacchalf scaling and filtering can only be performed in
 multi-dataset scaling mode (not single dataset or scaling against a reference)"""
             )
 
-    @Subject.notify_event(event="run_scale_and_filter")
     def run(self):
         """Run cycles of scaling and filtering."""
         with ScalingHTMLContextManager(self):

--- a/algorithms/scaling/cross_validation/crossvalidator.py
+++ b/algorithms/scaling/cross_validation/crossvalidator.py
@@ -8,7 +8,6 @@ import itertools
 from copy import deepcopy
 import pkg_resources
 
-from dials.algorithms.scaling.observers import register_merging_stats_observers
 from libtbx.table_utils import simple_table
 from libtbx import phil
 from scitbx.array_family import flex
@@ -222,7 +221,6 @@ is provided. For example, physical.decay_correction rather than decay_correction
             experiments=deepcopy(self.experiments),
             reflections=deepcopy(self.reflections),
         )
-        register_merging_stats_observers(algorithm)
         algorithm.run()
         results = self.get_results_from_script(algorithm)
         self.add_results_to_results_dict(config_no, results)

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -85,11 +85,11 @@ def register_default_scaling_observers(script):
     script.register_observer(
         event="merging_statistics", observer=MergingStatisticsObserver()
     )
-    script.register_observer(
-        event="run_script",
-        observer=ScalingSummaryGenerator(),
-        callback="print_scaling_summary",
-    )
+    # script.register_observer(
+    #    event="run_script",
+    #    observer=ScalingSummaryGenerator(),
+    #    callback="print_scaling_summary",
+    # )
     script.register_observer(
         event="run_script",
         observer=ScalingHTMLGenerator(),
@@ -115,11 +115,11 @@ def register_merging_stats_observers(script):
     script.register_observer(
         event="merging_statistics", observer=MergingStatisticsObserver()
     )
-    script.register_observer(
-        event="run_script",
-        observer=ScalingSummaryGenerator(),
-        callback="print_scaling_summary",
-    )
+    # script.register_observer(
+    #    event="run_script",
+    #    observer=ScalingSummaryGenerator(),
+    #    callback="print_scaling_summary",
+    # )
 
 
 def register_scale_and_filter_observers(script):
@@ -135,11 +135,23 @@ def register_scale_and_filter_observers(script):
         pass
 
 
-@singleton
-class ScalingSummaryGenerator(Observer):
-    """
-    Observer to summarise data
-    """
+# @singleton
+# class ScalingSummaryGenerator(Observer):
+#    """
+#    Observer to summarise data
+#    """
+
+
+class ScalingSummaryContextManager(object):
+    def __init__(self, script):
+        self.script = script
+        self.data = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.print_scaling_summary(self.script)
 
     def print_scaling_summary(self, script):
         """Log summary information after scaling."""

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -85,16 +85,6 @@ def register_default_scaling_observers(script):
     script.register_observer(
         event="merging_statistics", observer=MergingStatisticsObserver()
     )
-    # script.register_observer(
-    #    event="run_script",
-    #    observer=ScalingSummaryGenerator(),
-    #    callback="print_scaling_summary",
-    # )
-    script.register_observer(
-        event="run_script",
-        observer=ScalingHTMLGenerator(),
-        callback="make_scaling_html",
-    )
     register_scaler_observers(script.scaler)
 
 
@@ -115,31 +105,10 @@ def register_merging_stats_observers(script):
     script.register_observer(
         event="merging_statistics", observer=MergingStatisticsObserver()
     )
-    # script.register_observer(
-    #    event="run_script",
-    #    observer=ScalingSummaryGenerator(),
-    #    callback="print_scaling_summary",
-    # )
 
 
 def register_scale_and_filter_observers(script):
     script.register_observer(event="run_scale_and_filter", observer=FilteringObserver())
-    script.register_observer(
-        event="run_scale_and_filter",
-        observer=ScalingHTMLGenerator(),
-        callback="make_scaling_html",
-    )
-    try:
-        script.unregister_observer(event="run_script", observer=ScalingHTMLGenerator())
-    except KeyError:
-        pass
-
-
-# @singleton
-# class ScalingSummaryGenerator(Observer):
-#    """
-#    Observer to summarise data
-#    """
 
 
 class ScalingSummaryContextManager(object):
@@ -242,11 +211,16 @@ were considered for use when refining the scaling model.
             logger.info(table_1_summary(stats, anom_stats, cut_stats, cut_anom_stats))
 
 
-@singleton
-class ScalingHTMLGenerator(Observer):
-    """
-    Observer to make a html report
-    """
+class ScalingHTMLContextManager(object):
+    def __init__(self, script):
+        self.script = script
+        self.data = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.make_scaling_html(self.script)
 
     def make_scaling_html(self, scaling_script):
         """Collect data from the individual observers and write the html."""

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -422,5 +422,5 @@ def make_merging_stats_plots(script):
         )
         anom_plotter = AnomalousPlotter(intensities_anom, strong_cutoff=d_min)
         d["anom_plots"].update(anom_plotter.make_plots())
-    d["image_range_tables"] = image_range_tables
+    d["image_range_tables"] = [image_range_tables]
     return d

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -107,10 +107,6 @@ def register_merging_stats_observers(script):
     )
 
 
-def register_scale_and_filter_observers(script):
-    script.register_observer(event="run_scale_and_filter", observer=FilteringObserver())
-
-
 class ScalingSummaryContextManager(object):
     def __init__(self, script):
         self.script = script
@@ -232,7 +228,7 @@ class ScalingHTMLContextManager(object):
         self.data.update(ScalingOutlierObserver().make_plots())
         self.data.update(ErrorModelObserver().make_plots())
         self.data.update(MergingStatisticsObserver().make_plots())
-        self.data.update(FilteringObserver().make_plots())
+        self.data.update(make_filtering_plots(scaling_script))
         if html_file:
             logger.info("Writing html report to %s", html_file)
             loader = ChoiceLoader(
@@ -416,29 +412,18 @@ class ErrorModelObserver(Observer):
         return d
 
 
-@singleton
-class FilteringObserver(Observer):
-    """
-    Observer to record data from the scaling and filtering algorithm.
-    """
-
-    def update(self, scaling_script):
-        if scaling_script.filtering_results:
-            self.data = {
-                "merging_stats": scaling_script.filtering_results.get_merging_stats(),
-                "initial_expids_and_image_ranges": scaling_script.filtering_results.initial_expids_and_image_ranges,
-                "cycle_results": scaling_script.filtering_results.get_cycle_results(),
-                "expids_and_image_ranges": scaling_script.filtering_results.expids_and_image_ranges,
-                "mode": scaling_script.params.filtering.deltacchalf.mode,
-            }
-
-    def make_plots(self):
-        """Make plots for scale and filter."""
-        if not self.data:
-            return {"filter_plots": {}}
-        # Make merging stats plots, histograms and image ranges.
-        d = make_scaling_filtering_plots(self.data)
+def make_filtering_plots(scaling_script):
+    if scaling_script.filtering_results:
+        data = {
+            "merging_stats": scaling_script.filtering_results.get_merging_stats(),
+            "initial_expids_and_image_ranges": scaling_script.filtering_results.initial_expids_and_image_ranges,
+            "cycle_results": scaling_script.filtering_results.get_cycle_results(),
+            "expids_and_image_ranges": scaling_script.filtering_results.expids_and_image_ranges,
+            "mode": scaling_script.params.filtering.deltacchalf.mode,
+        }
+        d = make_scaling_filtering_plots(data)
         return {"filter_plots": d}
+    return {"filter_plots": {}}
 
 
 @singleton

--- a/algorithms/scaling/observers.py
+++ b/algorithms/scaling/observers.py
@@ -1,5 +1,5 @@
 """
-Observers for the scaling algorithm.
+Helper functions/classes for making HTML report and scaling summary output.
 """
 from __future__ import absolute_import, division, print_function
 
@@ -82,7 +82,6 @@ def assert_is_json_serialisable(thing, name, path=None):
 class ScalingSummaryContextManager(object):
     def __init__(self, script):
         self.script = script
-        self.data = {}
 
     def __enter__(self):
         return self
@@ -235,8 +234,8 @@ def _make_scaling_html(scaling_script):
 
 
 def make_scaling_model_plots(experiments):
+    """Collect scaling model plots for html report."""
     data = {i: e.scaling_model.to_dict() for i, e in enumerate(experiments)}
-    """Generate scaling model component plot data."""
     d = OrderedDict()
     combined_plots = make_combined_plots(data)
     if combined_plots:

--- a/algorithms/scaling/test_observers.py
+++ b/algorithms/scaling/test_observers.py
@@ -1,335 +1,103 @@
 from __future__ import absolute_import, division, print_function
-import os
 import mock
-from cctbx import miller
-from dxtbx.model import Experiment, Crystal
+import pytest
+from dxtbx.serialize import load
 from dials.array_family import flex
-from dials.algorithms.scaling.model.model import KBScalingModel
-from dials.util.observer import Subject
+from dials.algorithms.scaling.scaling_library import scaled_data_as_miller_array
 from dials.algorithms.scaling.observers import (
-    register_default_scaling_observers,
-    ScalingModelObserver,
-    ScalingOutlierObserver,
-    ScalingHTMLGenerator,
-    ErrorModelObserver,
-    MergingStatisticsObserver,
-    ScalingSummaryGenerator,
+    make_error_model_plots,
+    make_scaling_model_plots,
+    make_outlier_plots,
+    print_scaling_summary,
+    print_scaling_model_error_summary,
+    ScalingHTMLContextManager,
+    make_filtering_plots,
+    make_merging_stats_plots,
 )
 
 
-def test_register_scaling_observers():
-    """Test the registering of the standard scaling observers."""
+@pytest.fixture
+def test_data(dials_data):
+    location = dials_data("l_cysteine_4_sweeps_scaled")
+    refl = location.join("scaled_20_25.refl").strpath
+    expt = location.join("scaled_20_25.expt").strpath
 
-    class Scaler(Subject):
-        """Test scaler class"""
-
-        def __init__(self):
-            super(Scaler, self).__init__(
-                events=[
-                    "performed_scaling",
-                    "performed_outlier_rejection",
-                    "performed_error_analysis",
-                ]
-            )
-
-    class TestScript(Subject):
-        """Test script class"""
-
-        def __init__(self):
-            super(TestScript, self).__init__(
-                events=["merging_statistics", "run_script", "run_filtering"]
-            )
-            self.scaler = Scaler()
-
-    script = TestScript()
-    register_default_scaling_observers(script)
-    assert script.get_observers("merging_statistics") == {
-        MergingStatisticsObserver(): MergingStatisticsObserver().update
-    }
-    assert script.get_observers("run_script") == {
-        ScalingHTMLGenerator(): ScalingHTMLGenerator().make_scaling_html,
-        ScalingSummaryGenerator(): ScalingSummaryGenerator().print_scaling_summary,
-    }
-    assert script.scaler.get_observers("performed_scaling") == {
-        ScalingModelObserver(): ScalingModelObserver().update
-    }
-    assert script.scaler.get_observers("performed_outlier_rejection") == {
-        ScalingOutlierObserver(): ScalingOutlierObserver().update
-    }
+    refls = flex.reflection_table.from_file(refl).split_by_experiment_id()
+    expts = load.experiment_list(expt, check_format=False)
+    params = mock.Mock()
+    return refls, expts, params
 
 
-def test_ScalingHTMLGenerator(run_in_tmpdir):
-    """Test the scaling html generator."""
+@pytest.fixture
+def test_script(test_data):
     script = mock.Mock()
-    script.params.output.html = "test.html"
-    script.params.output.json = "test.json"
-
-    # Test that ScalingHTMLGenerator works if all data is empty.
-    observer = ScalingHTMLGenerator()
-    observer.make_scaling_html(script)
-    assert os.path.exists("test.html")
-    assert os.path.exists("test.json")
-
-
-def test_ScalingModelObserver():
-    """Test that the observer correctly logs data when passed a scaler."""
-
-    KB_dict = {
-        "__id__": "KB",
-        "is_scaled": True,
-        "scale": {
-            "n_parameters": 1,
-            "parameters": [0.5],
-            "est_standard_devs": [0.05],
-            "null_parameter_value": 1,
-        },
-        "configuration_parameters": {"corrections": ["scale"]},
-    }
-
-    KBmodel = KBScalingModel.from_dict(KB_dict)
-    experiment = Experiment()
-    experiment.scaling_model = KBmodel
-    experiment.identifier = "0"
-
-    scaler1 = mock.Mock()
-    scaler1.experiment = experiment
-    scaler1.active_scalers = None
-
-    observer = ScalingModelObserver()
-    observer.update(scaler1)
-    assert observer.data[0] == KB_dict
-
-    msg = observer.return_model_error_summary()
-    assert msg != ""
-
-    mock_func = mock.Mock()
-    mock_func.return_value = {"plot": {"layout": {"title": ""}}}
-
-    with mock.patch(
-        "dials.algorithms.scaling.observers.plot_scaling_models", new=mock_func
-    ):
-        observer.make_plots()
-        assert mock_func.call_count == 1
-        assert mock_func.call_args_list == [mock.call(KB_dict)]
-
-    experiment2 = Experiment()
-    experiment2.scaling_model = KBmodel
-    experiment2.identifier = "1"
-    scaler2 = mock.Mock()
-    scaler2.experiment = experiment2
-    scaler2.active_scalers = None
-
-    multiscaler = mock.Mock()
-    multiscaler.active_scalers = [scaler1, scaler2]
-    observer.data = {}
-    observer.update(multiscaler)
-    assert observer.data[0] == KB_dict
-    assert observer.data[1] == KB_dict
-
-    mock_func = mock.Mock()
-    mock_func.return_value = {"plot": {"layout": {"title": ""}}}
-
-    with mock.patch(
-        "dials.algorithms.scaling.observers.plot_scaling_models", new=mock_func
-    ):
-        r = observer.make_plots()
-        assert mock_func.call_count == 2
-        assert mock_func.call_args_list == [mock.call(KB_dict), mock.call(KB_dict)]
-        assert all(i in r["scaling_model"] for i in ["plot_0", "plot_1"])
+    refls, expts, params = test_data
+    script.reflections = refls
+    script.experiments = expts
+    script.params = params
+    script.scaled_miller_array = scaled_data_as_miller_array(refls, expts)
+    script.merging_statistics_result = None
+    script.anom_merging_statistics_result = None
+    script.filtering_results = None
+    return script
 
 
-def test_ScalingOutlierObserver():
-    """Test that the observer correctly logs data when passed a scaler."""
-
-    mock_detector = mock.Mock()
-    mock_detector.get_image_size.return_value = [100.0, 200.0]
-    mock_scan = mock.Mock()
-    mock_scan.get_oscillation.return_value = [0.0, 1.0]
-    mock_scan.get_oscillation_range.return_value = [0.0, 4.0]
-
-    scaler = mock.Mock()
-    scaler.suitable_refl_for_scaling_sel = flex.bool(4, True)
-    scaler.outliers = flex.bool([False, True, False, False])
-    scaler.reflection_table = {
-        "xyzobs.px.value": flex.vec3_double(
-            [(0, 1, 2), (10, 11, 12), (20, 21, 22), (30, 31, 32)]
-        )
-    }
-    scaler.experiment.identifier = "0"
-    scaler.experiment.detector = [mock_detector]
-    scaler.experiment.scan = mock_scan
-    scaler.active_scalers = None
-
-    observer = ScalingOutlierObserver()
-    observer.update(scaler)
-    assert observer.data == {
-        0: {
-            "x": [10],
-            "y": [11],
-            "z": [12],
-            "image_size": [100.0, 200.0],
-            "z_range": [0.0, 4.0],
-        }
-    }
-
-    mock_func = mock.Mock()
-    mock_func.return_value = {
-        "outlier_xy_positions": {"layout": {"title": ""}},
-        "outliers_vs_z": {"layout": {"title": ""}},
-    }
-
-    with mock.patch("dials.algorithms.scaling.observers.plot_outliers", new=mock_func):
-        r = observer.make_plots()
-        assert mock_func.call_count == 1
-        assert mock_func.call_args_list == [mock.call(observer.data[0])]
-        assert all(
-            i in r["outlier_plots"] for i in ["outlier_plot_0", "outlier_plot_z0"]
-        )
+# test things which require refls, expts, params
+def test_make_scaling_model_plots(test_data):
+    _, expts, __ = test_data
+    graphs = make_scaling_model_plots(expts)
+    assert graphs
+    assert len(graphs["scaling_model"]) == 6  # 2 models, 3 components each
 
 
-def test_ErrorModelObserver():
-    """Test that the observer correctly logs data when passed a scaler."""
-
-    # Set some arbitrary data
-    vals = flex.double(range(1, 11))
-
-    scaler = mock.Mock()
-    scaler.error_model.filtered_Ih_table.intensities = vals
-    scaler.error_model.filtered_Ih_table.Ih_values = 2.0 * vals
-    scaler.error_model.filtered_Ih_table.variances = 3.0 * vals
-    scaler.error_model.filtered_Ih_table.calc_nh.return_value = flex.double(10, 1.0)
-    scaler.error_model.filtered_Ih_table.inverse_scale_factors = 2.0 * vals
-    scaler.error_model.parameters = [1.0, 0.02]
-    m = mock.Mock()
-    m.binning_info = {}
-    scaler.error_model.components = {"b": m}
-    scaler.active_scalers = None
-
-    observer = ErrorModelObserver()
-    observer.update(scaler)
-    assert observer.data["delta_hl"]
-    mock_func = mock.Mock()
-    mock_func.return_value = {"norm_plot": {}}
-    mock_func2 = mock.Mock()
-    mock_func2.return_value = {"isigi_plot": {}}
-    mock_func3 = mock.Mock()
-    mock_func3.return_value = {"variance_plot": {}}
-
-    with mock.patch(
-        "dials.algorithms.scaling.observers.normal_probability_plot", new=mock_func
-    ):
-        with mock.patch(
-            "dials.algorithms.scaling.observers.i_over_sig_i_vs_i_plot", new=mock_func2
-        ):
-            with mock.patch(
-                "dials.algorithms.scaling.observers.error_model_variance_plot",
-                new=mock_func3,
-            ):
-                r = observer.make_plots()
-                assert mock_func.call_count == 1
-                assert mock_func2.call_count == 1
-                assert mock_func3.call_count == 1
-                assert mock_func.call_args_list == [mock.call(observer.data)]
-                assert mock_func3.call_args_list == [mock.call(observer.data)]
-                assert "error_model_plots" in r
-
-
-def example_refls():
-    """Generate a reflection table for a test."""
-    refls = flex.reflection_table()
-    refls["inverse_scale_factor"] = flex.double([2.0, 1.0, 0.5])
-    refls["xyzobs.px.value"] = flex.vec3_double(
-        [(0.0, 0.0, 0.5), (0.0, 0.0, 5.5), (0.0, 0.0, 8.5)]
+def test_print_scaling_model_error_summary(test_data):
+    _, expts, __ = test_data
+    msg = print_scaling_model_error_summary(expts)
+    assert (
+        msg
+        == """Warning: Over half (83.67%) of model parameters have signficant
+uncertainty (sigma/abs(parameter) > 0.5), which could indicate a
+poorly-determined scaling problem or overparameterisation.
+"""
     )
-    refls.set_flags(flex.bool(3, False), refls.flags.outlier_in_scaling)
-    refls["intensity"] = flex.double([1.0, 1.0, 1.0])
-    refls["variance"] = flex.double([1.0, 1.0, 1.0])
-    refls["miller_index"] = flex.miller_index([(1, 1, 1), (1, 1, 1), (1, 1, 1)])
-    return refls
 
 
-def example_array(reflections):
-    """Generate a miller array for a test."""
-    exp_dict = {
-        "__id__": "crystal",
-        "real_space_a": [1.0, 0.0, 0.0],
-        "real_space_b": [0.0, 1.0, 0.0],
-        "real_space_c": [0.0, 0.0, 1.0],
-        "space_group_hall_symbol": "-P 2yb",
-    }
-    crystal = Crystal.from_dict(exp_dict)
-    ms = miller.set(
-        crystal_symmetry=crystal.get_crystal_symmetry(),
-        indices=reflections["miller_index"],
-        anomalous_flag=False,
-    )
-    ma = miller.array(ms, data=reflections["intensity"])
-    ma.set_sigmas(flex.sqrt(reflections["variance"]))
-    return ma
+def test_make_outlier_plots(test_data):
+    refls, expts, _ = test_data
+    graphs = make_outlier_plots(refls, expts)
+    assert graphs
+    assert len(graphs["outlier_plots"]) == 4
 
 
-def test_MergingStatisticsObserver():
-    """Test that the observer correctly logs data when passed a script."""
-    refls = example_refls()
-    script = mock.Mock()
-    script.merging_statistics_result = "result"
-    script.scaled_miller_array = example_array(refls)
-    script.experiments = [mock.Mock()]
-    script.experiments[0].scan.get_image_range.return_value = [0, 10]
-    script.experiments[0].scan.get_valid_image_ranges.return_value = [0, 10]
-    script.reflections = [refls]
-    observer = MergingStatisticsObserver()
-    observer.update(script)
+def test_make_error_model_plots(test_data):
+    _, expts, params = test_data
+    graphs = make_error_model_plots(params, expts)
+    assert graphs
+    assert "error_model_plots" in graphs
 
-    assert observer.data["statistics"] == "result"
-    assert observer.data["is_centric"] is True
-    assert "bm" in observer.data
-    assert "isigivsbatch" in observer.data
-    assert "r_merge_vs_batch" in observer.data
-    assert "scale_vs_batch" in observer.data
 
-    class MockResolution(object):
-        """A Mock class for ResolutionPlotsAndStats and IntensityStatisticsPlots."""
+# test things which require a script object
+def test_make_filtering_plots(test_script):
+    plots = make_filtering_plots(test_script)
+    assert plots
 
-        def __init__(self, *_, **__):
-            self.binner = mock.Mock()
-            self.binner.limits.return_value = flex.double([2.0, 2.0, 2.0])
 
-        def make_all_plots(self, *_):
-            """Mock resolution dependent plots method."""
-            return {"return_plots": {}}
+def test_make_merging_stats_plots(test_script):
+    plots = make_merging_stats_plots(test_script)
+    assert plots
+    assert plots["image_range_tables"]
 
-        def make_plots(self, *_):
-            """Mock anomalous plots method."""
-            return {"anom_plots": []}
 
-        def statistics_tables(self, *_):
-            """Mock statistics tables method."""
-            return "return_tables"
+def test_print_scaling_summary(test_script):
+    print_scaling_summary(test_script)
 
-        def generate_resolution_dependent_plots(self, *_):
-            """Mock method for namesake in IntensityStatisticsPlots"""
-            return {"cc_one_half": {"data": [{}, {}, {}, {}]}}
 
-        def generate_miscellanous_plots(self, *_):
-            """Mock method for namesake in IntensityStatisticsPlots"""
-            return {"misc_plots": []}
+def test_ScalingHTMLContextManager(test_script, tmpdir):
+    script = test_script
+    script.params.output.html = tmpdir.join("test.html").strpath
+    script.params.output.json = tmpdir.join("test.json").strpath
+    with ScalingHTMLContextManager(script):
+        pass
 
-    with mock.patch(
-        "dials.algorithms.scaling.observers.ResolutionPlotsAndStats", new=MockResolution
-    ):
-        with mock.patch(
-            "dials.algorithms.scaling.observers.IntensityStatisticsPlots",
-            new=MockResolution,
-        ):
-            with mock.patch(
-                "dials.algorithms.scaling.observers.AnomalousPlotter",
-                new=MockResolution,
-            ):
-                r = observer.make_plots()
-                assert r["scaling_tables"] == "return_tables"
-                assert "return_plots" in r["resolution_plots"]
-                assert "cc_one_half" in r["resolution_plots"]
-                assert "batch_plots" in r
-                assert r["misc_plots"] == {"misc_plots": []}
-                assert "anom_plots" in r
+    assert tmpdir.join("test.html").check()
+    assert tmpdir.join("test.json").check()

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -815,9 +815,9 @@ def test_scale_cross_validate(dials_data, tmpdir, mode, parameter, parameter_val
     assert not result.returncode and not result.stderr
 
 
-@pytest.mark.xfail(
-    reason="test state leakage, cf. https://github.com/dials/dials/issues/1271",
-)
+# @pytest.mark.xfail(
+#    reason="test state leakage, cf. https://github.com/dials/dials/issues/1271",
+# )
 def test_few_reflections(dials_data):
     u"""
     Test that dials.symmetry does something sensible if given few reflections.

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -815,9 +815,6 @@ def test_scale_cross_validate(dials_data, tmpdir, mode, parameter, parameter_val
     assert not result.returncode and not result.stderr
 
 
-# @pytest.mark.xfail(
-#    reason="test state leakage, cf. https://github.com/dials/dials/issues/1271",
-# )
 def test_few_reflections(dials_data):
     u"""
     Test that dials.symmetry does something sensible if given few reflections.

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -45,7 +45,6 @@ from dials.algorithms.scaling.algorithm import ScalingAlgorithm, ScaleAndFilterA
 from dials.algorithms.scaling.observers import (
     register_default_scaling_observers,
     register_merging_stats_observers,
-    register_scale_and_filter_observers,
 )
 
 try:
@@ -189,7 +188,6 @@ def run_scaling(params, experiments, reflections):
         # Register the observers at the highest level
         if params.filtering.method:
             algorithm = ScaleAndFilterAlgorithm(params, experiments, reflections)
-            register_scale_and_filter_observers(algorithm)
         else:
             algorithm = ScalingAlgorithm(params, experiments, reflections)
 

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -42,10 +42,6 @@ from dials.util import log, show_mail_on_error, Sorry
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 from dials.algorithms.scaling.algorithm import ScalingAlgorithm, ScaleAndFilterAlgorithm
-from dials.algorithms.scaling.observers import (
-    register_default_scaling_observers,
-    # register_merging_stats_observers,
-)
 
 try:
     from typing import List
@@ -185,16 +181,10 @@ def run_scaling(params, experiments, reflections):
         return (None, None)
 
     else:
-        # Register the observers at the highest level
         if params.filtering.method:
             algorithm = ScaleAndFilterAlgorithm(params, experiments, reflections)
         else:
             algorithm = ScalingAlgorithm(params, experiments, reflections)
-
-        if params.output.html:
-            register_default_scaling_observers(algorithm)
-        # else:
-        #    register_merging_stats_observers(algorithm)
 
         algorithm.run()
 

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -44,7 +44,7 @@ from dials.util.version import dials_version
 from dials.algorithms.scaling.algorithm import ScalingAlgorithm, ScaleAndFilterAlgorithm
 from dials.algorithms.scaling.observers import (
     register_default_scaling_observers,
-    register_merging_stats_observers,
+    # register_merging_stats_observers,
 )
 
 try:
@@ -193,8 +193,8 @@ def run_scaling(params, experiments, reflections):
 
         if params.output.html:
             register_default_scaling_observers(algorithm)
-        else:
-            register_merging_stats_observers(algorithm)
+        # else:
+        #    register_merging_stats_observers(algorithm)
 
         algorithm.run()
 

--- a/newsfragments/1381.misc
+++ b/newsfragments/1381.misc
@@ -1,0 +1,1 @@
+Code improvement: remove observer objects from scaling code


### PR DESCRIPTION
 The use of observer objects has been shown to lead to issues due to the use of global objects (#1271).

Replace these objects with simpler function calls or context managers depending on the situation.