### PR TITLE
partiality_threshold=0.4 in cosym, symmetry and ttr

### DIFF
--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("dials.command_line.cosym")
 
 phil_scope = iotbx.phil.parse(
     """\
-partiality_threshold = 0.99
+partiality_threshold = 0.4
   .type = float
   .help = "Use reflections with a partiality above the threshold."
 

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -73,7 +73,7 @@ relative_length_tolerance = 0.05
 absolute_angle_tolerance = 2
   .type = float(value_min=0)
 
-partiality_threshold = 0.99
+partiality_threshold = 0.4
   .type = float
   .help = "Use only reflections with a partiality above this threshold."
 

--- a/command_line/two_theta_refine.py
+++ b/command_line/two_theta_refine.py
@@ -93,6 +93,10 @@ phil_scope = parse(
       .help = "If integrated centroids are provided, filter these so that only"
               "those with both the 'integrated' and 'strong' flags are used"
 
+    partiality_threshold = 0.4
+      .type = float
+      .help = "Use only reflections with a partiality above this threshold."
+
     combine_crystal_models = True
       .type = bool
       .help = "When multiple experiments are provided as input, combine these to"
@@ -476,7 +480,11 @@ class Script(object):
         # Filter data if scaled to remove outliers
         if "inverse_scale_factor" in reflections:
             try:
-                reflections = filter_reflection_table(reflections, ["scale"])
+                reflections = filter_reflection_table(
+                    reflections,
+                    ["scale"],
+                    partiality_threshold=params.refinement.partiality_threshold,
+                )
             except ValueError as e:
                 logger.warn(e)
                 logger.info(

--- a/newsfragments/1470.bugfix
+++ b/newsfragments/1470.bugfix
@@ -1,0 +1,1 @@
+Lower default partiality_threshold to 0.4 for dials.symmetry, dials.cosym and dials.two_theta_refine. The previous default of 0.99 could occasionally result in too many reflections being rejected for particularly narrow wedges.

--- a/test/command_line/test_two_theta_refine.py
+++ b/test/command_line/test_two_theta_refine.py
@@ -67,6 +67,7 @@ def test_two_theta_refine_scaled_data(dials_data, tmpdir):
         refls,
         expts,
         "output.experiments=refined_cell.expt",
+        "partiality_threshold=0.99",
     ]
     result = procrunner.run(command, working_directory=tmpdir)
     assert not result.returncode and not result.stderr


### PR DESCRIPTION
Set the default partiality_threshold to 0.4 in dials.cosym, dials.symmetry and dials.two_theta_refine. The previous default of 0.99 could occasionally be overzealous in rejecting reflections, especially with particularly narrow wedges. This issue was identified by errors encountered running xia2.multiplex on [James Holton's "Micro-focus Data Processing Challenge" dataset](https://bl831.als.lbl.gov/~jamesh/challenge/microfocus/).