### PR TITLE
Show error in integration if shoebox data is missing

### DIFF
--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -673,6 +673,9 @@ def run(args=None, phil=phil_scope):
     else:
         reference = reference[0]
 
+    if "shoebox" not in reference:
+        sys.exit("Error: shoebox data missing from reflection table")
+
     try:
         experiments, reflections, report = run_integration(
             params, experiments, reference

--- a/command_line/integrate.py
+++ b/command_line/integrate.py
@@ -673,7 +673,7 @@ def run(args=None, phil=phil_scope):
     else:
         reference = reference[0]
 
-    if "shoebox" not in reference:
+    if reference and "shoebox" not in reference:
         sys.exit("Error: shoebox data missing from reflection table")
 
     try:

--- a/newsfragments/1421.bugfix
+++ b/newsfragments/1421.bugfix
@@ -1,0 +1,1 @@
+``dials.integrate``: Check for and show error message if shoebox data is missing


### PR DESCRIPTION
After the recent dials-support message about this, it seems like a good idea to show a proper error message, since it's something we can easily detect and User Stack Traces are Always Bad.
