### PR TITLE
Add dano/sigdano to the output of dials.merge, and make html report

### DIFF
--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -342,8 +342,8 @@ def make_dano_plots(anomalous_data):
             "dano": {
                 "data": [],
                 "help": """\
-This plot shows the size of the anomalous differences of F relative to the uncertainties.
-(< |F(+)-F(-)|  / σ(F(+)-F(-)) >). A value of 0.8 is indicative of pure noise, and
+This plot shows the size of the anomalous differences of F relative to the uncertainties,
+(<|F(+)-F(-)|/σ(F(+)-F(-))>). A value of 0.8 is indicative of pure noise, and
 a suggested cutoff is when the value falls below 1.2, although these guides require
 reliable sigma estimates. For further information see
 https://strucbio.biologie.uni-konstanz.de/ccp4wiki/index.php?title=SHELX_C/D/E
@@ -394,13 +394,13 @@ https://strucbio.biologie.uni-konstanz.de/ccp4wiki/index.php?title=SHELX_C/D/E
     )
 
     data["dF"]["dano"]["layout"] = {
-        "title": "< |ΔF| / σ(ΔF) > vs resolution",
+        "title": "<|ΔF|/σ(ΔF)> vs resolution",
         "xaxis": {
             "title": "Resolution (Å)",
             "tickvals": d_star_sq_tickvals,
             "ticktext": d_star_sq_ticktext,
         },
-        "yaxis": {"title": "< |ΔF| / σ(ΔF) >", "rangemode": "tozero"},
+        "yaxis": {"title": "<|ΔF|/σ(ΔF)>", "rangemode": "tozero"},
     }
     return data
 

--- a/algorithms/merging/test_merge.py
+++ b/algorithms/merging/test_merge.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from cctbx import crystal, miller
+from scitbx.array_family import flex
+
+from dials.algorithms.merging.merge import dano_over_sigdano
+
+
+def test_dano_over_sigdano():
+    """Create anomalous difference data and check the calculated value."""
+    ms = miller.build_set(
+        crystal_symmetry=crystal.symmetry(
+            space_group_symbol="P222", unit_cell=(6, 6, 6, 90, 90, 90)
+        ),
+        anomalous_flag=True,
+        d_min=5.0,
+    ).expand_to_p1()
+    ma = miller.array(
+        ms, data=flex.double([1, 2, 1, 3, 1, 4]), sigmas=flex.double(6, 1)
+    )
+    # differences are (1, 2, 3) i.e. mean 2, sigmas (sqrt2, sqrt2, sqrt2)
+    assert dano_over_sigdano(ma) == pytest.approx(2 ** 0.5)

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -15,9 +15,9 @@ from iotbx import phil
 from dials.algorithms.merging.merge import (
     MTZDataClass,
     generate_html_report,
+    make_dano_table,
     make_merged_mtz_file,
     merge,
-    print_dano_table,
     show_wilson_scaling_analysis,
     truncate,
 )
@@ -215,7 +215,7 @@ def merge_data_to_mtz(params, experiments, reflections):
         if stats_summary:
             logger.info(stats_summary)
         if anom_amplitudes:
-            print_dano_table(anom_amplitudes)
+            logger.info(make_dano_table(anom_amplitudes))
 
     # pass the dataclasses to an MTZ writer to generate the mtz file and return.
     return make_merged_mtz_file(mtz_datasets)

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -14,8 +14,10 @@ from iotbx import phil
 
 from dials.algorithms.merging.merge import (
     MTZDataClass,
+    generate_html_report,
     make_merged_mtz_file,
     merge,
+    print_dano_table,
     show_wilson_scaling_analysis,
     truncate,
 )
@@ -86,6 +88,9 @@ output {
     mtz = merged.mtz
         .type = str
         .help = "Filename to use for mtz output."
+    html = dials.merge.html
+        .type = str
+        .help = "Filename for html output report."
     crystal_names = XTAL
         .type = strings
         .help = "Crystal name to be used in MTZ file output (multiple names
@@ -197,7 +202,7 @@ def merge_data_to_mtz(params, experiments, reflections):
         else:
             merged_intensities = merged_array
 
-        # truncate the data, separately for normal and anomalous
+        anom_amplitudes = None
         if params.truncate:
             amplitudes, anom_amplitudes = truncate(merged_intensities)
             # This will add the data for F, SIGF
@@ -209,6 +214,8 @@ def merge_data_to_mtz(params, experiments, reflections):
         show_wilson_scaling_analysis(merged_intensities)
         if stats_summary:
             logger.info(stats_summary)
+        if anom_amplitudes:
+            print_dano_table(anom_amplitudes)
 
     # pass the dataclasses to an MTZ writer to generate the mtz file and return.
     return make_merged_mtz_file(mtz_datasets)
@@ -277,6 +284,9 @@ Only scaled data can be processed with dials.merge"""
     mtz_file.show_summary(out=out)
     logger.info(out.getvalue())
     mtz_file.write(params.output.mtz)
+
+    if params.output.html:
+        generate_html_report(mtz_file, params.output.html)
 
 
 if __name__ == "__main__":

--- a/command_line/scale.py
+++ b/command_line/scale.py
@@ -125,6 +125,7 @@ def _export_merged_mtz(params, experiments, joint_table):
     merge_params.partiality_threshold = params.cut_data.partiality_cutoff
     merge_params.output.crystal_names = [params.output.crystal_name]
     merge_params.output.project_name = params.output.project_name
+    merge_params.output.html = None
     merge_params.best_unit_cell = params.reflection_selection.best_unit_cell
     mtz_file = merge_data_to_mtz(merge_params, experiments, [joint_table])
     logger.disabled = False

--- a/newsfragments/1483.feature
+++ b/newsfragments/1483.feature
@@ -1,0 +1,1 @@
+dials.merge: Add dF/s(dF), also known as dano/sigdano, to statistics reported.

--- a/newsfragments/1483.feature
+++ b/newsfragments/1483.feature
@@ -1,1 +1,2 @@
-dials.merge: Add dF/s(dF), also known as dano/sigdano, to statistics reported.
+dials.merge: Add <dF/s(dF)>, to the statistics reported if anomalous=True.
+A html report is also generated to plot this statistic.

--- a/test/command_line/test_merge.py
+++ b/test/command_line/test_merge.py
@@ -57,7 +57,10 @@ def test_merge(dials_data, tmpdir, anomalous, truncate):
     ]
     result = procrunner.run(command, working_directory=tmpdir)
     assert not result.returncode and not result.stderr
