### PR TITLE
Remove "run_tests.py" from data files

### DIFF
--- a/newsfragments/1534.misc
+++ b/newsfragments/1534.misc
@@ -1,0 +1,1 @@
+fix up setup.py in preparation for future packaging work

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(),
     package_dir={"dials": "../dials"},
     data_files=[
-        ("dials", ["conftest.py", "__init__.py", "libtbx_refresh.py", "run_tests.py"])
+        ("dials", ["conftest.py", "__init__.py", "libtbx_refresh.py"])
     ],
     setup_requires=setup_requirements,
     test_suite="tests",


### PR DESCRIPTION
`"run_tests.py"` is marked as a required data file for the package, but the file is now missing (seems to have been recently removed?).

So now running pip install on the repository throws an error:

```
  running install_data
  creating build/bdist.linux-x86_64/wheel/dials-0.0.1.data
  creating build/bdist.linux-x86_64/wheel/dials-0.0.1.data/data
  creating build/bdist.linux-x86_64/wheel/dials-0.0.1.data/data/dials
  copying conftest.py -> build/bdist.linux-x86_64/wheel/dials-0.0.1.data/data/dials
  copying __init__.py -> build/bdist.linux-x86_64/wheel/dials-0.0.1.data/data/dials
  copying libtbx_refresh.py -> build/bdist.linux-x86_64/wheel/dials-0.0.1.data/data/dials
  error: can't copy 'run_tests.py': doesn't exist or not a regular file
  ----------------------------------------
  ERROR: Failed building wheel for dials
Failed to build dials
ERROR: Could not build wheels for dials which use PEP 517 and cannot be installed directly
```

Removing the reference to `"run_tests.py"` fixes the error.