### PR TITLE
Include small integer types from scitbx

### DIFF
--- a/array_family/flex.py
+++ b/array_family/flex.py
@@ -124,6 +124,18 @@ from cctbx.array_family.flex import (  # noqa: F401; lgtm
     xray_scatterer,
 )
 
+# small integer types from scitbx
+from scitbx.array_family.flex import (  # noqa: F401; lgtm
+    int8,
+    int16,
+    int32,
+    int64,
+    uint8,
+    uint16,
+    uint32,
+    uint64,
+)
+
 from dials.array_family.flex_ext import (  # noqa: F401; lgtm
     real,
     reflection_table_selector,

--- a/newsfragments/1488.feature
+++ b/newsfragments/1488.feature
@@ -1,0 +1,2 @@
+Include small integer types from scitbx (see https://github.com/cctbx/cctbx_project/pull/533 for details)
+

--- a/newsfragments/1488.feature
+++ b/newsfragments/1488.feature
@@ -1,2 +1,1 @@
-Include small integer types from scitbx (see https://github.com/cctbx/cctbx_project/pull/533 for details)
-
+Added `support for small integer types <https://github.com/cctbx/cctbx_project/pull/533>`_ to DIALS flex arrays


### PR DESCRIPTION
Not currently published via cctbx.array_family but that does not make a real difference