### PR TITLE
Fix tests after adding "number of images" to dials.show output

### DIFF
--- a/newsfragments/1532.misc
+++ b/newsfragments/1532.misc
@@ -1,0 +1,1 @@
+Fix tests for changes from `cctbx/dxtbx#271 <https://github.com/cctbx/dxtbx/pull/271>`_

--- a/test/command_line/test_show.py
+++ b/test/command_line/test_show.py
@@ -52,6 +52,7 @@ Beam centre:
     mm: (212.48,220.00)
     px: (1235.34,1279.08)
 Scan:
+    number of images:   9
     image range:   {1,9}
     oscillation:   {0,0.2}
     exposure time: 0.2
@@ -120,6 +121,7 @@ Beam centre:
     mm: (210.76,205.28)
     px: (1225.35,1193.47)
 Scan:
+    number of images:   540
     image range:   {1,540}
     oscillation:   {82,0.15}
     exposure time: 0.067
@@ -176,6 +178,7 @@ Beam centre:
     mm: (212.48,220.00)
     px: (1235.34,1279.08)
 Scan:
+    number of images:   9
     image range:   {1,9}
     oscillation:   {0,0.2}
     exposure time: 0.2
@@ -260,6 +263,7 @@ Beam centre:
     mm, raw image: (191.95,444.63)
     px, raw image: (1116.00,2585.96)
 Scan:
+    number of images:   1
     image range:   {1,1}
     oscillation:   {0,0.1}
     exposure time: 0.2


### PR DESCRIPTION
Fix `dials.show` tests following change to add `number of images` to the output, in https://github.com/cctbx/dxtbx/pull/271