### PR TITLE
Cosym: choose cluster containing the most identity reindexing ops

### DIFF
--- a/algorithms/symmetry/cosym/__init__.py
+++ b/algorithms/symmetry/cosym/__init__.py
@@ -175,10 +175,12 @@ class CosymAnalysis(symmetry_base, Subject):
                 sg_best = sg_primitive.change_basis(cb_op_best_primitive.inverse())
                 # best_subgroup above is the bravais type, so create thin copy here with the
                 # user-input space group instead
+                best_subsym = best_subsym.customized_copy(
+                    space_group_info=sg_best.info()
+                )
                 best_subgroup = {
-                    "best_subsym": best_subsym.customized_copy(
-                        space_group_info=sg_best.info()
-                    ),
+                    "subsym": best_subsym.change_basis(cb_op_inp_best.inverse()),
+                    "best_subsym": best_subsym,
                     "cb_op_inp_best": cb_op_inp_best,
                 }
 
@@ -297,7 +299,7 @@ class CosymAnalysis(symmetry_base, Subject):
     def _optimise(self, termination_params):
         NN = len(self.input_intensities)
         dim = self.target.dim
-        n_sym_ops = len(self.target.get_sym_ops())
+        n_sym_ops = len(self.target.sym_ops)
         coords = flex.random_double(NN * n_sym_ops * dim)
 
         import scitbx.lbfgs
@@ -357,9 +359,7 @@ class CosymAnalysis(symmetry_base, Subject):
             self._symmetry_analysis = None
             return
 
-        sym_ops = [
-            sgtbx.rt_mx(s).new_denominators(1, 12) for s in self.target.get_sym_ops()
-        ]
+        sym_ops = [sgtbx.rt_mx(s).new_denominators(1, 12) for s in self.target.sym_ops]
         self._symmetry_analysis = SymmetryAnalysis(
             self.coords, sym_ops, self.subgroups, self.cb_op_inp_min
         )
@@ -372,52 +372,46 @@ class CosymAnalysis(symmetry_base, Subject):
         )
         self.params.cluster.n_clusters = len(cosets.partitions)
 
-    def _space_group_for_dataset(self, dataset_id, sym_ops):
-        if self.input_space_group is not None:
-            sg = copy.deepcopy(self.input_space_group)
-        else:
-            sg = sgtbx.space_group()
-        ref_sym_op_id = None
-        ref_cluster_id = None
-        for sym_op_id in range(len(sym_ops)):
-            i_cluster = self.cluster_labels[
-                len(self.input_intensities) * sym_op_id + dataset_id
-            ]
-            if i_cluster < 0:
-                continue
-            if ref_sym_op_id is None:
-                ref_sym_op_id = sym_op_id
-                ref_cluster_id = i_cluster
-                continue
-            op = sym_ops[ref_sym_op_id].inverse().multiply(sym_ops[sym_op_id])
-            if i_cluster == ref_cluster_id:
-                sg.expand_smx(op.new_denominators(1, 12))
-        return sg.make_tidy()
-
     def _reindexing_ops_for_dataset(self, dataset_id, sym_ops, cosets):
