### PR TITLE
Document indexing strategies

### DIFF
--- a/algorithms/indexing/basis_vector_search/fft1d.py
+++ b/algorithms/indexing/basis_vector_search/fft1d.py
@@ -16,12 +16,31 @@ characteristic_grid = None
 
 
 class FFT1D(Strategy):
-    """Basis vector search using a 1D FFT.
+    """
+    Basis vector search using 1D FFTs in reciprocal space.
+
+    A set of dimensionless radial unit vectors, typically ~7000 in total, is chosen
+    so that they are roughly evenly spaced in solid angle over a hemisphere. The
+    reciprocal space displacements of the measured spot centroids are then projected
+    onto each of these radial vectors in turn (that is, we calculate the scalar
+    product of each displacement with each unit vector).  A 1D FFT of the linear
+    density of projected spot positions is performed along each direction.
+    Aggregating the results of all the transforms, the three shortest non-collinear
+    wave vectors with the greatest spectral weight correspond to the basis vectors of
+    the direct lattice.
 
     See:
         Steller, I., Bolotovsky, R. & Rossmann, M. G. (1997). J. Appl. Cryst. 30, 1036-1040.
         Sauter, N. K., Grosse-Kunstleve, R. W. & Adams, P. D. (2004). J. Appl. Cryst. 37, 399-409.
     """
+
+    phil_help = (
+        " 'Search for the basis vectors of the direct lattice by performing a series "
+        "of 1D FFTs along various directions in reciprocal space.  This has a lower "
+        "memory requirement than a single 3D FFT (the fft3d method).  This method may "
+        "also be more appropriate than a 3D FFT if the reflections are from narrow "
+        "wedges of rotation data or from stills data.' "
+    )
 
     phil_scope = phil.parse(fft1d_phil_str)
 

--- a/algorithms/indexing/basis_vector_search/fft1d.py
+++ b/algorithms/indexing/basis_vector_search/fft1d.py
@@ -23,7 +23,7 @@ class FFT1D(Strategy):
     so that they are roughly evenly spaced in solid angle over a hemisphere. The
     reciprocal space displacements of the measured spot centroids are then projected
     onto each of these radial vectors in turn (that is, we calculate the scalar
-    product of each displacement with each unit vector).  A 1D FFT of the linear
+    product of each displacement with each unit vector). A 1D FFT of the linear
     density of projected spot positions is performed along each direction.
     Aggregating the results of all the transforms, the three shortest non-collinear
     wave vectors with the greatest spectral weight correspond to the basis vectors of
@@ -35,11 +35,11 @@ class FFT1D(Strategy):
     """
 
     phil_help = (
-        " 'Search for the basis vectors of the direct lattice by performing a series "
-        "of 1D FFTs along various directions in reciprocal space.  This has a lower "
-        "memory requirement than a single 3D FFT (the fft3d method).  This method may "
+        "Search for the basis vectors of the direct lattice by performing a series of "
+        "1D FFTs along various directions in reciprocal space. This has a lower "
+        "memory requirement than a single 3D FFT (the fft3d method). This method may "
         "also be more appropriate than a 3D FFT if the reflections are from narrow "
-        "wedges of rotation data or from stills data.' "
+        "wedges of rotation data or from stills data."
     )
 
     phil_scope = phil.parse(fft1d_phil_str)

--- a/algorithms/indexing/basis_vector_search/fft3d.py
+++ b/algorithms/indexing/basis_vector_search/fft3d.py
@@ -47,7 +47,7 @@ class FFT3D(Strategy):
     Basis vector search using a 3D FFT in reciprocal space.
 
     Reciprocal space is sampled as a 3D Cartesian grid, aligned with the basis of the
-    laboratory frame.  The reciprocal-space positions of the centroids of measured
+    laboratory frame. The reciprocal-space positions of the centroids of measured
     spots are ascribed a value of 1, with the rest of the grid assigned a value of 0.
     A 3D FFT is performed and the three shortest non-collinear reciprocal spatial
     wave vectors with appreciable spectral weight correspond to the basis vectors of
@@ -55,7 +55,7 @@ class FFT3D(Strategy):
 
     Because this procedure requires a sampling of all of reciprocal space, up to the
     d* value of the measured spot with the highest resolution, it can be more memory
