### PR TITLE
Fix float comparison causing gaussianrs test failure

### DIFF
--- a/algorithms/profile_model/gaussian_rs/transform/transform.h
+++ b/algorithms/profile_model/gaussian_rs/transform/transform.h
@@ -947,8 +947,8 @@ namespace dials {
                       DIALS_ASSERT(kk < zfraction.accessor()[1]);
                       DIALS_ASSERT(k < zfraction.accessor()[0]);
                       double fraction = zfraction(k, kk);
-                      DIALS_ASSERT(fraction <= 1.0);
-                      DIALS_ASSERT(fraction >= 0.0);
+                      DIALS_ASSERT(fraction <= 1.0 + EPS);
+                      DIALS_ASSERT(fraction >= 0.0 - EPS);
                       double value = fraction * area * data(k, j, i);
                       profile_(kk, jj, ii) += value;
                     }

--- a/newsfragments/bugfix.1456
+++ b/newsfragments/bugfix.1456
@@ -1,1 +1,1 @@
-Fix integration failure due to GCC 9 update
+Fix integration failures when building with GCC 9

--- a/newsfragments/bugfix.1456
+++ b/newsfragments/bugfix.1456
@@ -1,0 +1,1 @@
+Fix integration failure due to GCC 9 update


### PR DESCRIPTION
GCC updating in conda from 7→9 caused failure in these assertions by ~1e-13 threshold.

Since calculating this involves error functions, it's safe to assume that nowhere was relying on sub-epsilon behaviours from this function, and other comparisons here use epsilon for checking too.

Fixes #1456.