### PR TITLE
For MPI, don't use single log file

### DIFF
--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -1196,6 +1196,13 @@ class Processor(object):
         logger.info("Integrating Reflections")
         logger.info("*" * 80)
 
+        cutoff = os.getenv('USE_INTEGRATION_CUTOFF')
+        if cutoff:
+            cutoff = float(cutoff)
+            for detector in experiments.detectors():
+                for panel in detector:
+                    panel.set_trusted_range((panel.get_trusted_range()[0], cutoff))
+
         indexed, _ = self.process_reference(indexed)
 
         if self.params.dispatch.coset:

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -657,28 +657,6 @@ class Script(object):
 
         # Process the data
         if params.mp.method == "mpi":
-            # # Configure the logging
-            # if params.output.logging_dir is None:
-            #     logfile = None
-            # else:
-            #     log_path = os.path.join(
-            #         params.output.logging_dir, "log_rank%04d.out" % rank
-            #     )
-            #     error_path = os.path.join(
-            #         params.output.logging_dir, "error_rank%04d.out" % rank
-            #     )
-            #     print("Redirecting stdout to %s" % log_path)
-            #     print("Redirecting stderr to %s" % error_path)
-            #     sys.stdout = open(log_path, "a")
-            #     sys.stderr = open(error_path, "a")
-            #     print("Should be redirected now")
-
-            #     logfile = os.path.join(
-            #         params.output.logging_dir, "info_rank%04d.out" % rank
-            #     )
-
-            # log.config(verbosity=options.verbose, logfile=logfile)
-
             if size <= 2:  # client/server only makes sense for n>2
                 subset = [
                     item for i, item in enumerate(iterable) if (i + rank) % size == 0
@@ -1193,13 +1171,6 @@ class Processor(object):
         logger.info("*" * 80)
         logger.info("Integrating Reflections")
         logger.info("*" * 80)
-
-        cutoff = os.getenv("USE_INTEGRATION_CUTOFF")
-        if cutoff:
-            cutoff = float(cutoff)
-            for detector in experiments.detectors():
-                for panel in detector:
-                    panel.set_trusted_range((panel.get_trusted_range()[0], cutoff))
 
         indexed, _ = self.process_reference(indexed)
 

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -359,7 +359,7 @@ class Script(object):
 
         try:
             from mpi4py import MPI
-        except ImportError as e:
+        except ImportError:
             rank = 0
             size = 1
         else:
@@ -415,7 +415,6 @@ class Script(object):
 
         st = time.time()
 
-
         if params.mp.method == "mpi":
             # Configure the logging
             if params.output.logging_dir is None:
@@ -443,7 +442,6 @@ class Script(object):
 
             # Configure logging
             log.config(verbosity=options.verbose, logfile="dials.process.log")
-
 
         bad_phils = [f for f in all_paths if os.path.splitext(f)[1] == ".phil"]
         if len(bad_phils) > 0:
@@ -634,7 +632,7 @@ class Script(object):
             iterable = list(zip(tags, all_paths))
 
         if params.input.max_images:
-            iterable = iterable[:params.input.max_images]
+            iterable = iterable[: params.input.max_images]
 
         if params.input.show_image_tags:
             print("Showing image tags for this dataset and exiting")
@@ -1196,7 +1194,7 @@ class Processor(object):
         logger.info("Integrating Reflections")
         logger.info("*" * 80)
 
-        cutoff = os.getenv('USE_INTEGRATION_CUTOFF')
+        cutoff = os.getenv("USE_INTEGRATION_CUTOFF")
         if cutoff:
             cutoff = float(cutoff)
             for detector in experiments.detectors():
@@ -1348,9 +1346,12 @@ class Processor(object):
 
         for crystal_model in experiments.crystals():
             if hasattr(crystal_model, "get_domain_size_ang"):
-                log_str += ". Final ML model: domain size angstroms: %f, half mosaicity degrees: %f" % (
-                    crystal_model.get_domain_size_ang(),
-                    crystal_model.get_half_mosaicity_deg(),
+                log_str += (
+                    ". Final ML model: domain size angstroms: %f, half mosaicity degrees: %f"
+                    % (
+                        crystal_model.get_domain_size_ang(),
+                        crystal_model.get_half_mosaicity_deg(),
+                    )
                 )
 
         logger.info(log_str)
@@ -1670,8 +1671,8 @@ class Processor(object):
 
             # Create a tar archive of the integration dictionary pickles
             if len(self.all_int_pickles) > 0 and self.params.output.integration_pickle:
-                tar_template_integration_pickle = (
-                    self.params.output.integration_pickle.replace("%d", "%s")
+                tar_template_integration_pickle = self.params.output.integration_pickle.replace(
+                    "%d", "%s"
                 )
                 outfile = (
                     os.path.join(

--- a/newsfragments/1471.bugfix
+++ b/newsfragments/1471.bugfix
@@ -1,0 +1,1 @@
+dials.stills_process improvement when using MPI: remove an extra log file to speed up processing on a big computing cluster


### PR DESCRIPTION
Using a single log file locks up the file system.  We already had log splitting in place, so this change just prevents configuring the log file twice if MPI is enabled.