### PR TITLE
DIALS 3.3.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,23 @@
+DIALS 3.3.4 (2021-03-05)
+========================
+
+Bugfixes
+--------
+
+- ``dials.import``: Selecting a subset of images with ``image_range=`` now works on stills (`#1592 <https://github.com/dials/dials/issues/1592>`_)
+- `dials.search_beam_centre`: Dramatically improved execution time for large data sets (`#1612 <https://github.com/dials/dials/issues/1612>`_)
+- ``dials.reindex``: Write ``.refl`` file output in the default
+  "MessagePack" format for better compatibility with downstream programs (`#1616 <https://github.com/dials/dials/issues/1616>`_)
+- ``dials.scale``: Fix rare memory crash from infinite loop, that could
+  occur with very bad quality datasets (`#1622 <https://github.com/dials/dials/issues/1622>`_)
+
+
+Improved Documentation
+----------------------
+
+- ``dials.refine``: More informative error message when reflections have weights of zero (`#1584 <https://github.com/dials/dials/issues/1584>`_)
+
+
 DIALS 3.3.3 (2021-02-15)
 ========================
 

--- a/algorithms/refinement/engine.py
+++ b/algorithms/refinement/engine.py
@@ -817,7 +817,7 @@ class GaussNewtonIterations(AdaptLstbx, normal_eqns_solving.iterations):
         log=None,
         tracking=None,
         max_iterations=20,
