### PR TITLE
Fix some minor issues in the indexing code

### DIFF
--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -654,12 +654,12 @@ class Indexer(object):
                         # with this deleted experiment - indexed flag removed
                         # below
                         last = len(experiments)
-                        sel = reflections_for_refinement["id"] == last
+                        sel = refined_reflections["id"] == last
                         logger.info(
                             "Removing %d reflections with id %d"
                             % (sel.count(True), last)
                         )
-                        reflections_for_refinement["id"].set_selected(sel, -1)
+                        refined_reflections["id"].set_selected(sel, -1)
 
                         break
 

--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -654,12 +654,12 @@ class Indexer(object):
                         # with this deleted experiment - indexed flag removed
                         # below
                         last = len(experiments)
-                        sel = refined_reflections["id"] == last
+                        sel = reflections_for_refinement["id"] == last
                         logger.info(
                             "Removing %d reflections with id %d"
                             % (sel.count(True), last)
                         )
-                        refined_reflections["id"].set_selected(sel, -1)
+                        reflections_for_refinement["id"].set_selected(sel, -1)
 
                         break
 

--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -571,6 +571,8 @@ class Indexer(object):
                 # no more lattices found
                 break
 
+            refined_experiments = None
+            refined_reflections = None
             for i_cycle in range(self.params.refinement_protocol.n_macro_cycles):
                 if (
                     i_cycle > 0

--- a/algorithms/indexing/indexer.py
+++ b/algorithms/indexing/indexer.py
@@ -301,7 +301,7 @@ phil_scope = iotbx.phil.parse(phil_str, process_includes=True)
 
 
 class Indexer(object):
-    def __init__(self, reflections, experiments, params=None):
+    def __init__(self, reflections, experiments, params):
         self.reflections = reflections
         self.experiments = experiments
 

--- a/algorithms/indexing/lattice_search/__init__.py
+++ b/algorithms/indexing/lattice_search/__init__.py
@@ -108,7 +108,7 @@ basis_vector_search_phil_scope.adopt_scope(
 
 
 class LatticeSearch(indexer.Indexer):
-    def __init__(self, reflections, experiments, params=None):
+    def __init__(self, reflections, experiments, params):
         super(LatticeSearch, self).__init__(reflections, experiments, params)
 
         self._lattice_search_strategy = None
@@ -293,7 +293,7 @@ class LatticeSearch(indexer.Indexer):
 
 
 class BasisVectorSearch(LatticeSearch):
-    def __init__(self, reflections, experiments, params=None):
+    def __init__(self, reflections, experiments, params):
         super(BasisVectorSearch, self).__init__(reflections, experiments, params)
 
         strategy_class = None

--- a/algorithms/indexing/lattice_search/__init__.py
+++ b/algorithms/indexing/lattice_search/__init__.py
@@ -111,21 +111,18 @@ class LatticeSearch(indexer.Indexer):
     def __init__(self, reflections, experiments, params=None):
         super(LatticeSearch, self).__init__(reflections, experiments, params)
 
-        strategy_class = None
+        self._lattice_search_strategy = None
         for entry_point in pkg_resources.iter_entry_points(
             "dials.index.lattice_search"
         ):
-            if entry_point.name == params.indexing.method:
+            if entry_point.name == self.params.method:
                 strategy_class = entry_point.load()
-
-        if strategy_class is not None:
-            self._lattice_search_strategy = strategy_class(
-                target_symmetry_primitive=self._symmetry_handler.target_symmetry_primitive,
-                max_lattices=self.params.basis_vector_combinations.max_refine,
-                params=getattr(self.params, entry_point.name),
-            )
-        else:
-            self._lattice_search_strategy = None
+                self._lattice_search_strategy = strategy_class(
+                    target_symmetry_primitive=self._symmetry_handler.target_symmetry_primitive,
+                    max_lattices=self.params.basis_vector_combinations.max_refine,
+                    params=getattr(self.params, entry_point.name, None),
+                )
+                break
 
     def find_candidate_crystal_models(self):
 

--- a/newsfragments/1515.bugfix
+++ b/newsfragments/1515.bugfix
@@ -1,2 +1,2 @@
-When more than one lattice search strategy is defined, ensure that the correct corresponding PHIL scope is used.
-Previously, the PHIL scope of the last listed strategy would be used for all the strategies.
+When there is more than one lattice search indexing method available for use in ``dials.index``, each method is now associated with the correct set of configuration options.
+Previously, the configuration options of the last listed method would mistakenly be used for all the methods.

--- a/newsfragments/1515.bugfix
+++ b/newsfragments/1515.bugfix
@@ -1,0 +1,2 @@
+When more than one lattice search strategy is defined, ensure that the correct corresponding PHIL scope is used.
+Previously, the PHIL scope of the last listed strategy would be used for all the strategies.


### PR DESCRIPTION
Catch some undefined variables and stuff like that.

* Previously `entry_point` in `getattr` call as part of `strategy_class` call in `dials.algorithms.indexing.lattice_search.LatticeSearch.__init__` would be the value of the last entry point in `pkg_resources.iter_entry_points("dials.index.lattice_search")`, not the matching entry point.
* ~Buried deep in `dials.algorithms.indexing.indexer.Indexer.index`, there's a code path with an undefined variable `refined_reflections`.  Presumably, `reflections_for_refinement` is what was intended.~
* Remove the impossible default parameter `params=None` in initialising `dials.algorithms.indexing.indexer.Indexer` and its subclasses.  `None.indexing` is always going to raise an `AttributeError`.