### PR TITLE
Retire use of the thaumatin_i04 dataset in tests

### DIFF
--- a/newsfragments/1406.misc
+++ b/newsfragments/1406.misc
@@ -1,0 +1,1 @@
+Refactor test to not depend on a huge dataset


### PR DESCRIPTION
The `thaumatin_i04` dataset is a very large dataset (3.1 GB) taking up a lot of resources in the Azure CI.
This PR rewrites the test to use a much smaller dataset that is already used elsewhere - in fact it just uses pre-processed data and does not look at a raw dataset at all.

(`thaumatin_i04` is still used in the tutorials, but that is not relevant for running the tests.)