### PR TITLE
Fix for slice_experiments if image_range != (1,N)

### DIFF
--- a/newsfragments/1383.bugfix
+++ b/newsfragments/1383.bugfix
@@ -1,0 +1,1 @@
+Fix for slice_experiments if image range doesn't start at 1

--- a/util/slice.py
+++ b/util/slice.py
@@ -34,7 +34,10 @@ def slice_experiments(experiments, image_ranges):
         end = sr[1] - arr_start
         exp.scan.swap(exp.scan[beg:end])
         if exp.imageset is not None:
-            exp.imageset = exp.imageset[beg:end]
+            # Gorilla of temporary workarounds for inconsistent scan and imageset slicing
+            # https://github.com/cctbx/dxtbx/issues/213
+            offset = exp.scan.get_batch_offset()
+            exp.imageset = exp.imageset[beg + offset : end + offset]
 
         # account for scan-varying crystal
         if exp.crystal and exp.crystal.num_scan_points > 0:

--- a/util/test_slice.py
+++ b/util/test_slice.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import copy
-import pytest
 
 from dxtbx.model import Experiment, ExperimentList
 from dxtbx.model import Scan
@@ -32,9 +31,6 @@ def test_slice_experiments_centroid_test_data(dials_data):
     assert copy.deepcopy(sliced_experiments)
 
 
-@pytest.mark.xfail(
-    raises=OverflowError, reason="https://github.com/dials/dials/issues/1382"
-)
 def test_slice_experiments_centroid_test_data_starting_from_2(dials_data):
     files = dials_data("centroid_test_data").listdir("*.cbf", sort=True)[1:]
     experiments = ExperimentListFactory.from_filenames(f.strpath for f in files)


### PR DESCRIPTION
Gorilla of temporary workarounds for inconsistent scan and imageset slicing
(cctbx/dxtbx#213).

Fixes #1382