### PR TITLE
Mask generation: remove unnecessary get_raw_data()

### DIFF
--- a/algorithms/spot_finding/factory.py
+++ b/algorithms/spot_finding/factory.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import pickle
 import time
@@ -8,10 +9,10 @@ from dxtbx.imageset import ImageSequence
 from iotbx.phil import parse
 
 import dials.extensions
+import dials.util.masking
 from dials.algorithms.background.simple import Linear2dModeller
 from dials.algorithms.spot_finding.finder import SpotFinder
 from dials.array_family import flex
-from dials.util.masking import MaskGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -439,8 +440,9 @@ class SpotFinderFactory:
         # Create the threshold strategy
         threshold_function = SpotFinderFactory.configure_threshold(params)
 
-        # Configure the mask generator
-        mask_generator = MaskGenerator(params.spotfinder.filter)
+        mask_generator = functools.partial(
+            dials.util.masking.generate_mask, params=params.spotfinder.filter
+        )
 
         # Make sure 'none' is interpreted as None
         if params.spotfinder.mp.method == "none":

--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -791,7 +791,7 @@ class SpotFinder:
         :return: The observed spots
         """
         # The input mask
-        mask = self.mask_generator.generate(imageset)
+        mask = self.mask_generator(imageset)
         if self.mask is not None:
             mask = tuple(m1 & m2 for m1, m2 in zip(mask, self.mask))
 

--- a/command_line/background.py
+++ b/command_line/background.py
@@ -9,11 +9,11 @@ import iotbx.phil
 from libtbx.phil import parse
 from scitbx import matrix
 
+import dials.util.masking
 from dials.algorithms.spot_finding.factory import SpotFinderFactory
 from dials.algorithms.spot_finding.factory import phil_scope as spot_phil
 from dials.array_family import flex
 from dials.util import Sorry, show_mail_handle_errors
-from dials.util.masking import MaskGenerator
 from dials.util.options import OptionParser, flatten_experiments
 
 help_message = """
@@ -154,8 +154,7 @@ def background(imageset, indx, n_bins, corrected=False, mask_params=None):
         # Default mask params for trusted range
         mask_params = phil_scope.fetch(parse("")).extract().masking
 
-    mask_generator = MaskGenerator(mask_params)
-    mask = mask_generator.generate(imageset)
+    mask = dials.util.masking.generate_mask(imageset, mask_params)
 
     detector = imageset.get_detector()
     beam = imageset.get_beam()

--- a/command_line/generate_mask.py
+++ b/command_line/generate_mask.py
@@ -33,7 +33,7 @@ from scitbx.array_family import flex
 
 import dials.util
 import dials.util.log
-from dials.util.masking import MaskGenerator
+import dials.util.masking
 from dials.util.options import OptionParser, flatten_experiments
 
 Masks = List[Tuple[flex.bool, ...]]
@@ -108,11 +108,8 @@ def generate_mask(
             for i in range(num_imagesets)
         ]
 
-    # Generate the mask
-    generator = MaskGenerator(params)
-
     for imageset, filename in zip(imagesets, filenames):
-        mask = generator.generate(imageset)
+        mask = dials.util.masking.generate_mask(imageset, params)
         masks.append(mask)
 
         # Save the mask to file

--- a/newsfragments/1156.removal
+++ b/newsfragments/1156.removal
@@ -1,1 +1,1 @@
-Remove deprecated `use_trusted_range` parameter in spotfinding
+Remove previously deprecated ``use_trusted_range=`` parameter from masking configuration

--- a/newsfragments/1156.removal
+++ b/newsfragments/1156.removal
@@ -1,0 +1,1 @@
+Remove deprecated `use_trusted_range` parameter in spotfinding

--- a/newsfragments/1449.bugfix
+++ b/newsfragments/1449.bugfix
@@ -1,1 +1,1 @@
-Remove unnecessary extra call to imageset.get_raw_data() for the first image in spotfinding.
+Remove unnecessary call to ``imageset.get_raw_data()`` while generating masks. This was causing performance issues when spotfinding.