-    assert tmpdir.join("dials.merge.html").check()
+    if truncate and anomalous:
+        assert tmpdir.join("dials.merge.html").check()
+    else:
+        assert not tmpdir.join("dials.merge.html").check()
     expected_labels = mean_labels
     unexpected_labels = []
 
@@ -105,7 +108,6 @@ def test_merge_dmin_dmax(dials_data, tmpdir, best_unit_cell):
     ]
     result = procrunner.run(command, working_directory=tmpdir)
     assert not result.returncode and not result.stderr
-    assert tmpdir.join("dials.merge.html").check()
 
     # check the unit cell was correctly set if using best_unit_cell
     m = mtz.object(mtz_file.strpath)

--- a/test/command_line/test_merge.py
+++ b/test/command_line/test_merge.py
@@ -57,6 +57,7 @@ def test_merge(dials_data, tmpdir, anomalous, truncate):
     ]
     result = procrunner.run(command, working_directory=tmpdir)
     assert not result.returncode and not result.stderr
+    assert tmpdir.join("dials.merge.html").check()
     expected_labels = mean_labels
     unexpected_labels = []
 
@@ -104,6 +105,7 @@ def test_merge_dmin_dmax(dials_data, tmpdir, best_unit_cell):
     ]
     result = procrunner.run(command, working_directory=tmpdir)
     assert not result.returncode and not result.stderr
+    assert tmpdir.join("dials.merge.html").check()
 
     # check the unit cell was correctly set if using best_unit_cell
     m = mtz.object(mtz_file.strpath)
@@ -168,6 +170,7 @@ def test_merge_multi_wavelength(dials_data, tmpdir):
     result = procrunner.run(command, working_directory=tmpdir)
     assert not result.returncode and not result.stderr
     assert tmpdir.join("merged.mtz").check()
