### PR TITLE
Make sys.exit messages show red in terminal

### DIFF
--- a/command_line/anvil_correction.py
+++ b/command_line/anvil_correction.py
@@ -359,5 +359,5 @@ def run(args=None, phil=phil_scope):  # type: (List[str], libtbx.phil.scope) -> 
 
 # Keep this minimal.  Try to keep the command-line behaviour neatly encapsulated in run.
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         run()

--- a/command_line/apply_mask.py
+++ b/command_line/apply_mask.py
@@ -6,7 +6,7 @@ from six.moves import cPickle as pickle
 from dxtbx.format.image import ImageBool
 from iotbx.phil import parse
 
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 
 help_message = """
 
@@ -100,6 +100,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/assign_experiment_identifiers.py
+++ b/command_line/assign_experiment_identifiers.py
@@ -6,7 +6,7 @@ import sys
 from libtbx import phil
 
 from dials.array_family import flex
-from dials.util import Sorry, show_mail_on_error
+from dials.util import Sorry, show_mail_handle_errors
 from dials.util.multi_dataset_handling import (
     assign_unique_identifiers,
     parse_multiple_datasets,
@@ -78,5 +78,5 @@ def run(args=None):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/combine_experiments.py
+++ b/command_line/combine_experiments.py
@@ -799,6 +799,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/complete_full_sphere.py
+++ b/command_line/complete_full_sphere.py
@@ -14,7 +14,7 @@ from scitbx import matrix
 from dials.algorithms.refinement import rotation_decomposition
 from dials.algorithms.shadowing.filter import filter_shadowed_reflections
 from dials.array_family import flex
-from dials.util import log, show_mail_on_error
+from dials.util import log, show_mail_handle_errors
 from dials.util.options import OptionParser, flatten_experiments
 
 logger = logging.getLogger("dials.command_line.complete_full_sphere")
@@ -233,6 +233,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/compute_delta_cchalf.py
+++ b/command_line/compute_delta_cchalf.py
@@ -7,7 +7,7 @@ import logging
 from libtbx.phil import parse
 
 from dials.algorithms.statistics.cc_half_algorithm import CCHalfFromDials, CCHalfFromMTZ
-from dials.util import log, show_mail_on_error
+from dials.util import log, show_mail_handle_errors
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
 logger = logging.getLogger("dials.command_line.compute_delta_cchalf")
@@ -139,5 +139,5 @@ of datasets in the reflection table (%s)
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -17,7 +17,7 @@ from dials.command_line.symmetry import (
     change_of_basis_ops_to_minimum_cell,
     eliminate_sys_absent,
 )
-from dials.util import Sorry, log, show_mail_on_error
+from dials.util import Sorry, log, show_mail_handle_errors
 from dials.util.exclude_images import get_selection_for_valid_image_ranges
 from dials.util.filter_reflections import filtered_arrays_from_experiments_reflections
 from dials.util.multi_dataset_handling import (
@@ -376,5 +376,5 @@ def run(args):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run(sys.argv[1:])

--- a/command_line/create_profile_model.py
+++ b/command_line/create_profile_model.py
@@ -4,7 +4,7 @@ import logging
 
 from libtbx.phil import parse
 
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 
 logger = logging.getLogger("dials.command_line.create_profile_model")
 
@@ -219,6 +219,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/damage_analysis.py
+++ b/command_line/damage_analysis.py
@@ -47,7 +47,7 @@ from scitbx.array_family import flex
 
 from dials.command_line.symmetry import median_unit_cell
 from dials.pychef import Statistics, batches_to_dose, interpret_images_to_doses_options
-from dials.util import log, resolution_analysis, show_mail_on_error
+from dials.util import log, resolution_analysis, show_mail_handle_errors
 from dials.util.filter_reflections import filter_reflection_table
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
@@ -335,5 +335,5 @@ def run(args=None, phil=phil_scope):  # type: (List[str], phil.scope) -> None
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -16,7 +16,7 @@ from dxtbx.model.experiment_list import (
 )
 from libtbx.phil import parse
 
-from dials.util import Sorry, show_mail_on_error
+from dials.util import Sorry, show_mail_handle_errors
 from dials.util.multi_dataset_handling import generate_experiment_identifiers
 from dials.util.options import flatten_experiments
 
@@ -924,6 +924,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/filter_reflections.py
+++ b/command_line/filter_reflections.py
@@ -12,7 +12,7 @@ from libtbx.phil import parse
 
 from dials.algorithms.integration import filtering
 from dials.array_family import flex
-from dials.util import Sorry, log, show_mail_on_error, tabulate
+from dials.util import Sorry, log, show_mail_handle_errors, tabulate
 from dials.util.filter_reflections import SumAndPrfIntensityReducer, SumIntensityReducer
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
@@ -452,5 +452,5 @@ def run():
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/find_shared_models.py
+++ b/command_line/find_shared_models.py
@@ -7,7 +7,7 @@ from collections import Counter
 from dxtbx.imageset import ImageSequence
 from libtbx.phil import parse
 
-from dials.util import log, show_mail_on_error, tabulate
+from dials.util import log, show_mail_handle_errors, tabulate
 from dials.util.options import OptionParser, flatten_experiments
 from dials.util.version import dials_version
 
@@ -148,6 +148,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/find_spots.py
+++ b/command_line/find_spots.py
@@ -9,7 +9,7 @@ from libtbx.phil import parse
 from dials.algorithms.shoebox import MaskCode
 from dials.algorithms.spot_finding import per_image_analysis
 from dials.array_family import flex
-from dials.util import log, show_mail_on_error
+from dials.util import log, show_mail_handle_errors
 from dials.util.ascii_art import spot_counts_per_image_plot
 from dials.util.multi_dataset_handling import generate_experiment_identifiers
 from dials.util.options import OptionParser, flatten_experiments
@@ -225,6 +225,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/frame_orientations.py
+++ b/command_line/frame_orientations.py
@@ -231,6 +231,6 @@ def extract_experiment_data(exp, scale=1):
 
 
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/generate_mask.py
+++ b/command_line/generate_mask.py
@@ -178,5 +178,5 @@ def run(phil=phil_scope, args=None):
 
 
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         run()

--- a/command_line/import_xds.py
+++ b/command_line/import_xds.py
@@ -11,7 +11,7 @@ from rstbx.cftbx.coordinate_frame_helpers import align_reference_frame
 from scitbx import matrix
 
 from dials.array_family import flex
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 from dials.util.command_line import Command
 from dials.util.options import OptionParser
 
@@ -454,6 +454,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -33,7 +33,7 @@ import dials.util.log
 from dials.algorithms.integration.integrator import create_integrator
 from dials.algorithms.profile_model.factory import ProfileModelFactory
 from dials.array_family import flex
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 from dials.util.command_line import heading
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.slice import slice_crystal
@@ -696,5 +696,5 @@ def run(args=None, phil=phil_scope):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -16,7 +16,7 @@ from dials.algorithms.merging.merge import (
     make_merged_mtz_file,
     merge_and_truncate,
 )
-from dials.util import Sorry, log, show_mail_on_error
+from dials.util import Sorry, log, show_mail_handle_errors
 from dials.util.export_mtz import match_wavelengths
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
@@ -177,5 +177,5 @@ Only scaled data can be processed with dials.merge"""
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/merge_reflection_lists.py
+++ b/command_line/merge_reflection_lists.py
@@ -6,7 +6,7 @@ import sys
 
 from libtbx.phil import parse
 
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 from dials.util.command_line import Command
 from dials.util.options import OptionParser
 
