### PR TITLE
re-enable Azure cache

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -21,6 +21,13 @@ jobs:
     displayName: syntax validation
     pool:
       vmImage: ubuntu-20.04
+
+    # Silence a warning. This can be removed in April 2021
+    # https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/percentEncoding.md
+    variables:
+    - name: DECODE_PERCENTS
+      value: true
+
     steps:
       - checkout: none
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
-  CACHE_VERSION: 20201102
-  ENABLE_CACHE: 0
+  CACHE_VERSION: 20210205
+  ENABLE_CACHE: 1
 
 schedules:
   # nightly builds to populate caches

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,4 +13,4 @@ comment:
   layout: "diff, flags"
   branches:
     - master
-  after_n_builds: 2
+  after_n_builds: 6

--- a/newsfragments/1582.misc
+++ b/newsfragments/1582.misc
@@ -1,0 +1,1 @@
+Re-enable build caches in Azure


### PR DESCRIPTION
We had those disabled for nearly 3 months in
1f1dbef
due to an Azure cache integrity bug.

It _looks_ like this is no longer an issue.