-    intensive than alternative approaches.  To mitigate this, the 3D FFT will
+    intensive than alternative approaches. To mitigate this, the 3D FFT will
     sometimes be curtailed to a region of reciprocal space below a certain
     resolution, and higher-resolution spots will be ignored.
 
@@ -65,10 +65,10 @@ class FFT3D(Strategy):
     """
 
     phil_help = (
-        " 'Search for the basis vectors of the direct lattice by performing a 3D FFT "
-        "in reciprocal space of the density of found spots.  Since this can be quite "
+        "Search for the basis vectors of the direct lattice by performing a 3D FFT in "
+        "reciprocal space of the density of found spots. Since this can be quite "
         "memory-intensive, the data used for indexing may automatically be "
-        "constrained to just the lower resolution spots.' "
+        "constrained to just the lower resolution spots."
     )
 
     phil_scope = phil.parse(fft3d_phil_str)

--- a/algorithms/indexing/basis_vector_search/fft3d.py
+++ b/algorithms/indexing/basis_vector_search/fft3d.py
@@ -43,12 +43,33 @@ reciprocal_space_grid {
 
 
 class FFT3D(Strategy):
-    """Basis vector search using a 3D FFT.
+    """
+    Basis vector search using a 3D FFT in reciprocal space.
+
+    Reciprocal space is sampled as a 3D Cartesian grid, aligned with the basis of the
+    laboratory frame.  The reciprocal-space positions of the centroids of measured
+    spots are ascribed a value of 1, with the rest of the grid assigned a value of 0.
+    A 3D FFT is performed and the three shortest non-collinear reciprocal spatial
+    wave vectors with appreciable spectral weight correspond to the basis vectors of
+    the real space lattice.
+
+    Because this procedure requires a sampling of all of reciprocal space, up to the
+    d* value of the measured spot with the highest resolution, it can be more memory
+    intensive than alternative approaches.  To mitigate this, the 3D FFT will
+    sometimes be curtailed to a region of reciprocal space below a certain
+    resolution, and higher-resolution spots will be ignored.
 
     See:
         Bricogne, G. (1986). Proceedings of the EEC Cooperative Workshop on Position-Sensitive Detector Software (Phase III), p. 28. Paris: LURE.
         Campbell, J. W. (1998). J. Appl. Cryst. 31, 407-413.
     """
+
+    phil_help = (
+        " 'Search for the basis vectors of the direct lattice by performing a 3D FFT "
+        "in reciprocal space of the density of found spots.  Since this can be quite "
+        "memory-intensive, the data used for indexing may automatically be "
+        "constrained to just the lower resolution spots.' "
+    )
 
     phil_scope = phil.parse(fft3d_phil_str)
 

--- a/algorithms/indexing/basis_vector_search/real_space_grid_search.py
+++ b/algorithms/indexing/basis_vector_search/real_space_grid_search.py
@@ -28,11 +28,33 @@ max_vectors = 30
 
 
 class RealSpaceGridSearch(Strategy):
-    """Basis vector search using a real space grid search.
+    """
+    Basis vector search using a real space grid search.
+
+    Search strategy to index found spots based on known unit cell parameters.  It is
+    often useful for difficult cases of narrow-wedge rotation data or stills data,
+    especially where there is diffraction from multiple crystals.
+
+    A set of dimensionless radial unit vectors, typically ~7000 in total, is chosen
+    so that they are roughly evenly spaced in solid angle over a hemisphere.  For
+    each direction, each of the three known unit cell vectors is aligned with the
+    unit vector and is scored according to how well it accords with the periodicity
+    in that direction of the reconstructed reciprocal space positions of the observed
+    spot centroids.  Examining the highest-scoring combinations, any basis vectors in
+    orientations that are too nearly collinear with a shorter basis vector are
+    eliminated.  The highest-scoring remaining combinations are selected as the basis
+    of the direct lattice.
 
     See:
         Gildea, R. J., Waterman, D. G., Parkhurst, J. M., Axford, D., Sutton, G., Stuart, D. I., Sauter, N. K., Evans, G. & Winter, G. (2014). Acta Cryst. D70, 2652-2666.
     """
+
+    phil_help = (
+        " 'Index the found spots by testing a known unit cell in various orientations "
+        "until the best match is found.  This strategy is often useful for difficult "
+        "cases of narrow-wedge rotation data or stills data, especially where there "
+        "is diffraction from multiple crystals.' "
+    )
 
     phil_scope = phil.parse(real_space_grid_search_phil_str)
 

--- a/algorithms/indexing/basis_vector_search/real_space_grid_search.py
+++ b/algorithms/indexing/basis_vector_search/real_space_grid_search.py
@@ -31,18 +31,18 @@ class RealSpaceGridSearch(Strategy):
     """
     Basis vector search using a real space grid search.
 