+    assert tmpdir.join("dials.merge.html").check()
     m = mtz.object(tmpdir.join("merged.mtz").strpath)
     labels = []
     for ma in m.as_miller_arrays(merge_equivalents=False):


### PR DESCRIPTION
One useful anomalous indicator that other programs report (XSCALE, shelxc) is dano/sigdano, i.e. the mean of the absolute differences over the mean of the difference sigmas: < | F(+) - F(-) | > / < sig(F(+) - F(-)) >. 
The staff at I23 beamline have requested this be added to DIALS as a key indicator of anomalous signal. As it relies on Fs, it seems most sensible to report on this in `dials.merge`, so in `dials.merge` the merging stats now have an extra final column, e.g.
```
            ----------Merging statistics by resolution bin----------           

 d_max  d_min   #obs  #uniq   mult.  %comp       <I>  <I/sI>    r_mrg   r_meas    r_pim   r_anom   cc1/2   cc_ano dF/s(dF)
 69.31   3.29  22601   3392    6.66  98.63     532.6    69.2    0.037    0.040    0.015    0.042   0.999*   0.297*   1.909
  3.29   2.61  22267   3319    6.71  97.53     193.3    47.8    0.050    0.054    0.021    0.060   0.998*   0.338*   1.766
  2.61   2.28  22519   3258    6.91  96.76      99.2    35.7    0.065    0.070    0.027    0.073   0.997*   0.362*   1.456
  2.28   2.07  22169   3243    6.84  95.95      67.5    27.3    0.078    0.085    0.032    0.081   0.996*   0.249*   1.223
  2.07   1.93  21502   3167    6.79  95.19      44.0    20.5    0.099    0.107    0.041    0.101   0.994*   0.204*   1.095
  1.93   1.81  21655   3187    6.79  94.37      25.0    14.1    0.136    0.147    0.056    0.133   0.991*   0.188*   0.966
  1.81   1.72  21246   3151    6.74  93.89      15.6    10.0    0.180    0.195    0.074    0.175   0.986*   0.146*   0.863
  1.72   1.65  20887   3104    6.73  93.07      10.4     7.2    0.232    0.252    0.096    0.220   0.978*   0.148*   0.761
  1.65   1.58  21639   3123    6.93  92.64       8.3     6.1    0.275    0.297    0.112    0.241   0.973*   0.055*   0.702
  1.58   1.53  20674   3082    6.71  92.00       6.3     4.7    0.327    0.354    0.136    0.304   0.955*   0.063*   0.667
  1.53   1.48  20145   3066    6.57  91.58       5.0     3.8    0.382    0.415    0.161    0.348   0.939*   0.021    0.588
  1.48   1.44  20801   3029    6.87  90.74       3.7     3.0    0.473    0.512    0.194    0.416   0.922*   0.055*   0.533
  1.44   1.40  18330   2982    6.15  90.31       3.2     2.5    0.523    0.571    0.227    0.497   0.891*  -0.002    0.494
  1.40   1.37  13881   2480    5.60  72.83       2.7     2.0    0.585    0.646    0.268    0.593   0.811*  -0.001    0.454
  1.37   1.33   9578   1749    5.48  52.71       2.4     1.8    0.638    0.704    0.292    0.650   0.748*  -0.019    0.426
  1.33   1.31   6726   1287    5.23  38.73       2.3     1.6    0.654    0.725    0.305    0.714   0.737*   0.003    0.430
  1.31   1.28   4850   1001    4.85  29.69       2.0     1.3    0.745    0.833    0.362    0.826   0.603*  -0.018    0.373
  1.28   1.26   2923    700    4.18  21.03       1.8     1.1    0.854    0.973    0.452    1.003   0.406*   0.029    0.354
  1.26   1.23   1214    407    2.98  12.37       1.5     0.8    0.895    1.067    0.567    1.156   0.284*  -0.156    0.279
  1.23   1.21    305    191    1.60   5.64       1.6     0.6    0.746    0.987    0.640    1.033   0.489*  -0.357    0.388
 69.19   1.21 315912  48918    6.46  72.87      69.3    17.1    0.064    0.070    0.027    0.070   0.999*   0.358*   0.794
```