### PR TITLE
Local indexing: take into account phi in nearest neighbour analysis

### DIFF
--- a/algorithms/indexing/index.h
+++ b/algorithms/indexing/index.h
@@ -197,16 +197,17 @@ namespace dials { namespace algorithms {
       // convert into a single array for input to AnnAdaptor
       // based on flex.vec_3.as_double()
       // scitbx/array_family/boost_python/flex_vec3_double.cpp
-      af::shared<double> rlps_double(reciprocal_space_points.size() * 3,
+      af::shared<double> rlps_double(reciprocal_space_points.size() * 4,
                                      af::init_functor_null<double>());
       double* r = rlps_double.begin();
       for (std::size_t i = 0; i < reciprocal_space_points.size(); i++) {
         for (std::size_t j = 0; j < 3; j++) {
           *r++ = reciprocal_space_points[i][j];
         }
+        *r++ = phi[i];
       }
 
-      AnnAdaptor ann = AnnAdaptor(rlps_double, 3, nearest_neighbours);
+      AnnAdaptor ann = AnnAdaptor(rlps_double, 4, nearest_neighbours);
       ann.query(rlps_double);
 
       const double one_over_epsilon = 1.0 / epsilon;

--- a/algorithms/indexing/test_assign_indices.py
+++ b/algorithms/indexing/test_assign_indices.py
@@ -246,7 +246,7 @@ def test_index_reflections(dials_regression):
     assert dict(counts) == {-1: 1390, 0: 114692}
 
 
-def test_4rotation_local(dials_regression):
+def test_local_4rotation(dials_regression):
     """Test the fix for https://github.com/dials/dials/issues/1458"""
 
     data_dir = os.path.join(dials_regression, "indexing_test_data", "4rotation")
@@ -275,6 +275,7 @@ def test_4rotation_local(dials_regression):
     # Assign indices with the correct scan oscillation
     AssignIndicesLocal()(reflections, experiments)
     n_indexed = (reflections["miller_index"] == (0, 0, 0)).count(True)
+    miller_indices = reflections["miller_index"]
 
     # Modify the scan oscillation such that we are out by 1 degree per rotation
     experiments[0].scan.set_oscillation((0, 1 - 1 / 360), deg=True)
@@ -289,3 +290,5 @@ def test_4rotation_local(dials_regression):
     # in oscillation angle
     AssignIndicesLocal()(reflections, experiments)
     assert abs((reflections["miller_index"] == (0, 0, 0)).count(True) - n_indexed) < 10
+    # Assert that most miller indices are the same as before we modified the oscillation
+    assert (reflections["miller_index"] == miller_indices).count(False) < 100

--- a/algorithms/indexing/test_assign_indices.py
+++ b/algorithms/indexing/test_assign_indices.py
@@ -256,26 +256,27 @@ def test_local_multiple_rotations(dials_data):
     # Override the scan range to ensure we have 4 full rotations
     experiments[0].scan.set_image_range((1, 1440))
 
+    # Generate some predicted reflections
     reflections = flex.reflection_table.from_predictions(experiments[0], dmin=4)
     reflections["imageset_id"] = flex.int(len(reflections), 0)
     reflections["id"] = flex.int(len(reflections), -1)
     reflections["xyzobs.px.value"] = reflections["xyzcal.px"]
     reflections["xyzobs.mm.value"] = reflections["xyzcal.mm"]
-
     predicted_miller_indices = reflections["miller_index"]
 
     # Prepare reflections for indexing
     reflections.centroid_px_to_mm(experiments)
     reflections.map_centroids_to_reciprocal_space(experiments)
+
     # Reset miller indices to ensure they are reindexed
     reflections["miller_index"] = flex.miller_index(len(reflections), (0, 0, 0))
 
     # Assign indices with the correct scan oscillation
     AssignIndicesLocal()(reflections, experiments)
-    miller_indices = reflections["miller_index"]
+
     # Assert we have correctly indexed all reflections
-    assert (miller_indices == (0, 0, 0)).count(True) == 0
-    assert (miller_indices == predicted_miller_indices).count(False) == 0
+    assert (reflections["miller_index"] == (0, 0, 0)).count(True) == 0
+    assert (reflections["miller_index"] == predicted_miller_indices).count(False) == 0
 
     # Modify the scan oscillation such that we are out by 1 degree per rotation
     experiments[0].scan.set_oscillation((0, 1 - 1 / 360), deg=True)
@@ -286,10 +287,13 @@ def test_local_multiple_rotations(dials_data):
     reflections.centroid_px_to_mm(experiments)
     reflections.map_centroids_to_reciprocal_space(experiments)
 
+    # Assign indices, this time with the incorrect scan oscillation
     AssignIndicesLocal()(reflections, experiments)
+
     # Assert that most reflections have been indexed
     indexed_sel = reflections["miller_index"] == (0, 0, 0)
     assert indexed_sel.count(True) < 10
+
     # Assert that all indexed miller indices are correct
     assert (
         (reflections["miller_index"] != predicted_miller_indices) & ~indexed_sel

--- a/newsfragments/1459.bugfix
+++ b/newsfragments/1459.bugfix
@@ -1,0 +1,1 @@
+Local index assignment: take into account phi in nearest neighbour analysis

--- a/newsfragments/1459.bugfix
+++ b/newsfragments/1459.bugfix
@@ -1,1 +1,1 @@
-Local index assignment: take into account phi in nearest neighbour analysis
+Local index assignment: take into account phi in nearest neighbour analysis, which can significantly improve indexing rates in some cases with scans > 360°


### PR DESCRIPTION
In the "local" index assignment method, the nearest neighbour analysis should only identify as neighbouring those reflections that are close in phi. If, for example, there is a rotation misset in a scan that is more than one full rotation, this previously could cause issues for the local index assignment, leading to low numbers of indexed reflections.

Fixes #1458