### PR TITLE
Updates to mmcif output from export and two_theta_refine

### DIFF
--- a/command_line/export.py
+++ b/command_line/export.py
@@ -197,6 +197,12 @@ phil_scope = parse(
     compress = gz bz2 xz
       .type = choice
       .help = "Choose compression format (also appended to the file name)"
+
+    pdb_version = v50 *v5_next
+      .type = choice
+      .help = "The pdb mmcif dictionary version that the output mmcif file"
+              "should comply with. v5_next adds support for recording unmerged"
+              "data as well as additional scan metadata and statistics."
   }
 
   mosflm {

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -198,11 +198,12 @@ phil_scope = parse(
       .type = choice
       .help = "Choose compression format (also appended to the file name)"
 
-    pdb_version = v50 *v5_next
+    pdb_version = v5 *v5_next
       .type = choice
-      .help = "The pdb mmcif dictionary version that the output mmcif file"
-              "should comply with. v5_next adds support for recording unmerged"
-              "data as well as additional scan metadata and statistics."
+      .help = "This controls which pdb mmcif dictionary version the output"
+              "mmcif file should comply with. v5_next adds support for"
+              "recording unmerged data as well as additional scan metadata"
+              "and statistics, however writing can be slow for large datasets."
   }
 
   mosflm {

--- a/command_line/two_theta_refine.py
+++ b/command_line/two_theta_refine.py
@@ -371,10 +371,13 @@ class Script(object):
         logger.info("Saving mmCIF information to %s", filename)
 
         block = iotbx.cif.model.block()
+        block["_audit.revision_id"] = 1
         block["_audit.creation_method"] = dials_version()
         block["_audit.creation_date"] = datetime.date.today().isoformat()
+        block["_entry.id"] = "two_theta_refine"
         #   block["_publ.section_references"] = '' # once there is a reference...
 
+        block["_cell.entry_id"] = "two_theta_refine"
         for cell, esd, cifname in zip(
             crystal.get_unit_cell().parameters(),
             crystal.get_cell_parameter_sd(),
@@ -393,6 +396,7 @@ class Script(object):
         block["_cell.volume_esd"] = "%f" % crystal.get_cell_volume_sd()
 
         used_reflections = refiner.get_matches()
+        block["_cell_measurement.entry_id"] = "two_theta_refine"
         block["_cell_measurement.reflns_used"] = len(used_reflections)
         block["_cell_measurement.theta_min"] = (
             flex.min(used_reflections["2theta_obs.rad"]) * 180 / math.pi / 2
@@ -400,6 +404,10 @@ class Script(object):
         block["_cell_measurement.theta_max"] = (
             flex.max(used_reflections["2theta_obs.rad"]) * 180 / math.pi / 2
         )
+        block["_exptl_crystal.id"] = 1
+        block["_diffrn.id"] = "two_theta_refine"
+        block["_diffrn.crystal_id"] = 1
+        block["_diffrn_reflns.diffrn_id"] = "two_theta_refine"
         block["_diffrn_reflns.number"] = len(used_reflections)
         miller_span = miller.index_span(used_reflections["miller_index"])
         min_h, min_k, min_l = miller_span.min()

--- a/newsfragments/1528.bugfix
+++ b/newsfragments/1528.bugfix
@@ -1,1 +1,1 @@
-Updates to mmcif output to conform to latest pdb dictionaries.
+``dials.export``,``dials.two_theta_refine``: Updates to mmcif output to conform to latest pdb dictionaries (v5).

--- a/newsfragments/1528.bugfix
+++ b/newsfragments/1528.bugfix
@@ -1,0 +1,1 @@
+Updates to mmcif output to conform to latest pdb dictionaries.

--- a/test/command_line/test_export.py
+++ b/test/command_line/test_export.py
@@ -258,7 +258,22 @@ def test_mmcif(compress, hklout, dials_data, tmpdir):
     assert not result.returncode and not result.stderr
     assert tmpdir.join(hklin).check(file=1)
 
-    # TODO include similar test for exporting scaled data in mmcif format
+
+def test_mmcif_on_scaled_data(dials_data, tmpdir):
+    """Call dials.export format=mmcif after scaling"""
+    scaled_expt = dials_data("x4wide_processed").join("AUTOMATIC_DEFAULT_scaled.expt")
+    scaled_refl = dials_data("x4wide_processed").join("AUTOMATIC_DEFAULT_scaled.refl")
+    command = [
+        "dials.export",
+        "format=mmcif",
+        scaled_expt.strpath,
+        scaled_refl.strpath,
+        "mmcif.hklout=scaled.mmcif",
+        "compress=None",
+    ]
+    result = procrunner.run(command, working_directory=tmpdir.strpath)
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("scaled.mmcif").check(file=1)
 
 
 def test_xds_ascii(dials_data, tmpdir):

--- a/test/command_line/test_export.py
+++ b/test/command_line/test_export.py
@@ -260,7 +260,7 @@ def test_mmcif(compress, hklout, dials_data, tmpdir):
     assert tmpdir.join(hklin).check(file=1)
 
 
-@pytest.mark.parametrize("pdb_version", ["v50", "v5_next"])
+@pytest.mark.parametrize("pdb_version", ["v5", "v5_next"])
 def test_mmcif_on_scaled_data(dials_data, tmpdir, pdb_version):
     """Call dials.export format=mmcif after scaling"""
     scaled_expt = dials_data("x4wide_processed").join("AUTOMATIC_DEFAULT_scaled.expt")
@@ -279,7 +279,7 @@ def test_mmcif_on_scaled_data(dials_data, tmpdir, pdb_version):
     assert tmpdir.join("scaled.mmcif").check(file=1)
 
     model = iotbx.cif.reader(file_path=tmpdir.join("scaled.mmcif").strpath).model()
-    if pdb_version == "v50":
+    if pdb_version == "v5":
         assert "_pdbx_diffrn_data_section.id" not in model["dials"].keys()
     elif pdb_version == "v5_next":
         assert "_pdbx_diffrn_data_section.id" in model["dials"].keys()

--- a/util/export_mmcif.py
+++ b/util/export_mmcif.py
@@ -271,6 +271,9 @@ class MMCIFOutputFile(object):
                 "_pdbx_diffrn_scan.scan_angle_end",
             )
         )
+
+        expid_to_scan_id = {exp.identifier: i + 1 for i, exp in enumerate(experiments)}
+
         for i, exp in enumerate(experiments):
             scan = exp.scan
             crystal_id = crystal_to_id[exp.crystal]
@@ -409,9 +412,16 @@ class MMCIFOutputFile(object):
         h, k, l = [
             hkl.iround() for hkl in reflections["miller_index"].as_vec3_double().parts()
         ]
+        # make scan id consistent with header as defined above
+        scan_id = flex.int(reflections.size(), 0)
+        for id_ in reflections.experiment_identifiers().keys():
+            expid = reflections.experiment_identifiers()[id_]
+            sel = reflections["id"] == id_
+            scan_id.set_selected(sel, expid_to_scan_id[expid])
+
         loop_values = [
             flex.size_t_range(1, len(reflections) + 1),
-            reflections["id"] + 1,
+            scan_id,
             z0,
             z1,
             h,

--- a/util/export_mmcif.py
+++ b/util/export_mmcif.py
@@ -333,8 +333,8 @@ class MMCIFOutputFile(object):
             cif_block.update(merged_block)
 
         # Write the crystal information
-        # if v50, thats all so return
-        if self.params.mmcif.pdb_version == "v50":
+        # if v5, thats all so return
+        if self.params.mmcif.pdb_version == "v5":
             return cif_block
         # continue if v5_next
         cif_loop = iotbx.cif.model.loop(


### PR DESCRIPTION
I have been able to validate the current mmcif output files against the two different versions of the pdbx mmcif dictionary, tools available here:

https://sw-tools.rcsb.org/apps/MMCIF-DICT-SUITE/index.html

These changes fill in some missing items and update other sections to the up to date definitions.