### PR TITLE
Strip out calls to nullify_format_instance

### DIFF
--- a/algorithms/integration/image_integrator.py
+++ b/algorithms/integration/image_integrator.py
@@ -266,13 +266,6 @@ class ManagerImage(object):
         frames = self.experiments[0].scan.get_array_range()
         self.manager = ReflectionManagerPerImage(frames, self.reflections)
 
-        # Parallel reading of HDF5 from the same handle is not allowed. Python
-        # multiprocessing is a bit messed up and used fork on linux so need to
-        # close and reopen file.
-        for exp in self.experiments:
-            if exp.imageset.reader().is_single_file_reader():
-                exp.imageset.reader().nullify_format_instance()
-
         # Set the initialization time
         self.time.initialize = time() - start_time
 

--- a/algorithms/integration/parallel_integrator.py
+++ b/algorithms/integration/parallel_integrator.py
@@ -566,11 +566,6 @@ class IntegrationManager(object):
             self.blocks, self.reflections, self.params.integration.mp.njobs
         )
 
-        # Parallel reading of HDF5 from the same handle is not allowed. Python
-        # multiprocessing is a bit messed up and used fork on linux so need to
-        # close and reopen file.
-        self.experiments.nullify_all_single_file_reader_format_instances()
-
     def task(self, index):
         """
         Get a task.
@@ -1039,11 +1034,6 @@ class ReferenceCalculatorManager(object):
         self.manager = SimpleReflectionManager(
             self.blocks, self.reflections, self.params.integration.mp.njobs
         )
-
-        # Parallel reading of HDF5 from the same handle is not allowed. Python
-        # multiprocessing is a bit messed up and used fork on linux so need to
-        # close and reopen file.
-        self.experiments.nullify_all_single_file_reader_format_instances()
 
     def task(self, index):
         """

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -575,13 +575,6 @@ class _Manager(object):
         # Create the reflection manager
         self.manager = ReflectionManager(self.jobs, self.reflections)
 
-        # Parallel reading of HDF5 from the same handle is not allowed. Python
-        # multiprocessing is a bit messed up and used fork on linux so need to
-        # close and reopen file.
-        for exp in self.experiments:
-            if exp.imageset.reader().is_single_file_reader():
-                exp.imageset.reader().nullify_format_instance()
-
         # Set the initialization time
         self.time.initialize = time() - start_time
 

--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -532,11 +532,6 @@ class ExtractSpots:
                 callback=process_output,
             )
         else:
-            # Hack to avoid the call to nullify_format_instance() in the case
-            # of HDF5 files, which shouldn't be necessary if we aren't using
-            # multiprocessing
-            # See https://github.com/dials/dials/issues/144
-            function.first = False
             for task in indices:
                 result = function(task)
                 assert len(pixel_labeller) == len(

--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -75,7 +75,6 @@ class ExtractPixelsFromImage:
         if self.mask is not None:
             detector = self.imageset.get_detector()
             assert len(self.mask) == len(detector)
-        self.first = True
 
     def __call__(self, index):
         """
@@ -83,14 +82,6 @@ class ExtractPixelsFromImage:
 
         :param index: The index of the image
         """
-        # Parallel reading of HDF5 from the same handle is not allowed. Python
-        # multiprocessing is a bit messed up and used fork on linux so need to
-        # close and reopen file.
-        if self.first:
-            if self.imageset.reader().is_single_file_reader():
-                self.imageset.reader().nullify_format_instance()
-            self.first = False
-
         # Get the frame number
         if isinstance(self.imageset, ImageSequence):
             frame = self.imageset.get_array_range()[0] + index

--- a/command_line/find_bad_pixels.py
+++ b/command_line/find_bad_pixels.py
@@ -151,10 +151,6 @@ def run(args=None):
             sys.exit("Image outside of scan range")
         images = params.images
 
-    # work around issues with HDF5 and multiprocessing
-    if hasattr(imageset.reader(), "nullify_format_instance"):
-        imageset.reader().nullify_format_instance()
-
     n = int(math.ceil(len(images) / params.nproc))
     chunks = [images[i : i + n] for i in range(0, len(images), n)]
 

--- a/newsfragments/1542.misc
+++ b/newsfragments/1542.misc
@@ -1,0 +1,1 @@
+Remove redundant calls to ``nullify_format_instance``.


### PR DESCRIPTION
We had problems in the past with the behaviour of HDF5 under forking/parallel reads e.g. #35 #144 https://github.com/dials/dials/commit/01463cc47d963d68bbd6e546c7fc6fbab3f1760d https://github.com/dials/dials/commit/2550f7c9f704b547901c064ea932141ba0dc9ead https://github.com/dials/dials/commit/b19510e7b50f5367dc49d0ae5fe80d7c9359f4ce https://github.com/dials/dials/commit/36f63d63f9c70139bd53950dc4eca05c56e2cfea and also #1539.

While testing [a fix](https://github.com/ndevenish/dxtbx/commit/20979a52945596d3dfe2cd2b5a3d9f6aed695551) to centralise this check I stripped out the behaviour of `nullify_format_instance` and found that... I couldn't reproduce any of the problems. After some [digging](https://forum.hdfgroup.org/t/hdf5-and-parallelism-with-fork-2/5225), it looks like in HDF5 [1.10.5](https://portal.hdfgroup.org/display/support/HDF5+1.10.5) this problem was fixed by:

> Added a new option to enable/disable using pread/pwrite instead of
      read/write in the sec2, log, and core VFDs.
 > This option is enabled by default when pread/pwrite are detected.

Which does reading/writing in a stateless way. So, all of these workaround hacks have become redundant.

Possibly.

All the tests I've run appear to pass - this doesn't remove the need for `nullify_format_instance` completely because there seem to be some vestigial problem with Lazy* formats https://github.com/cctbx/dxtbx/issues/245. Does anyone have any memories/documented cases where this broke before to run tests through also? Otherwise, I'd suggest that we put it in and see if any problems come up related to it.