@@ -84,6 +84,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/missing_reflections.py
+++ b/command_line/missing_reflections.py
@@ -139,5 +139,5 @@ def run(args=None, phil=phil_scope):  # type: (List[str], libtbx.phil.scope) -> 
 
 
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         run()

--- a/command_line/model_background.py
+++ b/command_line/model_background.py
@@ -286,6 +286,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/plot_Fo_vs_Fc.py
+++ b/command_line/plot_Fo_vs_Fc.py
@@ -17,7 +17,7 @@ from iotbx import mtz
 from scitbx.array_family import flex
 from scitbx.lstbx import normal_eqns, normal_eqns_solving
 
-from dials.util import Sorry, show_mail_on_error
+from dials.util import Sorry, show_mail_handle_errors
 from dials.util.options import OptionParser
 
 matplotlib.use("Agg")
@@ -247,6 +247,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/plot_scan_varying_model.py
+++ b/command_line/plot_scan_varying_model.py
@@ -407,6 +407,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/predict.py
+++ b/command_line/predict.py
@@ -4,7 +4,7 @@ from libtbx.phil import parse
 
 from dials.algorithms.shadowing.filter import filter_shadowed_reflections
 from dials.array_family import flex
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 from dials.util.command_line import Command
 from dials.util.options import OptionParser, flatten_experiments
 
