### PR TITLE
dials.merge: Fix output of SigF, N+, N- in merged.mtz

### DIFF
--- a/1522.bugfix
+++ b/1522.bugfix
@@ -1,0 +1,1 @@
+dials.merge: Fix incorrect output of SigF, N+, N- in merged.mtz

--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -93,7 +93,7 @@ class MTZDataClass(object):
         merged_anomalous_array=None,
         amplitudes=None,
         anomalous_amplitudes=None,
-        redundancies=None,
+        multiplicities=None,
     ):
         self.wavelength = wavelength
         self.project_name = project_name
@@ -103,7 +103,7 @@ class MTZDataClass(object):
         self.merged_anomalous_array = merged_anomalous_array
         self.amplitudes = amplitudes
         self.anomalous_amplitudes = anomalous_amplitudes
-        self.redundancies = redundancies
+        self.multiplicities = multiplicities
 
 
 def make_merged_mtz_file(mtz_datasets):
@@ -141,7 +141,7 @@ def make_merged_mtz_file(mtz_datasets):
             dataset.merged_anomalous_array,
             dataset.amplitudes,
             dataset.anomalous_amplitudes,
-            dataset.redundancies,
+            dataset.multiplicities,
         )
 
     return mtz_writer.mtz_file

--- a/command_line/merge.py
+++ b/command_line/merge.py
@@ -186,11 +186,11 @@ def merge_data_to_mtz(params, experiments, reflections):
             merged_anomalous_array = merged_anomalous.array()
             # This will add the data for I(+), I(-), SIGI(+), SIGI(-), N(+), N(-)
             mtz_dataset.merged_anomalous_array = merged_anomalous_array
-            mtz_dataset.redundancies = merged_anomalous.redundancies()
+            mtz_dataset.multiplicities = merged_anomalous.redundancies()
         else:
             merged_anomalous_array = None
             # This will add the data for N
-            mtz_dataset.redundancies = merged.redundancies()
+            mtz_dataset.multiplicities = merged.redundancies()
 
         if params.anomalous:
             merged_intensities = merged_anomalous_array

--- a/util/export_mtz.py
+++ b/util/export_mtz.py
@@ -90,6 +90,7 @@ class MergedMTZWriter(MTZWriterBase):
         anom_array=None,
         amplitudes=None,
         anom_amplitudes=None,
+        redundancies=None,
         suffix=None,
     ):
         """Add merged data to the most recent dataset.
@@ -107,11 +108,8 @@ class MergedMTZWriter(MTZWriterBase):
         self.current_dataset.add_miller_array(merged_array, "IMEAN" + suffix)
         if anom_array:
             self.current_dataset.add_miller_array(anom_array, "I" + suffix)
-            self.current_dataset.add_miller_array(
-                anom_array.multiplicities(),
-                column_root_label="N" + suffix,
-                column_types="I",
-            )
+        if redundancies:
+            self.current_dataset.add_miller_array(redundancies, "N" + suffix)
         if amplitudes:
             self.current_dataset.add_miller_array(amplitudes, "F" + suffix)
         if anom_amplitudes:
@@ -127,12 +125,13 @@ class MADMergedMTZWriter(MergedMTZWriter):
         anom_array=None,
         amplitudes=None,
         anom_amplitudes=None,
+        redundancies=None,
         suffix=None,
     ):
         if not suffix:
             suffix = "_WAVE%s" % str(self.n_datasets)
         super(MADMergedMTZWriter, self).add_dataset(
-            merged_array, anom_array, amplitudes, anom_amplitudes, suffix
+            merged_array, anom_array, amplitudes, anom_amplitudes, redundancies, suffix
         )
 
 

--- a/util/export_mtz.py
+++ b/util/export_mtz.py
@@ -90,7 +90,7 @@ class MergedMTZWriter(MTZWriterBase):
         anom_array=None,
         amplitudes=None,
         anom_amplitudes=None,
-        redundancies=None,
+        multiplicities=None,
         suffix=None,
     ):
         """Add merged data to the most recent dataset.
@@ -108,8 +108,8 @@ class MergedMTZWriter(MTZWriterBase):
         self.current_dataset.add_miller_array(merged_array, "IMEAN" + suffix)
         if anom_array:
             self.current_dataset.add_miller_array(anom_array, "I" + suffix)
-        if redundancies:
-            self.current_dataset.add_miller_array(redundancies, "N" + suffix)
+        if multiplicities:
+            self.current_dataset.add_miller_array(multiplicities, "N" + suffix)
         if amplitudes:
             self.current_dataset.add_miller_array(amplitudes, "F" + suffix)
         if anom_amplitudes:
@@ -125,13 +125,18 @@ class MADMergedMTZWriter(MergedMTZWriter):
         anom_array=None,
         amplitudes=None,
         anom_amplitudes=None,
-        redundancies=None,
+        multiplicities=None,
         suffix=None,
     ):
         if not suffix:
             suffix = "_WAVE%s" % str(self.n_datasets)
         super(MADMergedMTZWriter, self).add_dataset(
-            merged_array, anom_array, amplitudes, anom_amplitudes, redundancies, suffix
+            merged_array,
+            anom_array,
+            amplitudes,
+            anom_amplitudes,
+            multiplicities,
+            suffix,
         )
 
 


### PR DESCRIPTION
For anomalous=True (the default), when merging anomalous Fs to normal Fs,
don't use_internal_variances. This gives an incorrect (overly high) value for SigF by several factors.

Also, the miller index multiplicities were being written as N+,
N- however this was intended to be the redundancy of observations
of each symmetry group, which is fixed here.