### PR TITLE
dials.estimate_resolution: improved error handling

### DIFF
--- a/command_line/estimate_resolution.py
+++ b/command_line/estimate_resolution.py
@@ -86,6 +86,10 @@ def run(args=None):
         )
     else:
         reflections = parse_multiple_datasets(reflections)
+        if len(experiments) != len(reflections):
+            sys.exit(
+                f"Mismatched number of experiments and reflection tables found: {len(experiments)} & {len(reflections)}."
+            )
         m = resolution_analysis.Resolutionizer.from_reflections_and_experiments(
             reflections, experiments, params.resolution
         )

--- a/newsfragments/1494.bugfix
+++ b/newsfragments/1494.bugfix
@@ -1,1 +1,1 @@
-dials.estimate_resolution: improved error handling
+``dials.estimate_resolution``: Handle very low multiplicity datasets without crashing, and better error handling

--- a/newsfragments/1494.bugfix
+++ b/newsfragments/1494.bugfix
@@ -1,0 +1,1 @@
+dials.estimate_resolution: improved error handling

--- a/test/command_line/test_estimate_resolution.py
+++ b/test/command_line/test_estimate_resolution.py
@@ -96,3 +96,23 @@ def test_dispatcher_name():
     result = procrunner.run(["dials.estimate_resolution"])
     assert not result.returncode
     assert not result.stderr
+
+
+def test_handle_fit_failure(dials_data, run_in_tmpdir, capsys):
+    location = dials_data("l_cysteine_dials_output")
+    filenames = [
+        location.join("11_integrated.expt"),
+        location.join("11_integrated.refl"),
+        location.join("23_integrated.expt"),
+        location.join("23_integrated.refl"),
+    ]
+    cmdline.run(["misigma=1"] + [f.strpath for f in filenames])
+    captured = capsys.readouterr()
+
+    expected_output = (
+        "Resolution fit against cc_half failed: No reflections left for fitting",
+        "Resolution Mn(I/sig):     0.62",
+    )
+    for line in expected_output:
+        assert line in captured.out
+    assert run_in_tmpdir.join("dials.estimate_resolution.html").check(file=1)

--- a/test/command_line/test_estimate_resolution.py
+++ b/test/command_line/test_estimate_resolution.py
@@ -116,3 +116,14 @@ def test_handle_fit_failure(dials_data, run_in_tmpdir, capsys):
     for line in expected_output:
         assert line in captured.out
     assert run_in_tmpdir.join("dials.estimate_resolution.html").check(file=1)
+
+
+def test_mismatched_experiments_reflections(dials_data, run_in_tmpdir):
+    location = dials_data("l_cysteine_dials_output")
+    filenames = [
+        location.join("11_integrated.expt"),
+        location.join("11_integrated.refl"),
+        location.join("23_integrated.refl"),
+    ]
+    with pytest.raises(SystemExit):
+        cmdline.run([f.strpath for f in filenames])

--- a/util/resolution_analysis.py
+++ b/util/resolution_analysis.py
@@ -632,7 +632,11 @@ class Resolutionizer(object):
             if metric == metrics.CC_REF and not self._reference:
                 limit = None
             if limit:
-                result = self.resolution(metric, limit=limit)
+                try:
+                    result = self.resolution(metric, limit=limit)
+                except RuntimeError as e:
+                    logger.info(f"Resolution fit against {name} failed: {e}")
+                    continue
                 pretty_name = metric_to_output.get(metric, name)
                 if result.d_min:
                     logger.info(


### PR DESCRIPTION
* Handle resolution fit failure as [highlighted](https://github.com/dials/dials/pull/1492#pullrequestreview-528998821) by @jbeilstenedmands 
* Handle mismatched number of expt/refl tables