@@ -136,6 +136,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -482,5 +482,5 @@ def run(args=None, phil=working_phil):
 
 
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         run()

--- a/command_line/refine_error_model.py
+++ b/command_line/refine_error_model.py
@@ -36,7 +36,7 @@ from dials.algorithms.scaling.plots import (
 from dials.algorithms.scaling.scaling_library import choose_initial_scaling_intensities
 from dials.algorithms.scaling.scaling_utilities import calculate_prescaling_correction
 from dials.report.plots import i_over_sig_i_vs_i_plot
-from dials.util import log, show_mail_on_error
+from dials.util import log, show_mail_handle_errors
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 
@@ -199,5 +199,5 @@ def run(args=None, phil=phil_scope):  # type: (List[str], phil.scope) -> None
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -29,7 +29,7 @@ from dials.report.plots import (
     make_image_range_table,
     scale_rmerge_vs_batch_plot,
 )
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 from dials.util.batch_handling import batch_manager
 from dials.util.command_line import Command
 
@@ -2561,6 +2561,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/rs_mapper.py
+++ b/command_line/rs_mapper.py
@@ -7,7 +7,7 @@ from iotbx import ccp4_map, phil
 from scitbx.array_family import flex
 
 import dials.algorithms.rs_mapper as recviewer
-from dials.util import Sorry, show_mail_on_error
+from dials.util import Sorry, show_mail_handle_errors
 from dials.util.options import OptionParser, flatten_experiments
 
 help_message = """
@@ -160,6 +160,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -43,7 +43,7 @@ from six.moves import cStringIO as StringIO
 from libtbx import phil
 
 from dials.algorithms.scaling.algorithm import ScaleAndFilterAlgorithm, ScalingAlgorithm
-from dials.util import Sorry, log, show_mail_on_error
+from dials.util import Sorry, log, show_mail_handle_errors
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 from dials.util.version import dials_version
 
@@ -255,5 +255,5 @@ def run(args=None, phil=phil_scope):  # type: (List[str], phil.scope) -> None
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/sequence_to_stills.py
+++ b/command_line/sequence_to_stills.py
@@ -20,7 +20,7 @@ from dials.algorithms.refinement.prediction.managed_predictors import (
 )
 from dials.array_family import flex
 from dials.model.data import Shoebox
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
 logger = logging.getLogger("dials.command_line.sequence_to_stills")
@@ -229,5 +229,5 @@ def run(args=None, phil=phil_scope):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/show_extensions.py
+++ b/command_line/show_extensions.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 
 
 class Script(object):
@@ -81,6 +81,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/slice_sequence.py
+++ b/command_line/slice_sequence.py
@@ -5,7 +5,7 @@ from os.path import basename, splitext
 from dxtbx.model.experiment_list import ExperimentList
 
 from dials.algorithms.refinement.refinement_helpers import calculate_frame_numbers
-from dials.util import Sorry, show_mail_on_error
+from dials.util import Sorry, show_mail_handle_errors
 from dials.util.slice import slice_experiments, slice_reflections
 
 help_message = """
@@ -235,6 +235,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/sort_reflections.py
+++ b/command_line/sort_reflections.py
@@ -90,6 +90,6 @@ class Sort(object):
 
 
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         script = Sort()
         script.run()

--- a/command_line/split_experiments.py
+++ b/command_line/split_experiments.py
@@ -6,7 +6,7 @@ from dxtbx.model.experiment_list import ExperimentList
 from libtbx.phil import parse
 
 from dials.array_family import flex
-from dials.util import Sorry, show_mail_on_error
+from dials.util import Sorry, show_mail_handle_errors
 from dials.util.export_mtz import match_wavelengths
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
 
@@ -337,6 +337,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -1662,6 +1662,6 @@ class Processor(object):
 
 
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -27,7 +27,7 @@ from dials.algorithms.symmetry.absences.screw_axes import ScrewAxisObserver
 from dials.algorithms.symmetry.laue_group import LaueGroupAnalysis
 from dials.array_family import flex
 from dials.command_line.reindex import reindex_experiments
-from dials.util import log, show_mail_on_error, tabulate
+from dials.util import log, show_mail_handle_errors, tabulate
 from dials.util.exclude_images import (
     exclude_image_ranges_from_scans,
     get_selection_for_valid_image_ranges,
@@ -565,5 +565,5 @@ def run(args=None):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         run()

--- a/command_line/two_theta_offset.py
+++ b/command_line/two_theta_offset.py
@@ -6,7 +6,7 @@ from libtbx.phil import parse
 from scitbx import matrix
 from scitbx.math import r3_rotation_axis_and_angle_from_matrix
 
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 from dials.util.options import OptionParser, flatten_experiments
 
 help_message = """
@@ -163,6 +163,6 @@ def find_centre_of_rotation(x1, x2, y1, y2):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/command_line/two_theta_refine.py
+++ b/command_line/two_theta_refine.py
@@ -29,7 +29,7 @@ from dials.algorithms.refinement.two_theta_refiner import (
     TwoThetaTarget,
 )
 from dials.array_family import flex
-from dials.util import log, show_mail_on_error, tabulate
+from dials.util import log, show_mail_handle_errors, tabulate
 from dials.util.filter_reflections import filter_reflection_table
 from dials.util.multi_dataset_handling import parse_multiple_datasets
 from dials.util.options import OptionParser, reflections_and_experiments_from_files
@@ -538,6 +538,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/doc/examples/boilerplate.py
+++ b/doc/examples/boilerplate.py
@@ -17,7 +17,7 @@ import libtbx.phil
 # dxtbx.model.Experiment objects, collated in ExperimentList objects.
 from dxtbx.model import ExperimentList
 
-# All command-line DIALS programs should run with dials.util.show_mail_on_error.
+# All command-line DIALS programs should run with dials.util.show_mail_handle_errors.
 import dials.util
 
 # The logging module is used to raise log messages.  Additionally, dials.util.log
@@ -164,5 +164,5 @@ def run(args=None, phil=phil_scope):  # type: (List[str], libtbx.phil.scope) -> 
 
 # Keep this minimal.  Try to keep the command-line behaviour neatly encapsulated in run.
 if __name__ == "__main__":
-    with dials.util.show_mail_on_error():
+    with dials.util.show_mail_handle_errors():
         run()

--- a/doc/examples/read_experiment_and_data/experiment_data.py
+++ b/doc/examples/read_experiment_and_data/experiment_data.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 from libtbx.phil import parse
 
 import dials.util.options
-from dials.util import show_mail_on_error
+from dials.util import show_mail_handle_errors
 
 help_message = """
 
@@ -115,6 +115,6 @@ class Script(object):
 
 
 if __name__ == "__main__":
-    with show_mail_on_error():
+    with show_mail_handle_errors():
         script = Script()
         script.run()

--- a/newsfragments/1420.feature
+++ b/newsfragments/1420.feature
@@ -1,0 +1,1 @@
+Exit error messages from commands will now be colourized

--- a/test/util/test_exception_handler.py
+++ b/test/util/test_exception_handler.py
@@ -2,6 +2,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
+import sys
+
 import pytest
 import six
 
@@ -34,3 +37,29 @@ def test_crash_with_bytestring():
             raise _SomeError(b"This is a byte string")
     assert "report this error" in repr(exc.value)
     assert "This is a" in repr(exc.value)
+
+
+def test_coloured_exit(monkeypatch):
+    with pytest.raises(SystemExit) as e:
+        with dials.util.make_sys_exit_red():
+            sys.exit("Ohno")
+    assert e.value.code == "Ohno"
+
+    class _AttySysErr:
+        def isatty(self):
+            return True
+
+    # Force colouring on
+    monkeypatch.setattr(sys, "stderr", _AttySysErr())
+
+    with pytest.raises(SystemExit) as e:
+        with dials.util.make_sys_exit_red():
+            sys.exit("Ohno")
+    assert str(e.value.code).startswith("\033[")
+
+    # and off again...
+    monkeypatch.setitem(os.environ, "NO_COLOR", "1")
+    with pytest.raises(SystemExit) as e:
+        with dials.util.make_sys_exit_red():
+            sys.exit("Ohno")
+    assert e.value.code == "Ohno"

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,20 +1,28 @@
-from __future__ import absolute_import, division, print_function
-
 import contextlib
+import faulthandler
 import functools
+import os
+import signal
 import sys
 
-import six
 import tabulate as _tabulate
 import tqdm
 
 from libtbx.utils import Sorry
 
+# Coloured exit code support on windows
+try:
+    import colorama
+except ImportError:
+    pass
+else:
+    colorama.init()
+
 __all__ = [
     "debug_console",
     "debug_context_manager",
     "progress",
-    "show_mail_on_error",
+    "show_mail_handle_errors",
     "Sorry",
     "tabulate",
 ]
@@ -140,34 +148,47 @@ def debug_context_manager(original_context_manager, name="", log_func=None):
 
 @contextlib.contextmanager
 def show_mail_on_error():
-    if six.PY3:
-        import faulthandler
-
-        faulthandler.enable()
-        with contextlib.suppress(AttributeError, ImportError):
-            import signal
-
-            faulthandler.register(signal.SIGUSR2, all_threads=True)
+    faulthandler.enable()
+    with contextlib.suppress(AttributeError, ImportError):
+        faulthandler.register(signal.SIGUSR2, all_threads=True)
     try:
         yield
     except Exception as e:
-        text = u"Please report this error to dials-support@lists.sourceforge.net:"
-        if len(e.args) == 0:
-            e.args = (text,)
+        text = "Please report this error to dials-support@lists.sourceforge.net:"
+        if len(e.args) == 1:
+            e.args = (f"{text} {e.args[0]}",)
         elif issubclass(e.__class__, Sorry):
             raise
-        elif len(e.args) == 1:
-            if isinstance(e.args[0], six.text_type):
-                if six.PY2:
-                    e.args = (
-                        (text + u" " + e.args[0]).encode(
-                            "ascii", errors="xmlcharrefreplace"
-                        ),
-                    )
-                else:
-                    e.args = (text + u" " + e.args[0],)
-            else:
-                e.args = (str(text) + " " + str(e.args[0]),)
         else:
-            e.args = (text,) + e.args
+            e.args = (text, *e.args)
         raise
+
+
+@contextlib.contextmanager
+def make_sys_exit_red():
+    """Make sys.exit call messages red, if appropriate"""
+    try:
+        yield
+    except SystemExit as e:
+        # Don't colour if requested not to, or user formatted already
+        if (
+            isinstance(e.code, str)
+            and "NO_COLOR" not in os.environ
+            and sys.stderr.isatty()
+            and "\033" not in e.code
+        ):
+            e.code = f"\033[31m{e.code}\033[0m"
+        raise
+
+
+@contextlib.contextmanager
+def show_mail_handle_errors():
+    """
+    Handle showing errors to the user, including contact email, and colors.
+
+    If a stack trace occurs, the user will be give the contact email to report
+    the error to. If a sys.exit is caught, it will be converted to red, if
+    appropriate.
+    """
+    with make_sys_exit_red(), show_mail_on_error():
+        yield

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -155,12 +155,14 @@ def show_mail_on_error():
         yield
     except Exception as e:
         text = "Please report this error to dials-support@lists.sourceforge.net:"
+        if issubclass(e.__class__, Sorry):
+            raise
+
         if len(e.args) == 1:
             e.args = (f"{text} {e.args[0]}",)
-        elif issubclass(e.__class__, Sorry):
-            raise
         else:
             e.args = (text, *e.args)
+
         raise
 
 

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -149,7 +149,7 @@ def debug_context_manager(original_context_manager, name="", log_func=None):
 @contextlib.contextmanager
 def show_mail_on_error():
     faulthandler.enable()
-    with contextlib.suppress(AttributeError, ImportError):
+    with contextlib.suppress(AttributeError):
         faulthandler.register(signal.SIGUSR2, all_threads=True)
     try:
         yield


### PR DESCRIPTION
Logging shows errors in red now, but calls to `sys.exit` bypassed this. In this pull, this is corrected by the standard dials context wrapper, previously used to show the mail message to users.

I've called the new function `show_mail_handle_errors` instead of `show_mail_on_error` because it's starting to do more work than just mail notice handling, and I thought that the scope of what it actually does had crept up enough that the name is confusing.

I'm open to suggestions for better names.

(The most important changes are in [`util/__init__.py`](https://github.com/dials/dials/pull/1420/files#diff-0d55fa38d139143d6fcd846d32fccdbd ) )