### PR TITLE
Clear imageset cache after processing in client/server mode

### DIFF
--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -527,6 +527,7 @@ class Script(object):
                         experiment.detector = imageset.get_detector()
 
                     processor.process_experiments(tag, experiments)
+                    imageset.clear_cache()
                 if finalize:
                     processor.finalize()
                 return processor

--- a/newsfragments/1412.bugfix
+++ b/newsfragments/1412.bugfix
@@ -1,0 +1,1 @@
+Bugfix in stills_process. Clearing the imageset cache during processing prevents memory usage getting too high.


### PR DESCRIPTION
Fixes memory leak introduced in dials/dials@87929e297d81a20eec933ea6b6b006db5a75972c. See cctbx/dxtbx#218.