### PR TITLE
Handle experiment identifiers for dials.slice_sequence block_size=x

### DIFF
--- a/command_line/slice_sequence.py
+++ b/command_line/slice_sequence.py
@@ -167,7 +167,7 @@ class Script(object):
 
             if len(experiments) > 1:
                 raise Sorry(
-                    "For slicing into blocks please provide a single " "scan only"
+                    "For slicing into blocks please provide a single scan only"
                 )
             scan = experiments[0].scan
 
@@ -178,10 +178,8 @@ class Script(object):
             sliced = [
                 slice_experiments(experiments, [sr])[0] for sr in params.image_range
             ]
-            sliced_experiments = ExperimentList()
             generate_experiment_identifiers(sliced)
-            for exp in sliced:
-                sliced_experiments.append(exp)
+            sliced_experiments = ExperimentList(sliced)
 
             # slice reflections if present
             if slice_refs:

--- a/command_line/slice_sequence.py
+++ b/command_line/slice_sequence.py
@@ -6,7 +6,9 @@ from dxtbx.model.experiment_list import ExperimentList
 
 import dials.util
 from dials.algorithms.refinement.refinement_helpers import calculate_frame_numbers
+from dials.array_family import flex
 from dials.util import Sorry
+from dials.util.multi_dataset_handling import generate_experiment_identifiers
 from dials.util.slice import slice_experiments, slice_reflections
 
 help_message = """
@@ -158,33 +160,42 @@ class Script(object):
 
         # check if slicing into blocks
         if params.block_size is not None:
-            if slice_exps:
-                if len(experiments) > 1:
-                    raise Sorry(
-                        "For slicing into blocks please provide a single " "scan only"
-                    )
-                scan = experiments[0].scan
+            if not slice_exps:
+                raise Sorry(
+                    "For slicing into blocks, an experiment file must be provided"
+                )
+
+            if len(experiments) > 1:
+                raise Sorry(
+                    "For slicing into blocks please provide a single " "scan only"
+                )
+            scan = experiments[0].scan
 
             # Having extracted the scan, calculate the blocks
             params.image_range = calculate_block_ranges(scan, params.block_size)
 
             # Do the slicing then recombine
-            if slice_exps:
-                sliced = [
-                    slice_experiments(experiments, [sr])[0] for sr in params.image_range
-                ]
-                sliced_experiments = ExperimentList()
-                for exp in sliced:
-                    sliced_experiments.append(exp)
+            sliced = [
+                slice_experiments(experiments, [sr])[0] for sr in params.image_range
+            ]
+            sliced_experiments = ExperimentList()
+            generate_experiment_identifiers(sliced)
+            for exp in sliced:
+                sliced_experiments.append(exp)
 
             # slice reflections if present
             if slice_refs:
                 sliced = [
                     slice_reflections(reflections, [sr]) for sr in params.image_range
                 ]
-                sliced_reflections = sliced[0]
-                for i, rt in enumerate(sliced[1:]):
-                    rt["id"] += i + 1  # set id
+                sliced_reflections = flex.reflection_table()
+                identifiers = sliced_experiments.identifiers()
+                for i, rt in enumerate(sliced[0:]):
+                    if rt.experiment_identifiers():
+                        for k in rt.experiment_identifiers().keys():
+                            del rt.experiment_identifiers()[k]
+                    rt["id"] = flex.int(rt.size(), i)  # set id
+                    rt.experiment_identifiers()[i] = identifiers[i]
                     sliced_reflections.extend(rt)
 
         else:

--- a/command_line/slice_sequence.py
+++ b/command_line/slice_sequence.py
@@ -166,9 +166,7 @@ class Script(object):
                 )
 
             if len(experiments) > 1:
-                raise Sorry(
-                    "For slicing into blocks please provide a single scan only"
-                )
+                raise Sorry("For slicing into blocks please provide a single scan only")
             scan = experiments[0].scan
 
             # Having extracted the scan, calculate the blocks
@@ -188,10 +186,10 @@ class Script(object):
                 ]
                 sliced_reflections = flex.reflection_table()
                 identifiers = sliced_experiments.identifiers()
-                for i, rt in enumerate(sliced[0:]):
-                    if rt.experiment_identifiers():
-                        for k in rt.experiment_identifiers().keys():
-                            del rt.experiment_identifiers()[k]
+                # resetting experiment identifiers
+                for i, rt in enumerate(sliced):
+                    for k in rt.experiment_identifiers().keys():
+                        del rt.experiment_identifiers()[k]
                     rt["id"] = flex.int(rt.size(), i)  # set id
                     rt.experiment_identifiers()[i] = identifiers[i]
                     sliced_reflections.extend(rt)

--- a/test/command_line/test_slice_sequence.py
+++ b/test/command_line/test_slice_sequence.py
@@ -85,7 +85,6 @@ def test_slice_sequence_to_degree_blocks(dials_data, tmpdir):
     sliced_expts = load.experiment_list(
         tmpdir.join("sliced.expt").strpath, check_format=False
     )
-    print(list(sliced_expts.identifiers()))
     assert len(sliced_expts) == 17
     sliced_refl = flex.reflection_table.from_file(tmpdir.join("sliced.refl").strpath)
     assert len(set(sliced_refl.experiment_identifiers().values())) == 17


### PR DESCRIPTION
I found that trying to slice a dataset using the block_size option failed, due to non-handling of experiment identifiers, so the behaviour is fixed and a test added (this section of the code was untested).

```
DIAMRM5030:mpges whi10850$ dials.slice_sequence 7_refined.* block_size=10
The following parameters have been modified:

block_size = 10
input {
  experiments = 7_refined.expt
  reflections = 7_refined.refl
}

Traceback (most recent call last):
  File "/dials/build/../modules/dials/command_line/slice_sequence.py", line 245, in <module>
    run()
  File "/dials/build/../conda_base/python.app/Contents/lib/python3.6/contextlib.py", line 52, in inner
    return func(*args, **kwds)
  File "/dials/build/../modules/dials/command_line/slice_sequence.py", line 241, in run
    script.run(args)
  File "/dials/build/../modules/dials/command_line/slice_sequence.py", line 178, in run
    sliced_experiments.append(exp)
RuntimeError: Please report this error to dials-support@lists.sourceforge.net: dxtbx Internal Error: /dials/modules/dxtbx/model/experiment_list.h(190): DXTBX_ASSERT(index < 0) failure.
```