### PR TITLE
Use get_url_scheme

### DIFF
--- a/command_line/find_spots_client.py
+++ b/command_line/find_spots_client.py
@@ -13,6 +13,7 @@ import urllib.parse
 import urllib.request
 
 import libtbx.phil
+from dxtbx.util import get_url_scheme
 
 import dials.util
 
@@ -221,7 +222,7 @@ def run(args=None):
     filenames = []
     args = []
     for arg in mixed_args:
-        if urllib.parse.urlparse(arg).scheme:
+        if get_url_scheme(arg):
             # Make this look like a path. If you squint. And are looking away.
             filenames.append("/" + urllib.parse.quote(arg))
         else:

--- a/newsfragments/1583.bugfix
+++ b/newsfragments/1583.bugfix
@@ -1,0 +1,1 @@
+Fix importing using paths with wildcards on Windows

--- a/util/options.py
+++ b/util/options.py
@@ -11,11 +11,11 @@ from collections import defaultdict, namedtuple
 from glob import glob
 
 from orderedset import OrderedSet
-from six.moves.urllib.parse import urlparse
 
 import libtbx.phil
 from dxtbx.model import ExperimentList
 from dxtbx.model.experiment_list import ExperimentListFactory
+from dxtbx.util import get_url_scheme
 
 from dials.array_family import flex
 from dials.util import Sorry
@@ -267,7 +267,7 @@ class Importer(object):
         args_new = []
         for arg in args:
             # Don't expand wildcards if URI-style filename
-            if "*" in arg and not urlparse(arg).scheme:
+            if "*" in arg and not get_url_scheme(arg):
                 args_new.extend(glob(arg))
             else:
                 args_new.append(arg)
@@ -471,7 +471,7 @@ class PhilCommandParser(object):
                     else:
                         raise
             # Treat "has a schema" as "looks like a URL (not phil)
-            elif "=" in arg and not urlparse(arg).scheme:
+            elif "=" in arg and not get_url_scheme(arg):
                 try:
                     user_phils.append(interpretor.process_arg(arg=arg))
                 except Exception:


### PR DESCRIPTION
Correctly account for Windows paths by using `get_url_scheme`. Fixes #1583. Requires https://github.com/cctbx/dxtbx/pull/301.