### PR TITLE
Address procrunner deprecation warnings

### DIFF
--- a/test/command_line/test_estimate_gain.py
+++ b/test/command_line/test_estimate_gain.py
@@ -1,14 +1,12 @@
-from __future__ import absolute_import, division, print_function
-
 import procrunner
 
 
-def test(dials_data, tmpdir):
+def test(dials_data, tmp_path):
     input_filename = dials_data("centroid_test_data").join("datablock.json").strpath
 
     result = procrunner.run(
         ["dials.estimate_gain", "input.experiments=" + input_filename],
-        working_directory=tmpdir,
+        working_directory=tmp_path,
     )
     assert not result.returncode and not result.stderr
-    assert b"Estimated gain: 1.0" in result["stdout"]
+    assert b"Estimated gain: 1.0" in result.stdout

--- a/test/command_line/test_find_spots_server_client.py
+++ b/test/command_line/test_find_spots_server_client.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import multiprocessing
 import socket
 import sys
@@ -15,7 +13,7 @@ def start_server(server_command, working_directory):
     procrunner.run(server_command, working_directory=working_directory)
 
 
-def test_find_spots_server_client(dials_data, tmpdir):
+def test_find_spots_server_client(dials_data, tmp_path):
     if sys.hexversion >= 0x3080000 and sys.platform == "darwin":
         pytest.skip("find_spots server known to be broken on MacOS with Python 3.8+")
 
@@ -25,9 +23,7 @@ def test_find_spots_server_client(dials_data, tmpdir):
     server_command = ["dials.find_spots_server", "port=%i" % port, "nproc=3"]
     print(server_command)
 
-    p = multiprocessing.Process(
-        target=start_server, args=(server_command, tmpdir.strpath)
-    )
+    p = multiprocessing.Process(target=start_server, args=(server_command, tmp_path))
     p.daemon = True
     s.close()
     p.start()
@@ -89,7 +85,7 @@ def exercise_client(port, filenames):
     print(index_client_command)
     result = procrunner.run(index_client_command)
     assert not result.returncode and not result.stderr
-    out = "<document>%s</document>" % result["stdout"]
+    out = "<document>%s</document>" % result.stdout
 
     xmldoc = minidom.parseString(out)
     assert len(xmldoc.getElementsByTagName("image")) == 1
@@ -113,7 +109,7 @@ def exercise_client(port, filenames):
     client_command = client_command + filenames[1:]
     result = procrunner.run(client_command)
     assert not result.returncode and not result.stderr
-    out = "<document>%s</document>" % result["stdout"]
+    out = "<document>%s</document>" % result.stdout
 
     xmldoc = minidom.parseString(out)
     images = xmldoc.getElementsByTagName("image")

--- a/test/command_line/test_plot_Fo_vs_Fc.py
+++ b/test/command_line/test_plot_Fo_vs_Fc.py
@@ -1,14 +1,11 @@
-from __future__ import absolute_import, division, print_function
-
 import procrunner
 
 
-def test(dials_data, tmpdir):
+def test(dials_data, tmp_path):
     mtz_file = dials_data("lysozyme_electron_diffraction").join("refmac_final.mtz")
     result = procrunner.run(
-        ["dials.plot_Fo_vs_Fc", "hklin={0}".format(mtz_file.strpath)],
-        working_directory=tmpdir,
+        ["dials.plot_Fo_vs_Fc", "hklin=" + mtz_file.strpath], working_directory=tmp_path
     )
     assert not result.returncode and not result.stderr
-    assert tmpdir.join("Fo_vs_Fc.pdf").check()
-    assert "|Fe| = 42.0" in result["stdout"].decode()
+    assert tmp_path.joinpath("Fo_vs_Fc.pdf").is_file()
+    assert "|Fe| = 42.0" in result.stdout.decode()


### PR DESCRIPTION
accessing the return object as an array was [deprecated in 2.1](https://procrunner.readthedocs.io/en/latest/history.html#id2).

Campsite cleanup: Switch tests from the `tmpdir` fixture to the `tmp_path` fixture.