-        **kwds
+        **kwds,
     ):
 
         AdaptLstbx.__init__(
@@ -956,11 +956,11 @@ class LevenbergMarquardtIterations(GaussNewtonIterations):
         # early test for linear independence, require all right hand side elements to be non-zero
         RHS = self.step_equations().right_hand_side()
         if RHS.count(0.0) > 0:
+            p_names = [
+                b for a, b in zip(RHS, self._parameters.get_param_names()) if a == 0.0
+            ]
             raise DialsRefineRuntimeError(
-                r"""There is at least one normal equation with a right hand side of zero,
-meaning that the parameters are not all independent, and there is no unique
-solution.  Mathematically, some kind of row reduction needs to be performed
-before this can be solved."""
+                f"The normal equations have an indeterminate solution. The problematic parameters are {', '.join(p_names)}."
             )
 
         # return early if refinement is not possible

--- a/algorithms/refinement/weighting_strategies.py
+++ b/algorithms/refinement/weighting_strategies.py
@@ -20,6 +20,11 @@ class StatisticalWeightingStrategy(object):
             sel = w > 0.0
             w.set_selected(sel, 1.0 / w.select(sel))
         reflections["xyzobs.mm.weights"] = flex.vec3_double(*parts)
+        indexed = reflections.select(reflections.get_flags(reflections.flags.indexed))
+        if any(indexed["xyzobs.mm.weights"].norms() == 0.0):
+            raise DialsRefineConfigError(
+                "Cannot set statistical weights as some indexed reflections have observed variances equal to zero"
+            )
 
         return reflections
 

--- a/algorithms/scaling/combine_intensities.py
+++ b/algorithms/scaling/combine_intensities.py
@@ -145,7 +145,7 @@ class SingleDatasetIntensityCombiner(object):
             avg = flex.mean(raw_intensities)
             Imid = flex.max(raw_intensities) / 10.0
             Imid_list = [0, 1, avg, Imid]
-            while Imid > avg:
+            while (Imid > avg) and (Imid > 10):
                 Imid /= 10.0
                 Imid_list.append(Imid)
             self.Imids = Imid_list
@@ -337,7 +337,7 @@ class MultiDatasetIntensityCombiner(object):
             avg = flex.mean(raw_intensities)
             Imid = flex.max(raw_intensities) / 10.0
             Imid_list = [0, 1, avg, Imid]
-            while Imid > avg:
+            while (Imid > avg) and (Imid > 10):
                 Imid /= 10.0
                 Imid_list.append(Imid)
             self.Imids = Imid_list

--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -550,9 +550,19 @@ class MetaDataUpdater(object):
                 if imageset.get_scan().is_still():
                     # make lots of experiments all pointing at one
                     # image set
-                    start, end = imageset.get_scan().get_array_range()
+
+                    # check if user has overridden the input - if yes, recall
+                    # that these are in people numbers (1...) and are inclusive
+                    if self.params.geometry.scan.image_range:
+                        user_start, user_end = self.params.geometry.scan.image_range
+                        offset = imageset.get_scan().get_array_range()[0]
+                        start, end = user_start - 1, user_end
+                    else:
+                        start, end = imageset.get_scan().get_array_range()
+                        offset = 0
+
                     for j in range(start, end):
-                        subset = imageset[j : j + 1]
+                        subset = imageset[j - offset : j - offset + 1]
                         experiments.append(
                             Experiment(
                                 imageset=imageset,

--- a/command_line/reindex.py
+++ b/command_line/reindex.py
@@ -7,8 +7,6 @@ import copy
 import os
 import sys
 
-import six.moves.cPickle as pickle
-
 import iotbx.phil
 from cctbx import sgtbx
 from rstbx.symmetry.constraints import parameter_reduction
@@ -358,8 +356,7 @@ experiments file must also be specified with the option: reference= """
         reflections["miller_index"].set_selected(~sel, (0, 0, 0))
 
         print("Saving reindexed reflections to %s" % params.output.reflections)
-        with open(params.output.reflections, "wb") as fh:
-            pickle.dump(reflections, fh, protocol=pickle.HIGHEST_PROTOCOL)
+        reflections.as_file(params.output.reflections)
 
 
 if __name__ == "__main__":

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -259,7 +259,7 @@ def _get_origin_offset_score(
     trial_detector = dps_extended.get_new_detector(
         experiment.detector, trial_origin_offset
     )
-    experiment = copy.deepcopy(experiment)
+    experiment = copy.copy(experiment)
     experiment.detector = trial_detector
 
     # Key point for this is that the spots must correspond to detector

--- a/test/algorithms/refinement/test_stills_prediction_parameters.py
+++ b/test/algorithms/refinement/test_stills_prediction_parameters.py
@@ -120,6 +120,9 @@ class _Test(object):
         self.reflections = flex.reflection_table.empty_standard(len(rays))
         self.reflections.update(rays)
 
+        # Set dummy observed variances to allow statistical weights to be set
+        self.reflections["xyzobs.mm.variance"] += (1e-3, 1e-3, 1e-6)
+
     def get_fd_gradients(self, pred_param, ref_predictor):
 
         # get finite difference gradients

--- a/test/command_line/test_import.py
+++ b/test/command_line/test_import.py
@@ -316,10 +316,7 @@ def test_template_with_missing_image_fails(centroid_test_data_with_missing_image
     # This should fail because image #4 is missing
     for image_range in (None, (3, 5)):
         result = procrunner.run(
-            [
-                "dials.import",
-                f"template={centroid_test_data_with_missing_image}",
-            ]
+            ["dials.import", f"template={centroid_test_data_with_missing_image}"]
             + (["image_range=%i,%i" % image_range] if image_range else []),
             working_directory=centroid_test_data_with_missing_image.parent,
         )
@@ -395,6 +392,40 @@ def test_import_still_sequence_as_experiments_subset(dials_data, tmpdir):
 
     iset = set(exp.imageset for exp in imported_exp)
     assert len(iset) == 1
+
+    # verify scans, goniometers kept too
+    assert all(exp.scan.get_oscillation() == (10.0, 0.0) for exp in imported_exp)
+    assert all(exp.goniometer is not None for exp in imported_exp)
+
+
+def test_import_still_sequence_as_expts_subset_by_range(dials_data, tmp_path):
+    image_files = dials_data("centroid_test_data").listdir("centroid*.cbf", sort=True)
+
+    out = tmp_path / "experiments_as_still.expt"
+
+    result = procrunner.run(
+        [
+            "dials.import",
+            "scan.oscillation=10,0",
+            "image_range=3,5",
+            f"output.experiments={out}",
+            *image_files,
+        ],
+        working_directory=tmp_path,
+    )
+
+    assert result.returncode == 0
+
+    imported_exp = load.experiment_list(out)
+    assert len(imported_exp) == 3
+    for exp in imported_exp:
+        assert exp.identifier != ""
+
+    iset = set(exp.imageset for exp in imported_exp)
+    assert len(iset) == 1
+    assert len(imported_exp[0].imageset) == 3
+
+    assert list(iset)[0].get_image_identifier(0) == image_files[2].strpath
 
     # verify scans, goniometers kept too
     assert all(exp.scan.get_oscillation() == (10.0, 0.0) for exp in imported_exp)

--- a/test/command_line/test_reindex.py
+++ b/test/command_line/test_reindex.py
@@ -101,6 +101,14 @@ def test_reindex(dials_regression, tmpdir):
         new_experiments2[0].crystal.get_A()
     )
 
+    # verify that the file can be read by dials.show
+    commands = [
+        "dials.show",
+        tmpdir.join("reindexed.refl").strpath,
+    ]
+    result = procrunner.run(commands, working_directory=tmpdir)
+    assert not result.returncode and not result.stderr
+
 
 def test_reindex_multi_sequence(dials_regression, tmpdir):
     data_dir = os.path.join(dials_regression, "indexing_test_data", "multi_sweep")


### PR DESCRIPTION
Bugfixes
--------

- ``dials.import``: Selecting a subset of images with ``image_range=`` now works on stills (#1592)
- `dials.search_beam_centre`: Dramatically improved execution time for large data sets (#1612)
- ``dials.reindex``: Write ``.refl`` file output in the default "MessagePack" format for better compatibility with downstream programs (#1616)
- ``dials.scale``: Fix rare memory crash from infinite loop, that could occur with very bad quality datasets (#1622)


Improved Documentation
----------------------

- ``dials.refine``: More informative error message when reflections have weights of zero (#1584)