### PR TITLE
Ensure reproducible ordering of sym_ops in cosym

### DIFF
--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -86,9 +86,7 @@ class Target(object):
 
         self._sym_ops = OrderedSet(["x,y,z"])
         self._lattice_group = lattice_group
-        self._sym_ops.update(
-            OrderedSet(op.as_xyz() for op in self._generate_twin_operators())
-        )
+        self._sym_ops.update(op.as_xyz() for op in self._generate_twin_operators())
         if dimensions is None:
             dimensions = max(2, len(self._sym_ops))
         self.set_dimensions(dimensions)

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -86,7 +86,9 @@ class Target(object):
 
         self._sym_ops = OrderedSet(["x,y,z"])
         self._lattice_group = lattice_group
-        self._sym_ops.update({op.as_xyz() for op in self._generate_twin_operators()})
+        self._sym_ops.update(
+            OrderedSet(op.as_xyz() for op in self._generate_twin_operators())
+        )
         if dimensions is None:
             dimensions = max(2, len(self._sym_ops))
         self.set_dimensions(dimensions)

--- a/newsfragments/1490.bugfix
+++ b/newsfragments/1490.bugfix
@@ -1,0 +1,1 @@
+Ensure that dials.cosym is deterministic.

--- a/newsfragments/1490.bugfix
+++ b/newsfragments/1490.bugfix
@@ -1,1 +1,1 @@
-Ensure that dials.cosym is deterministic.
+``dials.cosym``: Fix non-determinism. Repeat runs will now give identical results.


### PR DESCRIPTION
Non-deterministic ordering of the sym_ops meant that the rij_matrix
could contain the same values, but in a different order. This can
lead to significant differences in the calculated functional, gradients
and curvatures, ultimately causing cosym to be non-deterministic,
despite setting random seeds.