### PR TITLE
dials.merge should show normal merging statistics

### DIFF
--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -211,10 +211,7 @@ def merge(
         logger.error(e, exc_info=True)
         stats_summary = None
     else:
-        if anomalous and anom_stats:
-            stats_summary = make_merging_statistics_summary(anom_stats)
-        else:
-            stats_summary = make_merging_statistics_summary(stats)
+        stats_summary = make_merging_statistics_summary(stats)
         stats_summary += table_1_summary(stats, anom_stats)
 
     return merged, merged_anom, stats_summary


### PR DESCRIPTION
In a recent pull request (#1339), one of my changes had the side effect of making the `dials.merge` output show anomalous merging statistics in the log output.

This changes the output to always be the normal merging statistics which I feel is what would be expected and consistent with other programs e.g. `dials.scale`.