### PR TITLE
Test refactoring: reuse fixture output

### DIFF
--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -302,7 +302,7 @@ def test_scale_single_dataset_with_options(dials_data, tmpdir, option):
     run_one_scaling(tmpdir, args)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def vmxi_protk_reindexed(dials_data, tmpdir):
     """Reindex the protk data to be in the correct space group."""
     location = dials_data("vmxi_proteinase_k_sweeps")
@@ -357,9 +357,9 @@ def test_error_model_options(
 
     Current values taken at 14.11.19"""
     expt_1, refl_1 = vmxi_protk_reindexed
-    args = [refl_1, expt_1] + [o for o in options]
+    args = [refl_1, expt_1] + list(options)
     run_one_scaling(tmpdir, args)
-    expts = load.experiment_list(tmpdir.join("scaled.expt").strpath, check_format=False)
+    expts = load.experiment_list(tmpdir.join("scaled.expt"), check_format=False)
     config = expts[0].scaling_model.configdict
     if not expected:
         assert "error_model_parameters" not in config

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -303,7 +303,7 @@ def test_scale_single_dataset_with_options(dials_data, tmpdir, option):
 
 
 @pytest.fixture(scope="session")
-def vmxi_protk_reindexed(dials_data, tmpdir):
+def vmxi_protk_reindexed(dials_data, tmp_path_factory):
     """Reindex the protk data to be in the correct space group."""
     location = dials_data("vmxi_proteinase_k_sweeps")
 
@@ -313,8 +313,9 @@ def vmxi_protk_reindexed(dials_data, tmpdir):
         location.join("reflections_0.pickle"),
         "space_group=P422",
     ]
-    procrunner.run(command, working_directory=tmpdir)
-    return tmpdir.join("reindexed.expt"), tmpdir.join("reindexed.refl")
+    tmp_path = tmp_path_factory.mktemp("vmxi_protk_reindexed")
+    procrunner.run(command, working_directory=tmp_path)
+    return tmp_path / "reindexed.expt", tmp_path / "reindexed.refl"
 
 
 @pytest.mark.parametrize(

--- a/newsfragments/1400.misc
+++ b/newsfragments/1400.misc
@@ -1,0 +1,1 @@
+Refactor test to make it more efficient


### PR DESCRIPTION
The `vmxi_protk_reindexed` fixture generates 2 files that are used in 8 downstream tests.
The default fixture scope is `function`, which means the files are generated 8 times.
This PR changes the scope to `session`, which means the files are generated `min(8, nproc)` times, saving `0 <= x <= 10` seconds and `30*max(1, 8-nproc)` MB temporary disk space.

Minor campsite cleanups, and tmpdir → tmp_path