### PR TITLE
Optimise sigma calculation code in dials.integrate

### DIFF
--- a/algorithms/profile_model/gaussian_rs/calculator.py
+++ b/algorithms/profile_model/gaussian_rs/calculator.py
@@ -317,8 +317,7 @@ class ComputeEsdReflectingRange(object):
             # Compute intensity
             self.K = flex.double()
             for i0, i1 in zip(self.indices[:-1], self.indices[1:]):
-                selection = flex.size_t(range(i0, i1))
-                self.K.append(flex.sum(self.n.select(selection)))
+                self.K.append(flex.sum(self.n[i0:i1]))
 
             # Set the starting values to try 1, 3 degrees seems sensible for
             # crystal mosaic spread
@@ -379,15 +378,13 @@ class ComputeEsdReflectingRange(object):
             # recorded.
             #
             L = 0
-            for j, (i0, i1) in enumerate(zip(self.indices[:-1], self.indices[1:])):
-                selection = flex.size_t(range(i0, i1))
-                zj = zi.select(selection)
-                nj = n.select(selection)
-                kj = K[j]
-                Z = flex.sum(zj)
+            for (kj, i0, i1) in zip(K, self.indices[:-1], self.indices[1:]):
+                zj = zi[i0:i1]
+                nj = n[i0:i1]
+                logZ = math.log(flex.sum(zj))
                 # L += flex.sum(nj * flex.log(zj)) - kj * Z
                 # L += flex.sum(nj * flex.log(zj)) - kj * math.log(Z)
-                L += flex.sum(nj * flex.log(zj)) - kj * math.log(Z) + math.log(Z)
+                L += flex.sum(nj * flex.log(zj)) - kj * logZ + logZ
             logger.debug("Sigma M: %f, log(L): %f", sigma_m * 180 / math.pi, L)
 
             # Return the logarithm of r

--- a/newsfragments/1399.misc
+++ b/newsfragments/1399.misc
@@ -1,0 +1,1 @@
+Improve performance of sigma calculation code in dials.integrate


### PR DESCRIPTION
Replace 
```
selection = flex.size_t(range(i0, i1))
val = x.select(selection)
```
with functionally identical
```val = x[i0:i1]```

Gives significant performance improvement as the second case is within a loop with the target function calculation.
Also remove an unnecessary enumerate.

Just testing on beta-lactamase:
**master**
```  
6.1: Using 90666 / 91208 reflections for sigma calculation
        Calculating E.S.D Beam Divergence.
7.3: Calculating E.S.D Reflecting Range (mosaicity).
51.1:  sigma b: 0.039018 degrees
         sigma m: 0.056053 degrees
```
branch
```
   6.0: Using 90666 / 91208 reflections for sigma calculation
        Calculating E.S.D Beam Divergence.
   7.1: Calculating E.S.D Reflecting Range (mosaicity).
  29.5:  sigma b: 0.039018 degrees
         sigma m: 0.056053 degrees
```
Verified the output is identical using @graeme-winter's new matching tool.

