### PR TITLE
Reduce reliance on `is_scaled` property for dials scaling models.

### DIFF
--- a/algorithms/scaling/model/model.py
+++ b/algorithms/scaling/model/model.py
@@ -275,7 +275,6 @@ class ScalingModelBase(object):
             dict: A dictionary representation of the model.
         """
         dictionary = OrderedDict({"__id__": self.id_})
-        dictionary["is_scaled"] = self._is_scaled
         for key in self.components:
             dictionary[key] = OrderedDict(
                 [
@@ -557,7 +556,6 @@ class DoseDecay(ScalingModelBase):
         (s_params, d_params, abs_params, B) = (None, None, None, None)
         (s_params_sds, d_params_sds, a_params_sds, B_sd) = (None, None, None, None)
         configdict = obj["configuration_parameters"]
-        is_scaled = obj["is_scaled"]
         if "scale" in configdict["corrections"]:
             s_params = flex.double(obj["scale"]["parameters"])
             if "est_standard_devs" in obj["scale"]:
@@ -582,7 +580,7 @@ class DoseDecay(ScalingModelBase):
             "absorption": {"parameters": abs_params, "parameter_esds": a_params_sds},
         }
 
-        return cls(parameters_dict, configdict, is_scaled)
+        return cls(parameters_dict, configdict, is_scaled=True)
 
     def plot_model_components(self):
         d = OrderedDict()
@@ -794,7 +792,6 @@ class PhysicalScalingModel(ScalingModelBase):
         (s_params, d_params, abs_params) = (None, None, None)
         (s_params_sds, d_params_sds, a_params_sds) = (None, None, None)
         configdict = obj["configuration_parameters"]
-        is_scaled = obj["is_scaled"]
         if "scale" in configdict["corrections"]:
             s_params = flex.double(obj["scale"]["parameters"])
             if "est_standard_devs" in obj["scale"]:
@@ -814,7 +811,7 @@ class PhysicalScalingModel(ScalingModelBase):
             "absorption": {"parameters": abs_params, "parameter_esds": a_params_sds},
         }
 
-        return cls(parameters_dict, configdict, is_scaled)
+        return cls(parameters_dict, configdict, is_scaled=True)
 
     def plot_model_components(self):
         d = OrderedDict()
@@ -1075,7 +1072,6 @@ class ArrayScalingModel(ScalingModelBase):
         if obj["__id__"] != cls.id_:
             raise RuntimeError("expected __id__ %s, got %s" % (cls.id_, obj["__id__"]))
         configdict = obj["configuration_parameters"]
-        is_scaled = obj["is_scaled"]
         (dec_params, abs_params, mod_params) = (None, None, None)
         (d_params_sds, a_params_sds, m_params_sds) = (None, None, None)
         if "decay" in configdict["corrections"]:
@@ -1097,7 +1093,7 @@ class ArrayScalingModel(ScalingModelBase):
             "modulation": {"parameters": mod_params, "parameter_esds": m_params_sds},
         }
 
-        return cls(parameters_dict, configdict, is_scaled)
+        return cls(parameters_dict, configdict, is_scaled=True)
 
     def plot_model_components(self):
         d = OrderedDict()
@@ -1151,7 +1147,6 @@ class KBScalingModel(ScalingModelBase):
         if obj["__id__"] != cls.id_:
             raise RuntimeError("expected __id__ %s, got %s" % (cls.id_, obj["__id__"]))
         configdict = obj["configuration_parameters"]
-        is_scaled = obj["is_scaled"]
         (s_params, d_params) = (None, None)
         (s_params_sds, d_params_sds) = (None, None)
         if "scale" in configdict["corrections"]:
@@ -1168,7 +1163,7 @@ class KBScalingModel(ScalingModelBase):
             "decay": {"parameters": d_params, "parameter_esds": d_params_sds},
         }
 
-        return cls(parameters_dict, configdict, is_scaled)
+        return cls(parameters_dict, configdict, is_scaled=True)
 
     @classmethod
     def from_data(cls, params, experiment, reflection_table):

--- a/algorithms/scaling/scaler.py
+++ b/algorithms/scaling/scaler.py
@@ -330,7 +330,6 @@ uncertainty in the scaling model""" + (
         if parameter_manager.apm_list[0].var_cov_matrix:
             for i, scaler in enumerate(self.active_scalers):
                 scaler.update_var_cov(parameter_manager.apm_list[i])
-                scaler.experiment.scaling_model.set_scaling_model_as_scaled()
 
 
 class SingleScaler(ScalerBase):

--- a/algorithms/scaling/test_model.py
+++ b/algorithms/scaling/test_model.py
@@ -155,7 +155,6 @@ def test_KBScalingModel():
     # Test from_dict initialisation method.
     KB_dict = {
         "__id__": "KB",
-        "is_scaled": True,
         "scale": {
             "n_parameters": 1,
             "parameters": [0.5],
@@ -177,7 +176,6 @@ def test_KBScalingModel():
     # Test again with all parameters
     KB_dict = {
         "__id__": "KB",
-        "is_scaled": True,
         "scale": {
             "n_parameters": 1,
             "parameters": [0.5],
@@ -263,7 +261,6 @@ def test_PhysicalScalingModel(test_reflections, mock_exp):
     # Test from_dict initialisation method.
     physical_dict = {
         "__id__": "physical",
-        "is_scaled": True,
         "scale": {
             "n_parameters": 2,
             "parameters": [0.5, 1.0],
@@ -291,7 +288,6 @@ def test_PhysicalScalingModel(test_reflections, mock_exp):
     # Test from_dict initialisation method for all components.
     physical_dict = {
         "__id__": "physical",
-        "is_scaled": True,
         "scale": {
             "n_parameters": 2,
             "parameters": [0.5, 1.0],
@@ -563,7 +559,6 @@ def test_ArrayScalingModel(test_reflections, mock_exp):
     # Test from_dict initialisation method for another case.
     array_dict = {
         "__id__": "array",
-        "is_scaled": True,
         "decay": {
             "n_parameters": 4,
             "parameters": [0.5, 1.0, 0.4, 1.0],

--- a/newsfragments/1479.bugfix
+++ b/newsfragments/1479.bugfix
@@ -1,0 +1,1 @@
+dials.scale: fix issues for some uses of multi-crystal rescaling if full_matrix=False


### PR DESCRIPTION
The current code causes changes in behaviour depending on the use of the full_matrix option, for certain multi-scaling uses such as xia2.multiplex.

Therefore this change reduces the reliance on this parameter; if a scaling model is saved to disk, then it must have been scaled, so handle this when serialising/deserialising models.