### PR TITLE
Determine release branch independent of tags

### DIFF
--- a/newsfragments/1487.misc
+++ b/newsfragments/1487.misc
@@ -1,0 +1,1 @@
+Use git-branch instead of git-describe to derive branch name for versioning

--- a/util/version.py
+++ b/util/version.py
@@ -18,7 +18,7 @@ def get_git_version(dials_path, treat_merges_as_single_commit=False):
         # Obtain name of the current branch. If this fails then the other commands will probably also fail
         branch = (
             subprocess.check_output(
-                ["git", "describe", "--contains", "--all", "HEAD"],
+                ["git", "branch", "--all", "--contains", "HEAD"],
                 cwd=dials_path,
                 stderr=devnull,
             )


### PR DESCRIPTION
This lets us add tags to individual releases.

Adding non-annotated tags to the release branch confused the version checking into thinking that it was on a non-release branch, thus reporting incorrect version numbers. This uses git-branch instead of git-describe so that tags are excluded.