### PR TITLE
Minor change to filtering in scaling error model

### DIFF
--- a/newsfragments/1491.misc
+++ b/newsfragments/1491.misc
@@ -1,0 +1,1 @@
+dials.scale: adjustment to filtering for error modelling code.


### PR DESCRIPTION
Don't need to filter large deviations any more, as outliers are preremoved after 62b0ec3ecdbc7cb551ad3e813c58ec1ff27261aa

The effect of the filter was that it could occasionally remove too much data if a large error model correction is needed for the dataset.