-    Search strategy to index found spots based on known unit cell parameters.  It is
+    Search strategy to index found spots based on known unit cell parameters. It is
     often useful for difficult cases of narrow-wedge rotation data or stills data,
     especially where there is diffraction from multiple crystals.
 
     A set of dimensionless radial unit vectors, typically ~7000 in total, is chosen
-    so that they are roughly evenly spaced in solid angle over a hemisphere.  For
-    each direction, each of the three known unit cell vectors is aligned with the
-    unit vector and is scored according to how well it accords with the periodicity
-    in that direction of the reconstructed reciprocal space positions of the observed
-    spot centroids.  Examining the highest-scoring combinations, any basis vectors in
-    orientations that are too nearly collinear with a shorter basis vector are
-    eliminated.  The highest-scoring remaining combinations are selected as the basis
+    so that they are roughly evenly spaced in solid angle over a hemisphere. For each
+    direction, each of the three known unit cell vectors is aligned with the unit
+    vector and is scored according to how well it accords with the periodicity in
+    that direction of the reconstructed reciprocal space positions of the observed
+    spot centroids. Examining the highest-scoring combinations, any basis vectors in
+    orientations that are nearly collinear with a shorter basis vector are
+    eliminated. The highest-scoring remaining combinations are selected as the basis
     of the direct lattice.
 
     See:
@@ -50,10 +50,10 @@ class RealSpaceGridSearch(Strategy):
     """
 
     phil_help = (
-        " 'Index the found spots by testing a known unit cell in various orientations "
-        "until the best match is found.  This strategy is often useful for difficult "
+        "Index the found spots by testing a known unit cell in various orientations "
+        "until the best match is found. This strategy is often useful for difficult "
         "cases of narrow-wedge rotation data or stills data, especially where there "
-        "is diffraction from multiple crystals.' "
+        "is diffraction from multiple crystals."
     )
 
     phil_scope = phil.parse(real_space_grid_search_phil_str)

--- a/algorithms/indexing/basis_vector_search/strategy.py
+++ b/algorithms/indexing/basis_vector_search/strategy.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 class Strategy(object):
     """A base class for basis vector search strategies."""
 
-    phil_help = "''"
+    phil_help = None
 
     phil_scope = None
 

--- a/algorithms/indexing/basis_vector_search/strategy.py
+++ b/algorithms/indexing/basis_vector_search/strategy.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, print_function
 class Strategy(object):
     """A base class for basis vector search strategies."""
 
+    phil_help = "''"
+
     phil_scope = None
 
     def __init__(self, max_cell, params=None, *args, **kwargs):

--- a/algorithms/indexing/lattice_search/__init__.py
+++ b/algorithms/indexing/lattice_search/__init__.py
@@ -83,14 +83,6 @@ for entry_point in itertools.chain(
     pkg_resources.iter_entry_points("dials.index.basis_vector_search"),
     pkg_resources.iter_entry_points("dials.index.lattice_search"),
 ):
-    scope = (
-        """\
-%s {
-    include scope entry_point.load().phil_scope
-}
-    """
-        % entry_point.name
-    )
     ext_master_scope = libtbx.phil.parse(
         """
 %s

