### PR TITLE
Fix broken exclude_images= option in dials.scale

### DIFF
--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -102,6 +102,10 @@ def prepare_input(params, experiments, reflections):
     )
     logger.info("\nDataset ids are: %s \n", ",".join(str(i) for i in ids))
 
+    for r in reflections:
+        r.unset_flags(flex.bool(len(r), True), r.flags.bad_for_scaling)
+        r.unset_flags(flex.bool(r.size(), True), r.flags.scaled)
+
     reflections, experiments = exclude_image_ranges_for_scaling(
         reflections, experiments, params.exclude_images
     )
@@ -151,10 +155,6 @@ def prepare_input(params, experiments, reflections):
         )
         experiments.append(exp)
         reflections.append(reflection_table)
-
-    for r in reflections:
-        r.unset_flags(flex.bool(len(r), True), r.flags.bad_for_scaling)
-        r.unset_flags(flex.bool(r.size(), True), r.flags.scaled)
 
     #### Perform any non-batch cutting of the datasets, including the target dataset
     best_unit_cell = params.reflection_selection.best_unit_cell

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -714,6 +714,18 @@ def test_multi_scale_exclude_images(dials_data, tmpdir):
 
     run_one_scaling(tmpdir, [refl_1, refl_2, expt_1, expt_2] + extra_args)
 
+    refls = flex.reflection_table.from_file(tmpdir.join("scaled.refl").strpath)
+    d1 = refls.select(refls["id"] == 0)
+    d2 = refls.select(refls["id"] == 1)
+    nd1_scaled = d1.get_flags(d1.flags.scaled).count(True)
+    # full sweep would have 2312, expect ~2060
+    assert nd1_scaled < 2100
+    assert nd1_scaled > 2000
+    nd2_scaled = d2.get_flags(d2.flags.scaled).count(True)
+    # full sweep would have 3210
+    assert nd2_scaled < 2900
+    assert nd2_scaled > 2800
+
     scaling_models = load.experiment_list(
         tmpdir.join("scaled.expt").strpath, check_format=False
     ).scaling_models()
@@ -737,6 +749,18 @@ def test_multi_scale_exclude_images(dials_data, tmpdir):
     assert scaling_models[1].configdict["valid_image_range"] == [1, 1500]
     assert pytest.approx(scaling_models[0].configdict["valid_osc_range"], [0, 140.0])
     assert pytest.approx(scaling_models[1].configdict["valid_osc_range"], [-145.0, 5.0])
+
+    refls = flex.reflection_table.from_file(tmpdir.join("scaled.refl").strpath)
+    d1 = refls.select(refls["id"] == 0)
+    d2 = refls.select(refls["id"] == 1)
+    nd1_scaled = d1.get_flags(d1.flags.scaled).count(True)
+    # full sweep would have 2312, expect 1800
+    assert nd1_scaled < 1850
+    assert nd1_scaled > 1750
+    nd2_scaled = d2.get_flags(d2.flags.scaled).count(True)
+    # full sweep would have 3210, expect ~2850
+    assert nd2_scaled < 2900
+    assert nd2_scaled > 2800
 
 
 def test_targeted_scaling(dials_data, tmpdir):

--- a/newsfragments/1509.bugfix
+++ b/newsfragments/1509.bugfix
@@ -1,0 +1,1 @@
+dials.scale: fix non-functioning of exclude_images option in dials 3.2 series


### PR DESCRIPTION
Processing user data in the ccp4 workshop today revealed that this is currently broken, likely due to some recent changes to scaling flags, which effective resets the flags right after setting them for exclude_images....

So this change resets the flags as the very first thing. Tests also updated to explicitly check the number of scaled reflections coming out after excluding which would have caught this. 