### PR TITLE
find_spots_server: Return HTTP error code 500 for errors

### DIFF
--- a/command_line/find_spots_server.py
+++ b/command_line/find_spots_server.py
@@ -263,10 +263,10 @@ indexing_min_spots = 10
 class handler(server_base.BaseHTTPRequestHandler):
     def do_GET(self):
         """Respond to a GET request."""
-        self.send_response(200)
-        self.send_header("Content-type", "text/xml")
-        self.end_headers()
         if self.path == "/Ctrl-C":
+            self.send_response(200)
+            self.end_headers()
+
             global stop
             stop = True
             return
@@ -283,11 +283,15 @@ class handler(server_base.BaseHTTPRequestHandler):
         try:
             stats = work(filename, params)
             d.update(stats)
-
+            response = 200
         except Exception as e:
             d["error"] = str(e)
+            response = 500
 
-        response = json.dumps(d).encode("latin-1")
+        self.send_response(response)
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+        response = json.dumps(d).encode()
         self.wfile.write(response)
 
 

--- a/newsfragments/1443.bugfix
+++ b/newsfragments/1443.bugfix
@@ -1,0 +1,1 @@
+`dials.find_spots_server`: Return HTTP 500 instead of 200 when running fails

--- a/test/command_line/test_find_spots_server_client.py
+++ b/test/command_line/test_find_spots_server_client.py
@@ -1,45 +1,56 @@
-import multiprocessing
 import socket
+import subprocess
 import sys
 import time
 import timeit
+import urllib.request
 from xml.dom import minidom
 
 import procrunner
 import pytest
 
-
-def start_server(server_command, working_directory):
-    procrunner.run(server_command, working_directory=working_directory)
+from dials.command_line import find_spots_client
 
 
-def test_find_spots_server_client(dials_data, tmp_path):
+@pytest.fixture
+def server(tmp_path) -> int:
+    """Fixture to load a find_spots_server server"""
     if sys.hexversion >= 0x3080000 and sys.platform == "darwin":
         pytest.skip("find_spots server known to be broken on MacOS with Python 3.8+")
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("", 0))
-    port = s.getsockname()[1]
-    server_command = ["dials.find_spots_server", "port=%i" % port, "nproc=3"]
-    print(server_command)
+    # Find a free port to run the server on
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        host, port = sock.getsockname()
+    # Start the server
+    server_command = ["dials.find_spots_server", f"port={port}", "nproc=3"]
+    p = subprocess.Popen(server_command, cwd=tmp_path)
+    wait_for_server(port)
+    yield port
+    find_spots_client.run([f"port={port}", "stop"])
+    p.wait(timeout=3)
+    p.terminate()
 
-    p = multiprocessing.Process(target=start_server, args=(server_command, tmp_path))
-    p.daemon = True
-    s.close()
-    p.start()
-    wait_for_server(port)  # need to give server chance to start
 
+def test_server_return_codes(dials_data, server):
+    first_file = dials_data("centroid_test_data").listdir("*.cbf", sort=True)[0].strpath
+    response = urllib.request.urlopen(f"http://127.0.0.1:{server}/{first_file}")
+    assert response.code == 200
+    with pytest.raises(urllib.error.HTTPError):
+        urllib.request.urlopen(f"http://127.0.0.1:{server}/some/junk/filename")
+
+
+def test_find_spots_server_client(dials_data, tmp_path, server):
     filenames = [
         f.strpath for f in dials_data("centroid_test_data").listdir("*.cbf", sort=True)
     ]
 
     try:
-        exercise_client(port=port, filenames=filenames)
+        exercise_client(port=server, filenames=filenames)
 
     finally:
-        result = procrunner.run(["dials.find_spots_client", "port=%i" % port, "stop"])
+        result = procrunner.run(["dials.find_spots_client", f"port={server}", "stop"])
         assert not result.returncode and not result.stderr
-        p.terminate()
 
 
 def wait_for_server(port, max_wait=20):

--- a/test/command_line/test_find_spots_server_client.py
+++ b/test/command_line/test_find_spots_server_client.py
@@ -9,8 +9,6 @@ from xml.dom import minidom
 import procrunner
 import pytest
 
-from dials.command_line import find_spots_client
-
 
 @pytest.fixture
 def server(tmp_path) -> int:
@@ -27,9 +25,8 @@ def server(tmp_path) -> int:
     p = subprocess.Popen(server_command, cwd=tmp_path)
     wait_for_server(port)
     yield port
-    find_spots_client.run([f"port={port}", "stop"])
-    p.wait(timeout=3)
     p.terminate()
+    p.wait(timeout=3)
 
 
 def test_server_return_codes(dials_data, server):


### PR DESCRIPTION
Was finding that requests to the server that failed were returning HTTP code 200. Not helpful.

Also, do some refactoring of find_spots_server tests to use a common server instantiation via fixtures.