### PR TITLE
Use only cc_half by default in resolution analysis

### DIFF
--- a/newsfragments/1492.feature
+++ b/newsfragments/1492.feature
@@ -1,1 +1,1 @@
-dials.estimate_resolution: use only cc_half by default in resolution analysis
+dials.estimate_resolution: change default to only use cc_half in resolution analysis

--- a/newsfragments/1492.feature
+++ b/newsfragments/1492.feature
@@ -1,0 +1,1 @@
+dials.estimate_resolution: use only cc_half by default in resolution analysis

--- a/test/command_line/test_estimate_resolution.py
+++ b/test/command_line/test_estimate_resolution.py
@@ -72,11 +72,7 @@ def test_multi_sequence_with_batch_range(dials_data, run_in_tmpdir, capsys):
     )
     captured = capsys.readouterr()
 
-    expected_output = (
-        "Resolution cc_half:       0.61",
-        "Resolution I/sig:         0.59",
-        "Resolution Mn(I/sig):     0.59",
-    )
+    expected_output = "Resolution cc_half:       0.61"
     for line in expected_output:
         assert line in captured.out
     assert run_in_tmpdir.join("dials.estimate_resolution.html").check(file=1)

--- a/util/resolution_analysis.py
+++ b/util/resolution_analysis.py
@@ -349,12 +349,12 @@ phil_str = """
   cc_half_fit = polynomial *tanh
     .type = choice
     .expert_level = 1
-  isigma = 0.25
+  isigma = None
     .type = float(value_min=0)
     .help = "Minimum value of the unmerged <I/sigI> in the outer resolution shell"
     .short_caption = "Outer shell unmerged <I/sigI>"
     .expert_level = 1
-  misigma = 1.0
+  misigma = None
     .type = float(value_min=0)
     .help = "Minimum value of the merged <I/sigI> in the outer resolution shell"
     .short_caption = "Outer shell merged <I/sigI>"


### PR DESCRIPTION
CC1/2 is now accepted as the most appropriate for estimating the resolution
cutoff (other than paired refinement). I/sigI-based cutoffs can be unreliable
due to dependence of the sigmas on error modelling in integration/scaling.
This is now consistent with xia2 default behaviour.

See also xia2/xia2#374