### PR TITLE
Remove boost version restriction

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -1,7 +1,7 @@
 conda-forge::alabaster
 conda-forge::biopython
-conda-forge::boost<1.71
-conda-forge::boost-cpp<1.71
+conda-forge::boost
+conda-forge::boost-cpp
 conda-forge::bzip2
 conda-forge::c-compiler
 conda-forge::colorlog

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -1,7 +1,7 @@
 conda-forge::alabaster
 conda-forge::biopython
-conda-forge::boost<1.71
-conda-forge::boost-cpp<1.71
+conda-forge::boost
+conda-forge::boost-cpp
 conda-forge::bzip2
 conda-forge::c-compiler
 conda-forge::colorlog

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -1,7 +1,7 @@
 conda-forge::alabaster
 conda-forge::biopython
-conda-forge::boost<1.71
-conda-forge::boost-cpp<1.71
+conda-forge::boost
+conda-forge::boost-cpp
 conda-forge::bzip2
 # conda-forge::c-compiler
 conda-forge::colorlog

--- a/newsfragments/1426.misc
+++ b/newsfragments/1426.misc
@@ -1,0 +1,1 @@
+Remove the environment setup restriction to boost version 1.70, and allow building DIALS with newer boost versions.


### PR DESCRIPTION
and track the currently pinned conda-forge version of boost instead.

Conda-forge has moved to boost 1.72, and the cctbx-base package is built with this version as well. It looks like this doesn't cause any obvious issues, so remove the version limits that we currently have in place.