### PR TITLE
Allow bootstrapping with Python 3.9

### DIFF
--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -1093,7 +1093,7 @@ be passed separately with quotes to avoid confusion (e.g
         "--python",
         help="Install this minor version of Python (default: %(default)s)",
         default="3.8",
-        choices=("3.6", "3.7", "3.8"),
+        choices=("3.6", "3.7", "3.8", "3.9"),
     )
     parser.add_argument(
         "--branch",

--- a/newsfragments/1452.feature
+++ b/newsfragments/1452.feature
@@ -1,0 +1,1 @@
+DIALS bootstrap now allow creating a Python 3.9 environment


### PR DESCRIPTION
Enables the `--python 3.9` option for bootstrap.
(This obviously won't work yet because many 3.9 packages are still missing on conda-forge, but we can still already enable it now)