### PR TITLE
Apply an error model in the first part of scaling

### DIFF
--- a/algorithms/scaling/error_model/error_model.py
+++ b/algorithms/scaling/error_model/error_model.py
@@ -47,6 +47,10 @@ phil_scope = phil.parse(
             .help = "The number of intensity bins to use for the error model optimisation."
             .expert_level = 2
     }
+    reset_error_model = False
+        .type = bool
+        .help = "If True, the error model is reset to the default at the start"
+                "of scaling, as opposed to loading the current error model."
     """
 )
 

--- a/algorithms/scaling/error_model/error_model.py
+++ b/algorithms/scaling/error_model/error_model.py
@@ -51,26 +51,6 @@ phil_scope = phil.parse(
 )
 
 
-def get_error_model_class_and_scope(error_model_params):
-    """Return the correct error model class & phil scope from a params option."""
-    name = error_model_params.error_model
-    if name == "basic":
-        return BasicErrorModel, error_model_params.basic
-    else:
-        raise ValueError("Invalid choice of error model: %s" % name)
-
-
-def get_error_parameters_to_refine(model, scope):
-    """Get a list of components to refine."""
-    active_parameters = []
-    if model.id_ == "basic":
-        if not scope.a:
-            active_parameters.append("a")
-        if not scope.b:
-            active_parameters.append("b")
-    return active_parameters
-
-
 def calc_sigmaprime(x, Ih_table):
     """Calculate the error from the model."""
     sigmaprime = (
@@ -357,24 +337,52 @@ class BasicErrorModel(object):
 
     id_ = "basic"
 
-    def __init__(self, Ih_table, basic_params, min_partiality=0.4):
+    def __init__(self, a=None, b=None, basic_params=None):
 
-        """Raises: ValueError if insufficient reflections left after filtering."""
+        """
+        A basic two-parameter error model s'^2 = a^2(s^2 + (bI)^2)
+
+        If a and b are not given as arguments, the params scope is checked to
+        see if a user specified fixed value is set. If no fixed values are given
+        then the model starts with the default parameters a=1.0 b=0.02
+        """
 
         self.free_components = []
         self.sortedy = None
         self.sortedx = None
         self.binner = None
-        self.filtered_Ih_table = self.filter_unsuitable_reflections(
-            Ih_table, basic_params, min_partiality
-        )
-        a = basic_params.a if basic_params.a else 1.0
-        b = basic_params.b if basic_params.b else 0.02
+        if not basic_params:
+            basic_params = phil_scope.fetch().extract().basic
+        self.params = basic_params
+        self.filtered_Ih_table = None
+        if not a:
+            a = basic_params.a
+            if not a:
+                a = 1.0
+        if not b:
+            b = basic_params.b
+            if not b:
+                b = 0.02
         self.components = {"a": AComponent(a), "b": BComponent(b)}
+        self._active_parameters = []
+        # if the parameters have been set in the phil scope, then these are to be fixed
+        if not basic_params.a:
+            self._active_parameters.append("a")
+        if not basic_params.b:
+            self._active_parameters.append("b")
 
+    def configure_for_refinement(self, Ih_table, min_partiality=0.4):
+        """
+        Add data to allow error model refinement.
+
+        Raises: ValueError if insufficient reflections left after filtering.
+        """
+        self.filtered_Ih_table = self.filter_unsuitable_reflections(
+            Ih_table, self.params, min_partiality
+        )
         # always want binning info so that can calc for output.
         self.binner = ErrorModelBinner(
-            self.filtered_Ih_table, self.min_reflections_required, basic_params.n_bins
+            self.filtered_Ih_table, self.min_reflections_required, self.params.n_bins
         )
 
         # need to calculate sorted deltahl for norm dev plotting (and used by
@@ -384,9 +392,16 @@ class BasicErrorModel(object):
         self.binner.update(self.parameters)
 
     @property
+    def active_parameters(self):
+        return self._active_parameters
+
+    @property
     def parameters(self):
         """A list of the model parameters."""
-        return [self.components["a"].parameters[0], self.components["b"].parameters[0]]
+        return [
+            self.components["a"].parameters[0],
+            abs(self.components["b"].parameters[0]),
+        ]
 
     @parameters.setter
     def parameters(self, parameters):

--- a/algorithms/scaling/model/model.py
+++ b/algorithms/scaling/model/model.py
@@ -302,7 +302,10 @@ class ScalingModelBase(object):
     def load_error_model(self, error_params):
         # load existing model if there, but use user-specified values if given
         new_model = None
-        if "error_model_type" in self._configdict:
+        if (
+            "error_model_type" in self._configdict
+            and not error_params.reset_error_model
+        ):
             if self._configdict["error_model_type"] == "BasicErrorModel":
                 p = self._configdict["error_model_parameters"]
                 a = None

--- a/algorithms/scaling/model/model.py
+++ b/algorithms/scaling/model/model.py
@@ -13,6 +13,7 @@ import six
 
 from libtbx import Auto, phil
 
+from dials.algorithms.scaling.error_model.error_model import BasicErrorModel
 from dials.algorithms.scaling.model.components.scale_components import (
     LinearDoseDecay,
     QuadraticDoseDecay,
@@ -297,6 +298,23 @@ class ScalingModelBase(object):
     def from_dict(cls, obj):
         """Create a scaling model from a dictionary."""
         raise NotImplementedError()
+
+    def load_error_model(self, error_params):
+        # load existing model if there, but use user-specified values if given
+        new_model = None
+        if "error_model_type" in self._configdict:
+            if self._configdict["error_model_type"] == "BasicErrorModel":
+                p = self._configdict["error_model_parameters"]
+                a = None
+                b = None
+                if not error_params.basic.a:
+                    a = p[0]
+                if not error_params.basic.b:
+                    b = p[1]
+                new_model = BasicErrorModel(a, b, error_params.basic)
+        if not new_model:
+            new_model = BasicErrorModel(basic_params=error_params.basic)
+        self.set_error_model(new_model)
 
     def set_error_model(self, error_model):
         """Associate an error model with the dataset."""
@@ -810,7 +828,6 @@ class PhysicalScalingModel(ScalingModelBase):
             "decay": {"parameters": d_params, "parameter_esds": d_params_sds},
             "absorption": {"parameters": abs_params, "parameter_esds": a_params_sds},
         }
-
         return cls(parameters_dict, configdict, is_scaled=True)
 
     def plot_model_components(self):

--- a/algorithms/scaling/scaler_factory.py
+++ b/algorithms/scaling/scaler_factory.py
@@ -88,9 +88,9 @@ class ScalerFactory(object):
                 partiality_threshold=partiality_cutoff,
                 min_isigi=min_isigi,
             )
-            logger.disabled = False
             mask = ~good
             reflections.set_flags(mask, reflections.flags.excluded_for_scaling)
+        logger.disabled = False
         return reflections
 
     @staticmethod

--- a/algorithms/scaling/test_error_model.py
+++ b/algorithms/scaling/test_error_model.py
@@ -165,9 +165,9 @@ def test_error_model_on_simulated_data(
 
     block = Ih_table.blocked_data_list[0]
     BasicErrorModel.min_reflections_required = 250
-    params = generated_param()
 
-    error_model = BasicErrorModel(block, params.weighting.error_model.basic)
+    error_model = BasicErrorModel()
+    error_model.configure_for_refinement(block)
     assert error_model.binner.summation_matrix.n_rows > 400
     refinery = ErrorModelRefinery(error_model, parameters_to_refine=["a", "b"])
     refinery.run()
@@ -180,14 +180,16 @@ def test_error_model_on_simulated_data(
 def test_errormodel(large_reflection_table, test_sg):
     """Test the initialisation and methods of the error model."""
 
-    em = BasicErrorModel
-    em.min_reflections_required = 1
     Ih_table = IhTable([large_reflection_table], test_sg, nblocks=1)
     block = Ih_table.blocked_data_list[0]
     params = generated_param()
     params.weighting.error_model.basic.n_bins = 2
     params.weighting.error_model.basic.min_Ih = 1.0
-    error_model = em(block, params.weighting.error_model.basic)
+    em = BasicErrorModel
+    em.min_reflections_required = 1
+    error_model = em(basic_params=params.weighting.error_model.basic)
+    error_model.min_reflections_required = 1
+    error_model.configure_for_refinement(block)
     assert error_model.binner.summation_matrix[0, 1] == 1
     assert error_model.binner.summation_matrix[1, 1] == 1
     assert error_model.binner.summation_matrix[2, 0] == 1
@@ -236,7 +238,8 @@ def test_error_model_target(large_reflection_table, test_sg):
     params = generated_param()
     params.weighting.error_model.basic.n_bins = 2
     params.weighting.error_model.basic.min_Ih = 1.0
-    error_model = em(block, params.weighting.error_model.basic)
+    error_model = em(basic_params=params.weighting.error_model.basic)
+    error_model.configure_for_refinement(block)
     error_model.parameters = [1.0, 0.05]
     parameterisation = ErrorModelB_APM(error_model)
     target = ErrorModelTargetB(error_model)

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -348,7 +348,7 @@ def vmxi_protk_reindexed(dials_data, tmp_path_factory):
         ),
         (
             ["error_model.basic.b=0.051", "basic.minimisation=regression"],
-            (0.99, 0.051),
+            (1.0, 0.051),
             (0.05, 1e-6),
         ),
     ],

--- a/algorithms/scaling/test_scaler_factory.py
+++ b/algorithms/scaling/test_scaler_factory.py
@@ -9,6 +9,7 @@ import pytest
 from dxtbx.model import Crystal
 from libtbx import phil
 
+from dials.algorithms.scaling.error_model.error_model import BasicErrorModel
 from dials.algorithms.scaling.scaler import (
     MultiScaler,
     NullScaler,
@@ -168,7 +169,7 @@ def mock_exp(mock_scaling_component, idval=0):
     exp.scaling_model.components = {"scale": mock_scaling_component}
     exp.scaling_model.consecutive_refinement_order = ["scale"]
     exp.scaling_model.is_scaled = False
-    exp.scaling_model.configdict = {}
+    exp.scaling_model.error_model = BasicErrorModel()
     exp.scaling_model.configure_reflection_table.side_effect = side_effect_config_table
     exp_dict = {
         "__id__": "crystal",

--- a/command_line/refine_error_model.py
+++ b/command_line/refine_error_model.py
@@ -22,6 +22,7 @@ from iotbx import phil
 from dials.algorithms.scaling.combine_intensities import combine_intensities
 from dials.algorithms.scaling.error_model.engine import run_error_model_refinement
 from dials.algorithms.scaling.error_model.error_model import (
+    BasicErrorModel,
     calc_deltahl,
     calc_sigmaprime,
 )
@@ -101,8 +102,9 @@ def refine_error_model(params, experiments, reflection_tables):
     )
 
     # now do the error model refinement
+    model = BasicErrorModel(basic_params=params.basic)
     try:
-        model = run_error_model_refinement(params, Ih_table)
+        model = run_error_model_refinement(model, Ih_table)
     except (ValueError, RuntimeError) as e:
         logger.info(e)
     else:

--- a/newsfragments/1526.feature
+++ b/newsfragments/1526.feature
@@ -1,0 +1,1 @@
+dials.scale: Update algorithm to apply a more realistic initial error model, or load the existing error model if rescaling


### PR DESCRIPTION
Currently, the error model is refined and applied only after several cycles of scaling, outlier rejection etc.

This change loads an error model during setup, loading either a default model with `a = 1.0, b = 0.02`, or loading the current error model if rescaling. This is then applied to the data before the first cycles of scaling and outlier rejection and is later refined as in the current code. This helps to stabilise the first parts of scaling, particularly the outlier rejection, as we are starting with a more realistic error model (the current code could be seen as having an initial error model of `a = 1.0, b = 0.0`).

Also added is the option `reset_error_model`, which won't load any existing model when rescaling and just start with the default model of `a = 1.0, b = 0.02` instead.