--- a/algorithms/indexing/lattice_search/__init__.py
+++ b/algorithms/indexing/lattice_search/__init__.py
@@ -91,7 +91,15 @@ for entry_point in itertools.chain(
     """
         % entry_point.name
     )
-    ext_master_scope = libtbx.phil.parse("%s .expert_level=1 {}" % entry_point.name)
+    ext_master_scope = libtbx.phil.parse(
+        """
+%s
+.expert_level=1
+.help=%s
+{}
+        """
+        % (entry_point.name, entry_point.load().phil_help)
+    )
     ext_phil_scope = ext_master_scope.get_without_substitution(entry_point.name)
     assert len(ext_phil_scope) == 1
     ext_phil_scope = ext_phil_scope[0]

--- a/algorithms/indexing/lattice_search/low_res_spot_match.py
+++ b/algorithms/indexing/lattice_search/low_res_spot_match.py
@@ -121,20 +121,20 @@ class LowResSpotMatch(Strategy):
     A lattice search strategy matching low resolution spots to candidate indices.
 
     The match is based on resolution and reciprocal space distance between observed
-    spots.  A prior unit cell is required and solutions are assessed by matching the
-    low resolution spots against candidate reflection positions predicted from the
-    known cell.  This lattice search strategy is a special case designed to work for
-    electron diffraction still images, in which one typically only collects
-    reflections from the zero-order Laue zone.  In principle, it is not limited to
-    this type of data, but probably works best with narrow wedges, good initial
-    geometry and a small beam-stop shadow so that a good number of low-order
-    reflections are collected.
+    spots. A prior unit cell and space group are required and solutions are assessed
+    by matching the low resolution spots against candidate reflection positions
+    predicted from the known cell. This lattice search strategy is a special case
+    designed to work for electron diffraction still images, in which one typically
+    only collects reflections from the zero-order Laue zone. In principle, it is not
+    limited to this type of data, but probably works best with narrow wedges,
+    good initial geometry and a small beam-stop shadow so that a good number of
+    low-order reflections are collected.
     """
 
     phil_help = (
-        " 'A lattice search strategy that matches low resolution spots to candidate "
-        "indices based on a known unit cell.  Designed primarily for electron "
-        "diffraction still images.' "
+        "A lattice search strategy that matches low resolution spots to candidate "
+        "indices based on a known unit cell and space group. Designed primarily for "
+        "electron diffraction still images."
     )
 
     phil_scope = libtbx.phil.parse(low_res_spot_match_phil_str)

--- a/algorithms/indexing/lattice_search/low_res_spot_match.py
+++ b/algorithms/indexing/lattice_search/low_res_spot_match.py
@@ -91,7 +91,7 @@ candidate_spots
     .type = int
 
     d_star_tolerance = 4.0
-    .help = "Number of sigmas from the centroid position for which to"
+    .help = "Number of sigmas from the centroid position for which to "
             "calculate d* bands"
     .type = float
 }
@@ -117,9 +117,25 @@ max_quads = 600
 
 
 class LowResSpotMatch(Strategy):
-    """Lattice search by matching low resolution spots to candidate indices
-    based on resolution and reciprocal space distance between observed spots.
     """
+    A lattice search strategy matching low resolution spots to candidate indices.
+
+    The match is based on resolution and reciprocal space distance between observed
+    spots.  A prior unit cell is required and solutions are assessed by matching the
+    low resolution spots against candidate reflection positions predicted from the
+    known cell.  This lattice search strategy is a special case designed to work for
+    electron diffraction still images, in which one typically only collects
+    reflections from the zero-order Laue zone.  In principle, it is not limited to
+    this type of data, but probably works best with narrow wedges, good initial
+    geometry and a small beam-stop shadow so that a good number of low-order
+    reflections are collected.
+    """
+
+    phil_help = (
+        " 'A lattice search strategy that matches low resolution spots to candidate "
+        "indices based on a known unit cell.  Designed primarily for electron "
+        "diffraction still images.' "
+    )
 
     phil_scope = libtbx.phil.parse(low_res_spot_match_phil_str)
 

--- a/algorithms/indexing/lattice_search/strategy.py
+++ b/algorithms/indexing/lattice_search/strategy.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, print_function
 class Strategy(object):
     """A base class for lattice search strategies."""
 
+    phil_help = "''"
+
     phil_scope = None
 
     def __init__(self, params=None, *args, **kwargs):

--- a/algorithms/indexing/lattice_search/strategy.py
+++ b/algorithms/indexing/lattice_search/strategy.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 class Strategy(object):
     """A base class for lattice search strategies."""
 
-    phil_help = "''"
+    phil_help = None
 
     phil_scope = None
 

--- a/newsfragments/1519.doc
+++ b/newsfragments/1519.doc
@@ -1,0 +1,3 @@
+Each of the available indexing strategies in ``dials.index`` now has some help text explaining how it works.
+You can view this help by calling ``dials.index -c -a1 -e1`` and looking for ``method`` under ``indexing``.
+


### PR DESCRIPTION
Provide PHIL help for each of the basis vector and lattice search strategies and pass these through to the `dials.index` PHIL scope.  Give a little more info on how each strategy works in the docstring of the corresponding class.