-        reindexing_ops = {}
-        # Number of clusters in labels, ignoring noise if present.
-        n_clusters = len(set(self.cluster_labels)) - (
-            1 if -1 in self.cluster_labels else 0
-        )
+        """Identify the reindexing operator for each symmetry copy of the given dataset.
 
-        for i_cluster in range(n_clusters):
-            isel = (self.cluster_labels == i_cluster).iselection()
-            dataset_ids = isel % len(self.input_intensities)
-            sel = (dataset_ids == dataset_id).iselection()
-            for s in sel:
-                sym_op_id = isel[s] // len(self.input_intensities)
+        Args:
+            dataset_id (int): The index into the input list of datasets defining the
+                dataset for which to identify reindexing ops
+            sym_ops (list): List of cctbx.sgtbx.rt_mx used for the cosym symmetry
+                analysis
+            cosets (sgtbx.cosets.left_decomposition): Coset left decomposition of the
+                space group determined by the cosym analysis with respect to the lattice
+                group symmetry
+
+        Returns:
+            dict: The dictionary of reindexing operators for each copy of the dataset,
+                dataset_id. The keys are the id of the cluster containing that copy of
+                the dataset.
+        """
+        reindexing_ops = {}
+        for i_cluster in range(self.params.cluster.n_clusters):
+            # Select all points within this cluster
+            cluster_isel = (self.cluster_labels == i_cluster).iselection()
+            # dataset_ids of each points within this cluster
+            dataset_ids = cluster_isel % len(self.input_intensities)
+            # Index into cluster_isel for points corresponding to the requested dataset_id
+            dataset_isel = (dataset_ids == dataset_id).iselection()
+            for i in dataset_isel:
+                if i_cluster in reindexing_ops:
+                    # Finished with this cluster so exit loop early
+                    break
+                # sym_op for this copy of the dataset
+                sym_op = sym_ops[cluster_isel[i] // len(self.input_intensities)]
                 for partition in cosets.partitions:
-                    if sym_ops[sym_op_id] in partition:
-                        if i_cluster not in reindexing_ops:
-                            cb_op = sgtbx.change_of_basis_op(
-                                partition[0]
-                            ).new_denominators(self.cb_op_inp_min)
-                            reindexing_ops[i_cluster] = (
-                                self.cb_op_inp_min.inverse()
-                                * cb_op
-                                * self.cb_op_inp_min
-                            ).as_xyz()
+                    if sym_op in partition:
+                        cb_op = sgtbx.change_of_basis_op(partition[0]).new_denominators(
+                            self.cb_op_inp_min
+                        )
+                        reindexing_ops[i_cluster] = (
+                            self.cb_op_inp_min.inverse() * cb_op * self.cb_op_inp_min
+                        ).as_xyz()
+                        break
 
         return reindexing_ops
 
@@ -428,28 +422,22 @@ class CosymAnalysis(symmetry_base, Subject):
             self.cluster_labels = flex.double(self.coords.all()[0])
         else:
             self.cluster_labels = self._do_clustering(self.params.cluster.method)
+            # Number of clusters in labels, ignoring noise if present.
+            self.params.cluster.n_clusters = len(set(self.cluster_labels) - {-1})
 
-        sym_ops = [
-            sgtbx.rt_mx(s).new_denominators(1, 12) for s in self.target.get_sym_ops()
-        ]
+        sym_ops = [sgtbx.rt_mx(s).new_denominators(1, 12) for s in self.target.sym_ops]
 
         reindexing_ops = {}
-        space_groups = {}
+
+        cosets = sgtbx.cosets.left_decomposition(
+            self.target._lattice_group,
+            self.best_subgroup["subsym"].space_group().build_derived_acentric_group(),
+        )
 
         for dataset_id in range(len(self.input_intensities)):
-            space_groups[dataset_id] = self._space_group_for_dataset(
-                dataset_id, sym_ops
-            )
-
-            cosets = sgtbx.cosets.left_decomposition(
-                self.target._lattice_group, space_groups[dataset_id]
-            )
-
             reindexing_ops[dataset_id] = self._reindexing_ops_for_dataset(
                 dataset_id, sym_ops, cosets
             )
-
-        self.space_groups = space_groups
         self.reindexing_ops = reindexing_ops
 
     def _do_clustering(self, method):
@@ -521,7 +509,7 @@ class CosymAnalysis(symmetry_base, Subject):
         clustering = seed_clustering(
             self.coords,
             len(self.input_intensities),
-            len(self.target.get_sym_ops()),
+            len(self.target.sym_ops),
             min_silhouette_score=self.params.cluster.seed.min_silhouette_score,
             n_clusters=self.params.cluster.n_clusters,
         )

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 import copy
 import logging
 import math
+import warnings
 
 from orderedset import OrderedSet
 from scipy import sparse
@@ -84,15 +85,15 @@ class Target(object):
                 last_id = lid
                 self._lattices.append(n)
 
-        self._sym_ops = OrderedSet(["x,y,z"])
+        self.sym_ops = OrderedSet(["x,y,z"])
         self._lattice_group = lattice_group
-        self._sym_ops.update(op.as_xyz() for op in self._generate_twin_operators())
+        self.sym_ops.update(op.as_xyz() for op in self._generate_twin_operators())
         if dimensions is None:
-            dimensions = max(2, len(self._sym_ops))
+            dimensions = max(2, len(self.sym_ops))
         self.set_dimensions(dimensions)
 
         self._lattice_group = copy.deepcopy(self._data.space_group())
-        for sym_op in self._sym_ops:
+        for sym_op in self.sym_ops:
             self._lattice_group.expand_smx(sym_op)
         self._patterson_group = self._lattice_group.build_derived_patterson_group()
 
@@ -157,7 +158,7 @@ class Target(object):
     def _compute_rij_wij(self, use_cache=True):
         """Compute the rij_wij matrix."""
         n_lattices = self._lattices.size()
-        n_sym_ops = len(self._sym_ops)
+        n_sym_ops = len(self.sym_ops)
 
         NN = n_lattices * n_sym_ops
 
@@ -169,7 +170,7 @@ class Target(object):
 
         indices = {}
         space_group_type = self._data.space_group().type()
-        for cb_op in self._sym_ops:
+        for cb_op in self.sym_ops:
             cb_op = sgtbx.change_of_basis_op(cb_op)
             indices_reindexed = cb_op.apply(self._data.indices())
             miller.map_to_asu(space_group_type, False, indices_reindexed)
@@ -178,7 +179,7 @@ class Target(object):
         def _compute_rij_matrix_one_row_block(i):
             rij_cache = {}
 
-            n_sym_ops = len(self._sym_ops)
+            n_sym_ops = len(self.sym_ops)
             NN = n_lattices * n_sym_ops
 
             rij_row = []
@@ -199,12 +200,12 @@ class Target(object):
                 j_lower, j_upper = self._lattice_lower_upper_index(j)
                 intensities_j = self._data.data()[j_lower:j_upper]
 
-                for k, cb_op_k in enumerate(self._sym_ops):
+                for k, cb_op_k in enumerate(self.sym_ops):
                     cb_op_k = sgtbx.change_of_basis_op(cb_op_k)
 
                     indices_i = indices[cb_op_k.as_xyz()][i_lower:i_upper]
 
-                    for kk, cb_op_kk in enumerate(self._sym_ops):
+                    for kk, cb_op_kk in enumerate(self.sym_ops):
                         if i == j and k == kk:
                             # don't include correlation of dataset with itself
                             continue
@@ -316,7 +317,7 @@ class Target(object):
         Returns:
           f (float): The value of the target function at coordinates `x`.
         """
-        assert (x.size() // self.dim) == (self._lattices.size() * len(self._sym_ops))
+        assert (x.size() // self.dim) == (self._lattices.size() * len(self.sym_ops))
         inner = self.rij_matrix.deep_copy()
         NN = x.size() // self.dim
         for i in range(self.dim):
@@ -460,4 +461,8 @@ class Target(object):
         Returns:
           List[cctbx.sgtbx.rt_mx]: The list of symmetry operations.
         """
-        return self._sym_ops
+        warnings.warn(
+            "get_sym_ops() is deprecated, use sym_ops property instead",
+            DeprecationWarning,
+        )
+        return self.sym_ops

--- a/algorithms/symmetry/cosym/test_cosym_analyse_datasets.py
+++ b/algorithms/symmetry/cosym/test_cosym_analyse_datasets.py
@@ -4,6 +4,7 @@ import pytest
 
 import libtbx
 from cctbx import sgtbx
+from scitbx.array_family import flex
 
 from dials.algorithms.symmetry.cosym import CosymAnalysis, phil_scope
 from dials.algorithms.symmetry.cosym._generate_test_data import generate_test_data
@@ -111,20 +112,14 @@ def test_cosym(
             .build_derived_patterson_group()
         )
 
-    space_groups = {}
     reindexing_ops = {}
     for dataset_id in cosym.reindexing_ops.keys():
         if 0 in cosym.reindexing_ops[dataset_id]:
             cb_op = cosym.reindexing_ops[dataset_id][0]
             reindexing_ops.setdefault(cb_op, set())
             reindexing_ops[cb_op].add(dataset_id)
-        if dataset_id in cosym.space_groups:
-            space_groups.setdefault(cosym.space_groups[dataset_id], set())
-            space_groups[cosym.space_groups[dataset_id]].add(dataset_id)
 
     assert len(reindexing_ops) == len(expected_reindexing_ops)
-    assert len(space_groups) == 1
-    space_group_info = list(space_groups)[0].info()
 
     if use_known_space_group:
         expected_sg = sgtbx.space_group_info(space_group).group()
@@ -134,6 +129,7 @@ def test_cosym(
         )
     assert cosym.best_subgroup["best_subsym"].space_group() == expected_sg
 
+    space_group_info = cosym.best_subgroup["subsym"].space_group_info()
     for cb_op, ridx_set in reindexing_ops.items():
         for expected_set in expected_reindexing_ops.values():
             assert (len(ridx_set.symmetric_difference(expected_set)) == 0) or (
@@ -152,3 +148,23 @@ def test_cosym(
             assert reindexed.is_compatible_unit_cell(), str(
                 reindexed.crystal_symmetry()
             )
+
+
+def test_reindexing_ops_for_dataset(mocker):
+    # Mock a minimal CosymAnalysis instance
+    self = mocker.Mock()
+    self.cluster_labels = flex.double([1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0])
+    self.params.cluster.n_clusters = 2
+    self.input_intensities = [mocker.Mock(), mocker.Mock()]
+    self.cb_op_inp_min = sgtbx.change_of_basis_op()
+
+    # Lattice symmetry and true space group
+    lattice_group = sgtbx.space_group_info(symbol="C 2 2 2 (x+y,z,-2*y)").group()
+    sg = sgtbx.space_group_info(symbol="P 1 2 1").group()
+    cosets = sgtbx.cosets.left_decomposition(lattice_group, sg)
+
+    # Finally run the method we're testing
+    reindexing_ops = CosymAnalysis._reindexing_ops_for_dataset(
+        self, 0, list(lattice_group.smx()), cosets
+    )
+    assert reindexing_ops == {0: "x+z,-y,-z", 1: "x,y,z"}

--- a/algorithms/symmetry/cosym/test_cosym_target.py
+++ b/algorithms/symmetry/cosym/test_cosym_target.py
@@ -24,7 +24,7 @@ def test_cosym_target(space_group):
     for weights in [None, "count", "standard_error"]:
         print(weights)
         t = target.Target(intensities, dataset_ids, weights=weights)
-        m = len(t.get_sym_ops())
+        m = len(t.sym_ops)
         n = len(datasets)
         assert t.dim == m
         assert t.rij_matrix.all() == (n * m, n * m)

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -176,25 +176,12 @@ class cosym(Subject):
     def run(self):
         self.cosym_analysis.run()
 
-        space_groups = {}
         reindexing_ops = {}
         for dataset_id in self.cosym_analysis.reindexing_ops:
             if 0 in self.cosym_analysis.reindexing_ops[dataset_id]:
                 cb_op = self.cosym_analysis.reindexing_ops[dataset_id][0]
                 reindexing_ops.setdefault(cb_op, [])
                 reindexing_ops[cb_op].append(dataset_id)
-            if dataset_id in self.cosym_analysis.space_groups:
-                space_groups.setdefault(
-                    self.cosym_analysis.space_groups[dataset_id], []
-                )
-                space_groups[self.cosym_analysis.space_groups[dataset_id]].append(
-                    dataset_id
-                )
-
-        logger.info("Space groups:")
-        for sg, datasets in space_groups.items():
-            logger.info(str(sg.info().reference_setting()))
-            logger.info(datasets)
 
         logger.info("Reindexing operators:")
         for cb_op, datasets in reindexing_ops.items():

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import collections
 import logging
 import random
 import sys
@@ -177,9 +178,17 @@ class cosym(Subject):
         self.cosym_analysis.run()
 
         reindexing_ops = {}
+        sym_op_counts = {
+            cluster_id: collections.Counter(
+                ops[cluster_id] for ops in self.cosym_analysis.reindexing_ops.values()
+            )
+            for cluster_id in range(self.params.cluster.n_clusters)
+        }
+        identity_counts = [counts["x,y,z"] for counts in sym_op_counts.values()]
+        cluster_id = identity_counts.index(max(identity_counts))
         for dataset_id in self.cosym_analysis.reindexing_ops:
-            if 0 in self.cosym_analysis.reindexing_ops[dataset_id]:
-                cb_op = self.cosym_analysis.reindexing_ops[dataset_id][0]
+            if cluster_id in self.cosym_analysis.reindexing_ops[dataset_id]:
+                cb_op = self.cosym_analysis.reindexing_ops[dataset_id][cluster_id]
                 reindexing_ops.setdefault(cb_op, [])
                 reindexing_ops[cb_op].append(dataset_id)
 

--- a/newsfragments/1514.bugfix
+++ b/newsfragments/1514.bugfix
@@ -1,0 +1,1 @@
+dials.cosym: by default choose cluster containing the most identity reindexing ops. Under some circumstances, particularly in the case of approximate pseudosymmetry, the previous behaviour could result in reindexing operators being chosen that weren't genuine indexing ambiguities, instead distorting the input unit cells.

--- a/newsfragments/1514.misc
+++ b/newsfragments/1514.misc
@@ -1,0 +1,2 @@
+Cosym: deprecate target.get_sym_ops(), use target.sym_ops instead
+Remove CosymAnalysis.space_groups - this has been superceded by the pointless-style symmetry analysis

--- a/test/command_line/test_cosym.py
+++ b/test/command_line/test_cosym.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-import procrunner
 import pytest
 
 from cctbx import sgtbx, uctbx
@@ -12,23 +11,20 @@ from dials.algorithms.symmetry.cosym._generate_test_data import (
     generate_experiments_reflections,
 )
 from dials.array_family import flex
+from dials.util import Sorry
 
 
 @pytest.mark.parametrize("space_group", [None, "P 1", "P 4"])
-def test_cosym(dials_data, tmpdir, space_group):
+def test_cosym(dials_data, run_in_tmpdir, space_group):
     mcp = dials_data("multi_crystal_proteinase_k")
-    command = ["dials.cosym", "space_group=" + str(space_group)]
+    args = ["space_group=" + str(space_group)]
     for i in [1, 2, 3, 4, 5, 7, 8, 10]:
-        command.append(mcp.join("experiments_%d.json" % i).strpath)
-        command.append(mcp.join("reflections_%d.pickle" % i).strpath)
-
-    result = procrunner.run(command, working_directory=tmpdir.strpath)
-    assert not result.returncode and not result.stderr
-    assert tmpdir.join("symmetrized.refl").check(file=1)
-    assert tmpdir.join("symmetrized.expt").check(file=1)
-    experiments = load.experiment_list(
-        tmpdir.join("symmetrized.expt").strpath, check_format=False
-    )
+        args.append(mcp.join("experiments_%d.json" % i).strpath)
+        args.append(mcp.join("reflections_%d.pickle" % i).strpath)
+    dials_cosym.run(args=args)
+    assert os.path.isfile("symmetrized.refl")
+    assert os.path.isfile("symmetrized.expt")
+    experiments = load.experiment_list("symmetrized.expt", check_format=False)
     if space_group is None:
         assert (
             experiments[0].crystal.get_space_group().type().lookup_symbol() == "P 4 2 2"
@@ -40,48 +36,42 @@ def test_cosym(dials_data, tmpdir, space_group):
         )
 
 
-def test_cosym_partial_dataset(dials_data, tmpdir):
+def test_cosym_partial_dataset(dials_data, run_in_tmpdir):
     """Test how cosym handles partial/bad datasets."""
     mcp = dials_data("multi_crystal_proteinase_k")
-    command = ["dials.cosym"]
+    args = []
     for i in [1, 2]:
-        command.append(mcp.join("experiments_%d.json" % i).strpath)
-        command.append(mcp.join("reflections_%d.pickle" % i).strpath)
+        args.append(mcp.join("experiments_%d.json" % i).strpath)
+        args.append(mcp.join("reflections_%d.pickle" % i).strpath)
     # Make one dataset that will be removed in prefiltering
     r = flex.reflection_table.from_file(mcp.join("reflections_8.pickle").strpath)
     r["partiality"] = flex.double(r.size(), 0.1)
-    r.as_file(tmpdir.join("renamed.refl").strpath)
-    command.append(tmpdir.join("renamed.refl").strpath)
-    command.append(mcp.join("experiments_8.json").strpath)
+    r.as_file("renamed.refl")
+    args.append("renamed.refl")
+    args.append(mcp.join("experiments_8.json").strpath)
     # Add another good dataset at the end of the input list
-    command.append(mcp.join("experiments_10.json").strpath)
-    command.append(mcp.join("reflections_10.pickle").strpath)
+    args.append(mcp.join("experiments_10.json").strpath)
+    args.append(mcp.join("reflections_10.pickle").strpath)
 
-    result = procrunner.run(command, working_directory=tmpdir.strpath)
-    assert not result.returncode and not result.stderr
-    assert tmpdir.join("symmetrized.refl").check(file=1)
-    assert tmpdir.join("symmetrized.expt").check(file=1)
-    experiments = load.experiment_list(
-        tmpdir.join("symmetrized.expt").strpath, check_format=False
-    )
+    dials_cosym.run(args=args)
+    assert os.path.exists("symmetrized.refl")
+    assert os.path.exists("symmetrized.expt")
+    experiments = load.experiment_list("symmetrized.expt", check_format=False)
     assert len(experiments) == 3
 
 
-def test_cosym_partial_dataset_raises_sorry(dials_data, tmpdir):
+def test_cosym_partial_dataset_raises_sorry(dials_data, run_in_tmpdir, capsys):
     """Test how cosym handles partial/bad datasets."""
     mcp = dials_data("multi_crystal_proteinase_k")
-    command = ["dials.cosym"]
-    command.append(tmpdir.join("renamed.refl").strpath)
-    command.append(mcp.join("experiments_8.json").strpath)
+    args = ["renamed.refl", mcp.join("experiments_8.json").strpath]
     r2 = flex.reflection_table.from_file(mcp.join("reflections_10.pickle").strpath)
     r2["partiality"] = flex.double(r2.size(), 0.1)
-    r2.as_file(tmpdir.join("renamed2.refl").strpath)
-    command.append(tmpdir.join("renamed2.refl").strpath)
-    command.append(mcp.join("experiments_10.json").strpath)
+    r2.as_file("renamed2.refl")
+    args.append("renamed2.refl")
+    args.append(mcp.join("experiments_10.json").strpath)
 
-    result = procrunner.run(command, working_directory=tmpdir.strpath)
-    # Sorry exceptions are only raised as text at the system level
-    assert result.stderr.startswith(b"Sorry")
+    with pytest.raises(Sorry):
+        dials_cosym.run(args=args)
 
 
 @pytest.mark.parametrize(
@@ -109,9 +99,8 @@ def test_synthetic(
     sample_size,
     use_known_space_group,
     use_known_lattice_group,
-    tmpdir,
+    run_in_tmpdir,
 ):
-    os.chdir(tmpdir.strpath)
     space_group = sgtbx.space_group_info(space_group).group()
     if unit_cell is not None:
         unit_cell = uctbx.unit_cell(unit_cell)
@@ -125,15 +114,14 @@ def test_synthetic(
     )
 
     experiments.as_json("tmp.expt")
-    expt_file = tmpdir.join("tmp.expt").strpath
+    expt_file = "tmp.expt"
     joint_table = flex.reflection_table()
     for r in reflections:
         joint_table.extend(r)
     joint_table.as_file("tmp.refl")
-    refl_file = tmpdir.join("tmp.refl").strpath
+    refl_file = "tmp.refl"
 
-    command = [
-        "dials.cosym",
+    args = [
         expt_file,
         refl_file,
         "output.experiments=symmetrized.expt",
@@ -143,33 +131,18 @@ def test_synthetic(
     ]
 
     if use_known_space_group:
-        command.append("space_group=%s" % space_group.info())
+        args.append("space_group=%s" % space_group.info())
     if use_known_lattice_group:
-        command.append("lattice_group=%s" % space_group.info())
+        args.append("lattice_group=%s" % space_group.info())
     if dimensions is not None:
-        command.append("dimensions=%s" % dimensions)
+        args.append("dimensions=%s" % dimensions)
 
-    result = procrunner.run(command, working_directory=tmpdir.strpath)
-    assert not result.returncode and not result.stderr
-    assert tmpdir.join("symmetrized.refl").check(file=1)
-    assert tmpdir.join("symmetrized.expt").check(file=1)
-    assert tmpdir.join("cosym.html").check(file=1)
-    assert tmpdir.join("cosym.json").check(file=1)
-    """experiments, reflections = assign_unique_identifiers(experiments, reflections)
-    cosym_instance = cosym(experiments, reflections, params=params)
-    register_default_cosym_observers(cosym_instance)
-    cosym_instance.run()
-    cosym_instance.export()
-
-
-
-    assert os.path.exists(params.output.experiments)
-    assert os.path.exists(params.output.reflections)
-    assert os.path.exists(params.output.html)
-    assert os.path.exists(params.output.json)"""
-    cosym_expts = load.experiment_list(
-        tmpdir.join("symmetrized.expt").strpath, check_format=False
-    )
+    dials_cosym.run(args=args)
+    assert os.path.isfile("symmetrized.refl")
+    assert os.path.isfile("symmetrized.expt")
+    assert os.path.isfile("cosym.html")
+    assert os.path.isfile("cosym.json")
+    cosym_expts = load.experiment_list("symmetrized.expt", check_format=False)
     assert len(cosym_expts) == len(experiments)
     for expt in cosym_expts:
         if unit_cell is not None:


### PR DESCRIPTION
This can be important if the lattice symmetry is only very approximately related by pseudosymmetry to the true symmetry. If all potential reindexing ops are genuine indexing ambiguities, then it doesn't matter which one is chosen, however if not, then choosing the wrong one will distort the true unit cell. In such cases it is likely that the input datasets were already indexed consistently, therefore default to choosing the cluster that contains the most identity reindexing ops.