### PR TITLE
Add a more complete help_message for dials.merge

### DIFF
--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -21,7 +21,15 @@ from dials.util.export_mtz import match_wavelengths
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 
-help_message = """Program to merge scaled dials data."""
+help_message = """
+Merge scaled dials data.
+
+Examples::
+
+  dials.merge scaled.expt scaled.refl
+
+  dials.merge scaled.expt scaled.refl truncate=False
+"""
 
 logger = logging.getLogger("dials")
 phil_scope = phil.parse(

--- a/newsfragments/1413.doc
+++ b/newsfragments/1413.doc
@@ -1,0 +1,1 @@
+dials.merge: improve help message by adding usage examples


### PR DESCRIPTION
The main motivation here is that the single line `help_message` does not contain a newline, hence the output of `dials.merge` with no arguments is messy.

Make the epilogue message multi-line by adding some examples.