--- a/newsfragments/1449.bugfix
+++ b/newsfragments/1449.bugfix
@@ -1,0 +1,1 @@
+Remove unnecessary extra call to imageset.get_raw_data() for the first image in spotfinding.

--- a/newsfragments/1569.removal
+++ b/newsfragments/1569.removal
@@ -1,0 +1,1 @@
+``dials.util.masking.MaskGenerator` is deprecated in favour of ``dials.util.masking.generate_mask``

--- a/test/util/test_masking.py
+++ b/test/util/test_masking.py
@@ -8,9 +8,9 @@ import libtbx
 from dxtbx.model.experiment_list import ExperimentListFactory
 from dxtbx.serialize import load
 
+import dials.util.masking
 from dials.algorithms.shadowing.filter import filter_shadowed_reflections
 from dials.array_family import flex
-from dials.util.masking import lru_equality_cache
 
 
 @pytest.mark.parametrize(
@@ -120,7 +120,7 @@ def test_lru_equality_cache_basic():
         callargs.append(arg)
         return result[-1]
 
-    fun = lru_equality_cache(maxsize=20)(_callappend)
+    fun = dials.util.masking.lru_equality_cache(maxsize=20)(_callappend)
     hits, misses, maxsize, currsize = fun.cache_info()
     assert hits == 0
     assert misses == 0
@@ -156,7 +156,7 @@ def test_lru_equality_cache_id():
     def _callappend(*arg):
         callargs.append(arg)
 
-    fun = lru_equality_cache(maxsize=1)(_callappend)
+    fun = dials.util.masking.lru_equality_cache(maxsize=1)(_callappend)
 
     class EqTester:
         def __init__(self, a):
@@ -175,3 +175,24 @@ def test_lru_equality_cache_id():
     fun(a)
     fun(b)
     assert fun.cache_info() == (1, 1, 1, 1)
+
+
+def test_generate_mask(dials_data):
+    imageset = load.imageset(
+        dials_data("centroid_test_data").join("sweep.json").strpath
+    )
+    params = dials.util.masking.phil_scope.extract()
+    params.border = 2
+    params.d_min = 1.5
+    params.d_max = 40
+    params.untrusted[0].rectangle = (500, 600, 700, 800)
+    params.untrusted[0].circle = (1000, 1200, 100)
+    params.untrusted[0].polygon = (1500, 1500, 1600, 1600, 1700, 1500, 1500, 1500)
+    params.untrusted[0].pixel = (1183, 1383)
+    params.resolution_range = [(3.1, 3.2), (5.1, 5.2)]
+    params.ice_rings.filter = True
+    mask = dials.util.masking.generate_mask(imageset, params)
+    assert len(mask) == len(imageset.get_detector())
+    for m, im in zip(mask, imageset.get_raw_data(0)):
+        assert m.all() == im.all()
+    assert mask[0].count(False) == 4060817

--- a/util/image_viewer/mask_frame.py
+++ b/util/image_viewer/mask_frame.py
@@ -11,6 +11,8 @@ from wxtbx.phil_controls.floatctrl import FloatCtrl as _FloatCtrl
 from wxtbx.phil_controls.intctrl import IntCtrl
 from wxtbx.phil_controls.strctrl import StrCtrl
 
+import dials.util.masking
+
 
 class FloatCtrl(_FloatCtrl):
 
@@ -665,24 +667,18 @@ class MaskSettingsPanel(wx.Panel):
             pickle.dump(mask, fh, protocol=pickle.HIGHEST_PROTOCOL)
 
     def OnSaveMaskParams(self, event):
-        from dials.util.masking import phil_scope
-
         file_name = self.params.output.mask_params
         with open(file_name, "w") as f:
             print("Saving parameters to %s" % file_name)
-            phil_scope.fetch_diff(phil_scope.format(self.params.masking)).show(f)
+            dials.util.masking.phil_scope.fetch_diff(
+                dials.util.masking.phil_scope.format(self.params.masking)
+            ).show(f)
 
     def UpdateMask(self):
-
         image_viewer_frame = self.GetParent().GetParent()
-
-        # Generate the mask
-        from dials.util.masking import MaskGenerator
-
-        generator = MaskGenerator(self.params.masking)
-        imageset = image_viewer_frame.imagesets[0]  # XXX
-        mask = generator.generate(imageset)
-
+        mask = dials.util.masking.generate_mask(
+            image_viewer_frame.imagesets[0], self.params.masking
+        )
         image_viewer_frame.mask_image_viewer = mask
         image_viewer_frame.update_settings(layout=False)
 

--- a/util/masking.py
+++ b/util/masking.py
@@ -195,6 +195,26 @@ def _apply_resolution_mask(mask, beam, panel, *args):
     _get_resolution_masker(beam, panel).apply(mask, *args)
 
 
+class MaskGenerator:
+    """
+    Deprecated interface for generating mask.
+
+    To be upgraded to UserWarning in DIALS 3.4.
+    To be removed in DIALS 3.5.
+    """
+
+    def __init__(self, params):
+        warnings.warn(
+            "MaskGenerator is deprecated; please use dials.util.masking.generate_mask instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.params = params
+
+    def generate(self, imageset):
+        return generate_mask(imageset, self.params)
+
+
 def generate_mask(
     imageset: ImageSet, params: libtbx.phil.scope_extract
 ) -> Tuple[flex.bool]:

--- a/util/masking.py
+++ b/util/masking.py
@@ -4,13 +4,16 @@ import logging
 import math
 import warnings
 from collections import namedtuple
+from typing import Tuple
 
+import libtbx.phil
 from cctbx import crystal
 from dxtbx.masking import (
     mask_untrusted_circle,
     mask_untrusted_polygon,
     mask_untrusted_rectangle,
 )
+from dxtbx.model import ImageSet
 from iotbx.phil import parse
 
 from dials.array_family import flex
@@ -192,164 +195,161 @@ def _apply_resolution_mask(mask, beam, panel, *args):
     _get_resolution_masker(beam, panel).apply(mask, *args)
 
 
-class MaskGenerator(object):
-    """Generate a mask."""
+def generate_mask(
+    imageset: ImageSet, params: libtbx.phil.scope_extract
+) -> Tuple[flex.bool]:
+    """Generate a mask based on the input parameters.
 
-    def __init__(self, params):
-        """Set the parameters."""
-        self.params = params
+    Args:
+      imageset (ImageSet): The imageset for which to generate a mask
+      params (libtbx.phil.scope_extract): The phil parameters for mask generation. This
+        should be an extract of `dials.util.masking.phil_scope`
+    """
+    # Get the detector and beam
+    detector = imageset.get_detector()
+    beam = imageset.get_beam()
 
-    def generate(self, imageset):
-        """Generate the mask."""
-        # Get the detector and beam
-        detector = imageset.get_detector()
-        beam = imageset.get_beam()
+    # Create the mask for each panel
+    masks = []
+    for index, panel in enumerate(detector):
 
-        # Create the mask for each panel
-        masks = []
-        for index, panel in enumerate(detector):
+        # Build a trusted mask by looking for pixels that are always outside
+        # the trusted range. This identifies bad pixels, but does not include
+        # pixels that are overloaded on some images.
+        if params.use_trusted_range:
+            warnings.warn(
+                "Checking for hot pixels using the trusted_range is"
+                " deprecated. https://github.com/dials/dials/issues/1156",
+                FutureWarning,
+            )
+            trusted_mask = None
+            low, high = panel.get_trusted_range()
 
-            # Build a trusted mask by looking for pixels that are always outside
-            # the trusted range. This identifies bad pixels, but does not include
-            # pixels that are overloaded on some images.
-            if self.params.use_trusted_range:
-                warnings.warn(
-                    "Checking for hot pixels using the trusted_range is"
-                    " deprecated. https://github.com/dials/dials/issues/1156",
-                    FutureWarning,
-                )
-                trusted_mask = None
-                low, high = panel.get_trusted_range()
+            # Take 10 evenly-spaced images from the imageset. Pixels outside
+            # the trusted mask on all of these images are considered bad and
+            # masked. https://github.com/dials/dials/issues/1061
+            stride = max(int(len(imageset) / 10), 1)
+            image_indices = range(0, len(imageset), stride)
 
-                # Take 10 evenly-spaced images from the imageset. Pixels outside
-                # the trusted mask on all of these images are considered bad and
-                # masked. https://github.com/dials/dials/issues/1061
-                stride = max(int(len(imageset) / 10), 1)
-                image_indices = range(0, len(imageset), stride)
+            for image_index in image_indices:
+                image_data = imageset.get_raw_data(image_index)[index].as_double()
+                frame_mask = (image_data > low) & (image_data < high)
+                if trusted_mask is None:
+                    trusted_mask = frame_mask
+                else:
+                    trusted_mask = trusted_mask | frame_mask
 
-                for image_index in image_indices:
-                    image_data = imageset.get_raw_data(image_index)[index].as_double()
-                    frame_mask = (image_data > low) & (image_data < high)
-                    if trusted_mask is None:
-                        trusted_mask = frame_mask
-                    else:
-                        trusted_mask = trusted_mask | frame_mask
+                if trusted_mask.count(False) == 0:
+                    break
+            mask = trusted_mask
+        else:
+            mask = flex.bool(flex.grid(reversed(panel.get_image_size())), True)
 
-                    if trusted_mask.count(False) == 0:
-                        break
-                mask = trusted_mask
-            else:
-                mask = flex.bool(flex.grid(reversed(panel.get_image_size())), True)
+        # Add a border around the image
+        if params.border > 0:
+            logger.debug(f"Generating border mask:\n border = {params.border}")
+            border = params.border
+            height, width = mask.all()
+            borderx = flex.bool(flex.grid(border, width), False)
+            bordery = flex.bool(flex.grid(height, border), False)
+            mask[0:border, :] = borderx
+            mask[-border:, :] = borderx
+            mask[:, 0:border] = bordery
+            mask[:, -border:] = bordery
 
-            # Add a border around the image
-            if self.params.border > 0:
-                logger.debug(f"Generating border mask:\n border = {self.params.border}")
-                border = self.params.border
-                height, width = mask.all()
-                borderx = flex.bool(flex.grid(border, width), False)
-                bordery = flex.bool(flex.grid(height, border), False)
-                mask[0:border, :] = borderx
-                mask[-border:, :] = borderx
-                mask[:, 0:border] = bordery
-                mask[:, -border:] = bordery
+        # Apply the untrusted regions
+        for region in params.untrusted:
+            if region.panel is None:
+                region.panel = 0
+            if region.panel == index:
+                if not any(
+                    [region.circle, region.rectangle, region.polygon, region.pixel]
+                ):
+                    mask[:, :] = flex.bool(flex.grid(mask.focus()), False)
+                    continue
 
-            # Apply the untrusted regions
-            for region in self.params.untrusted:
-                if region.panel is None:
-                    region.panel = 0
-                if region.panel == index:
-                    if not any(
-                        [region.circle, region.rectangle, region.polygon, region.pixel]
-                    ):
-                        mask[:, :] = flex.bool(flex.grid(mask.focus()), False)
-                        continue
-
-                    if region.circle is not None:
-                        xc, yc, radius = region.circle
-                        logger.debug(
-                            "Generating circle mask:\n"
-                            + f" panel = {region.panel}\n"
-                            + f" xc = {xc}\n"
-                            + f" yc = {yc}\n"
-                            + f" radius = {radius}"
-                        )
-                        mask_untrusted_circle(mask, xc, yc, radius)
-                    if region.rectangle is not None:
-                        x0, x1, y0, y1 = region.rectangle
-                        logger.debug(
-                            "Generating rectangle mask:\n"
-                            + f" panel = {region.panel}\n"
-                            + f" x0 = {x0}\n"
-                            + f" y0 = {y0}\n"
-                            + f" x1 = {x1}\n"
-                            + f" y1 = {y1}"
-                        )
-                        mask_untrusted_rectangle(mask, x0, x1, y0, y1)
-                    if region.polygon is not None:
-                        assert (
-                            len(region.polygon) % 2 == 0
-                        ), "Polygon must contain 2D coords"
-                        vertices = []
-                        for i in range(int(len(region.polygon) / 2)):
-                            x = region.polygon[2 * i]
-                            y = region.polygon[2 * i + 1]
-                            vertices.append((x, y))
-                        polygon = flex.vec2_double(vertices)
-                        logger.debug(
-                            f"Generating polygon mask:\n panel = {region.panel}\n"
-                            + "\n".join(f" coord = {vertex}" for vertex in vertices)
-                        )
-                        mask_untrusted_polygon(mask, polygon)
-                    if region.pixel is not None:
-                        mask[region.pixel] = False
-
-            # Generate high and low resolution masks
-            if self.params.d_min is not None:
-                logger.debug(
-                    f"Generating high resolution mask:\n d_min = {self.params.d_min}"
-                )
-                _apply_resolution_mask(mask, beam, panel, 0, self.params.d_min)
-            if self.params.d_max is not None:
-                logger.debug(
-                    f"Generating low resolution mask:\n d_max = {self.params.d_max}"
-                )
-                d_max = self.params.d_max
-                d_inf = max(d_max + 1, 1e9)
-                _apply_resolution_mask(mask, beam, panel, d_max, d_inf)
-
-            try:
-                # Mask out the resolution range
-                for drange in self.params.resolution_range:
-                    d_min = min(drange)
-                    d_max = max(drange)
-                    assert d_min < d_max, "d_min must be < d_max"
+                if region.circle is not None:
+                    xc, yc, radius = region.circle
                     logger.debug(
-                        "Generating resolution range mask:\n"
-                        + f" d_min = {d_min}\n"
-                        + f" d_max = {d_max}"
+                        "Generating circle mask:\n"
+                        + f" panel = {region.panel}\n"
+                        + f" xc = {xc}\n"
+                        + f" yc = {yc}\n"
+                        + f" radius = {radius}"
                     )
-                    _apply_resolution_mask(mask, beam, panel, d_min, d_max)
-            except TypeError:
-                # Catch the default value None of self.params.resolution_range
-                if any(self.params.resolution_range):
-                    raise
+                    mask_untrusted_circle(mask, xc, yc, radius)
+                if region.rectangle is not None:
+                    x0, x1, y0, y1 = region.rectangle
+                    logger.debug(
+                        "Generating rectangle mask:\n"
+                        + f" panel = {region.panel}\n"
+                        + f" x0 = {x0}\n"
+                        + f" y0 = {y0}\n"
+                        + f" x1 = {x1}\n"
+                        + f" y1 = {y1}"
+                    )
+                    mask_untrusted_rectangle(mask, x0, x1, y0, y1)
+                if region.polygon is not None:
+                    assert (
+                        len(region.polygon) % 2 == 0
+                    ), "Polygon must contain 2D coords"
+                    vertices = []
+                    for i in range(int(len(region.polygon) / 2)):
+                        x = region.polygon[2 * i]
+                        y = region.polygon[2 * i + 1]
+                        vertices.append((x, y))
+                    polygon = flex.vec2_double(vertices)
+                    logger.debug(
+                        f"Generating polygon mask:\n panel = {region.panel}\n"
+                        + "\n".join(f" coord = {vertex}" for vertex in vertices)
+                    )
+                    mask_untrusted_polygon(mask, polygon)
+                if region.pixel is not None:
+                    mask[region.pixel] = False
 
-            # Mask out the resolution ranges for the ice rings
-            for drange in generate_ice_ring_resolution_ranges(
-                beam, panel, self.params.ice_rings
-            ):
+        # Generate high and low resolution masks
+        if params.d_min is not None:
+            logger.debug(f"Generating high resolution mask:\n d_min = {params.d_min}")
+            _apply_resolution_mask(mask, beam, panel, 0, params.d_min)
+        if params.d_max is not None:
+            logger.debug(f"Generating low resolution mask:\n d_max = {params.d_max}")
+            d_max = params.d_max
+            d_inf = max(d_max + 1, 1e9)
+            _apply_resolution_mask(mask, beam, panel, d_max, d_inf)
+
+        try:
+            # Mask out the resolution range
+            for drange in params.resolution_range:
                 d_min = min(drange)
                 d_max = max(drange)
                 assert d_min < d_max, "d_min must be < d_max"
                 logger.debug(
-                    "Generating ice ring mask:\n"
-                    + f" d_min = {d_min:.4f}\n"
-                    + f" d_max = {d_max:.4f}"
+                    "Generating resolution range mask:\n"
+                    + f" d_min = {d_min}\n"
+                    + f" d_max = {d_max}"
                 )
                 _apply_resolution_mask(mask, beam, panel, d_min, d_max)
+        except TypeError:
+            # Catch the default value None of params.resolution_range
+            if any(params.resolution_range):
+                raise
 
-            # Add to the list
-            masks.append(mask)
+        # Mask out the resolution ranges for the ice rings
+        for drange in generate_ice_ring_resolution_ranges(
+            beam, panel, params.ice_rings
+        ):
+            d_min = min(drange)
+            d_max = max(drange)
+            assert d_min < d_max, "d_min must be < d_max"
+            logger.debug(
+                "Generating ice ring mask:\n"
+                + f" d_min = {d_min:.4f}\n"
+                + f" d_max = {d_max:.4f}"
+            )
+            _apply_resolution_mask(mask, beam, panel, d_min, d_max)
 
-        # Return the mask
-        return tuple(masks)
+        # Add to the list
+        masks.append(mask)
+
+    # Return the mask
+    return tuple(masks)

--- a/util/masking.py
+++ b/util/masking.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import math
+import warnings
 from collections import namedtuple
 from typing import Tuple
 

--- a/util/masking.py
+++ b/util/masking.py
@@ -205,13 +205,9 @@ class MaskGenerator(object):
         detector = imageset.get_detector()
         beam = imageset.get_beam()
 
-        # Get the first image
-        image = imageset.get_raw_data(0)
-        assert len(detector) == len(image)
-
         # Create the mask for each panel
         masks = []
-        for index, (im, panel) in enumerate(zip(image, detector)):
+        for index, panel in enumerate(detector):
 
             # Build a trusted mask by looking for pixels that are always outside
             # the trusted range. This identifies bad pixels, but does not include
@@ -243,7 +239,7 @@ class MaskGenerator(object):
                         break
                 mask = trusted_mask
             else:
-                mask = flex.bool(flex.grid(im.all()), True)
+                mask = flex.bool(flex.grid(reversed(panel.get_image_size())), True)
 
             # Add a border around the image
             if self.params.border > 0:


### PR DESCRIPTION
The mask generation code doesn't actually use the image data, but just uses the image to get the panel sizes - which are available in the panel object! This extra call to `imageset.get_raw_data()` for the first image of an imageset causes significant overhead e.g. to the per-image analysis service used at DLS.

Convert single-method class to a function.