### PR TITLE
DIALS 3.4.1

### DIFF
--- a/algorithms/integration/report.py
+++ b/algorithms/integration/report.py
@@ -148,7 +148,7 @@ def generate_integration_report(experiment, reflections, n_resolution_bins=20):
 
         try:
             report["rmsd_xy"] = list(
-                indexer_sum.mean(data["xyz.rmsd"].select(data["int"]))
+                indexer_sum.mean(data["xyz.rmsd"].select(data["sum"]))
             )
         except Exception:
             report["rmsd_xy"] = [0.0] * len(binner)

--- a/algorithms/symmetry/__init__.py
+++ b/algorithms/symmetry/__init__.py
@@ -304,7 +304,10 @@ class symmetry_base:
             d_min = resolution_filter_from_array(
                 self.intensities, min_i_mean_over_sigma_mean, min_cc_half
             )
-            logger.info("High resolution limit set to: %.2f", d_min)
+            if d_min is not None:
+                logger.info("High resolution limit set to: %.2f", d_min)
+            else:
+                logger.info("High resolution limit set to: None")
         if d_min is not None:
             sel = self.intensities.resolution_filter_selection(d_min=d_min)
             self.intensities = self.intensities.select(sel).set_info(

--- a/algorithms/symmetry/cosym/engine.py
+++ b/algorithms/symmetry/cosym/engine.py
@@ -121,11 +121,15 @@ def minimize_scipy(
       coords (np.array): The starting coordinates for
         minimisation.
     """
-
+    options = {}
+    if max_iterations:
+        options.update(maxiter=max_iterations)
+    if max_calls:
+        options.update(maxfun=max_calls)
     return scipy.optimize.minimize(
         fun=target.compute_functional,
         x0=coords,
         jac=target.compute_gradients,
         method=method,
-        options=dict(maxiter=max_iterations, maxfun=max_calls),
+        options=options,
     )

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -294,9 +294,9 @@ class Target:
                 else:
                     wij_matrix += wij
 
-        rij_matrix = rij_matrix.todense().astype(np.float64)
+        rij_matrix = rij_matrix.toarray().astype(np.float64)
         if wij_matrix is not None:
-            wij_matrix = wij_matrix.todense().astype(np.float64)
+            wij_matrix = wij_matrix.toarray().astype(np.float64)
             if self._weights == "standard_error":
                 # http://www.sjsu.edu/faculty/gerstman/StatPrimer/correlation.pdf
                 sel = np.where(wij_matrix > 2)
@@ -319,15 +319,10 @@ class Target:
           f (float): The value of the target function at coordinates `x`.
         """
         assert (x.size // self.dim) == (len(self._lattices) * len(self.sym_ops))
-        inner = np.copy(self.rij_matrix)
-        NN = x.size // self.dim
-        for i in range(self.dim):
-            coord = x[i * NN : (i + 1) * NN]
-            outer_prod = np.outer(coord, coord)
-            inner -= outer_prod
-        elements = np.power(inner, 2)
+        x = x.reshape((self.dim, x.size // self.dim))
+        elements = np.square(self.rij_matrix - x.T @ x)
         if self.wij_matrix is not None:
-            elements = np.multiply(self.wij_matrix, elements)
+            np.multiply(self.wij_matrix, elements, out=elements)
         f = 0.5 * elements.sum()
         return f
 
@@ -371,32 +366,13 @@ class Target:
           f: The value of the target function at coordinates `x`.
           grad: The gradients of the target function with respect to the parameters.
         """
-        grad = np.empty(x.shape)
+        x = x.reshape((self.dim, x.size // self.dim))
         if self.wij_matrix is not None:
             wrij_matrix = np.multiply(self.wij_matrix, self.rij_matrix)
+            grad = -2 * x @ (wrij_matrix - np.multiply(self.wij_matrix, x.T @ x))
         else:
-            wrij_matrix = self.rij_matrix
-
-        coords = []
-        NN = x.size // self.dim
-        for i in range(self.dim):
-            coords.append(x[i * NN : (i + 1) * NN])
-
-        # term 1
-        for i in range(self.dim):
-            grad[i * NN : (i + 1) * NN] = np.matmul(wrij_matrix, coords[i])
-
-        for i in range(self.dim):
-            tmp_array = np.empty(x.shape)
-            tmp = np.outer(coords[i], coords[i])
-            if self.wij_matrix is not None:
-                tmp = np.multiply(self.wij_matrix, tmp)
-            for j in range(self.dim):
-                tmp_array[j * NN : (j + 1) * NN] = np.matmul(tmp, coords[j])
-            grad -= tmp_array
-        grad *= -2
-
-        return grad
+            grad = -2 * x @ (self.rij_matrix - x.T @ x)
+        return grad.flatten()
 
     def curvatures(self, x: np.ndarray) -> np.ndarray:
         """Compute the curvature of the target function at coordinates `x`.
@@ -411,18 +387,13 @@ class Target:
           curvs (np.ndarray):
           The curvature of the target function with respect to the parameters.
         """
-        NN = x.size // self.dim
-        curvs = np.empty(x.shape)
         if self.wij_matrix is not None:
             wij = self.wij_matrix
         else:
             wij = np.ones(self.rij_matrix.shape)
-        for i in range(self.dim):
-            curvs[i * NN : (i + 1) * NN] = np.matmul(
-                wij, np.power(x[i * NN : (i + 1) * NN], 2)
-            )
-        curvs *= 2
-        return curvs
+        x = x.reshape((self.dim, x.size // self.dim))
+        curvs = 2 * np.square(x) @ wij
+        return curvs.flatten()
 
     def curvatures_fd(self, x: np.ndarray, eps=1e-6) -> np.ndarray:
         """Compute the curvatures at coordinates `x` using finite differences.

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -248,10 +248,10 @@ class Target:
                             if corr.is_well_defined():
                                 cc = corr.coefficient()
                                 n = corr.n()
-                                rij_cache[key] = (cc, n)
                             else:
                                 cc = None
                                 n = None
+                            rij_cache[key] = (cc, n)
 
                         if (
                             n is None

--- a/algorithms/symmetry/cosym/test_cosym_target.py
+++ b/algorithms/symmetry/cosym/test_cosym_target.py
@@ -40,6 +40,10 @@ def test_cosym_target(space_group):
         c_fd = t.curvatures_fd(x, eps=1e-3)
         assert list(c) == pytest.approx(c_fd, rel=0.8e-1)
 
+        if weights == "count":
+            # Absolute upper limit on weights
+            assert t.wij_matrix.max() <= datasets[0].size()
+
         minimizer = engine.lbfgs_with_curvs(target=t, coords=x)
         # check functional has decreased and gradients are approximately zero
         f = t.compute_functional(minimizer.coords)

--- a/algorithms/symmetry/cosym/test_cosym_target.py
+++ b/algorithms/symmetry/cosym/test_cosym_target.py
@@ -33,9 +33,7 @@ def test_cosym_target(space_group):
         f0 = t.compute_functional(x)
         g = t.compute_gradients(x)
         g_fd = t.compute_gradients_fd(x)
-        for n, value in enumerate(zip(g, g_fd)):
-            assert value[0] == pytest.approx(value[1], rel=2e-3), n
-
+        np.testing.assert_allclose(g, g_fd, rtol=2e-3)
         c = t.curvatures(x)
         c_fd = t.curvatures_fd(x, eps=1e-3)
         assert list(c) == pytest.approx(c_fd, rel=0.8e-1)

--- a/newsfragments/1634.bugfix
+++ b/newsfragments/1634.bugfix
@@ -1,0 +1,1 @@
+``dials.cosym``: Cache cases where Rij is undefined, rather than recalculating each time. This can have significant performance benefits when handling large numbers of sparse data sets.

--- a/newsfragments/1635.bugfix
+++ b/newsfragments/1635.bugfix
@@ -1,0 +1,1 @@
+``dials.cosym``: Fix factor of 2 error when calculating target weights

--- a/newsfragments/1636.bugfix
+++ b/newsfragments/1636.bugfix
@@ -1,0 +1,1 @@
+``dials.cosym``: Fix broken ``engine=scipy`` option

--- a/newsfragments/1639.feature
+++ b/newsfragments/1639.feature
@@ -1,0 +1,1 @@
+``dials.cosym``: Significantly faster via improved computation of functional, gradients and curvatures

--- a/newsfragments/1640.bugfix
+++ b/newsfragments/1640.bugfix
@@ -1,0 +1,1 @@
+``dials.integrate``: Reject reflections with a high number of invalid pixels, which were being integrated since 3.4.0. This restores better merging statistics, and prevents many reflections being incorrect profiled as zero-intensity.

--- a/newsfragments/1640.feature
+++ b/newsfragments/1640.feature
@@ -1,0 +1,1 @@
+``dials.integrate``: Added parameter ``valid_foreground_threshold=``, to require a minimum fraction of valid pixels before profile fitting is attempted

--- a/newsfragments/1641.bugfix
+++ b/newsfragments/1641.bugfix
@@ -1,0 +1,1 @@
+Fix rare crash in symmetry calculations when no resolution limit could be calculated

--- a/test/command_line/test_cosym.py
+++ b/test/command_line/test_cosym.py
@@ -13,10 +13,12 @@ from dials.array_family import flex
 from dials.util import Sorry
 
 
-@pytest.mark.parametrize("space_group", [None, "P 1", "P 4"])
-def test_cosym(dials_data, run_in_tmpdir, space_group):
+@pytest.mark.parametrize(
+    "space_group,engine", [(None, "scitbx"), ("P 1", "scipy"), ("P 4", "scipy")]
+)
+def test_cosym(dials_data, run_in_tmpdir, space_group, engine):
     mcp = dials_data("multi_crystal_proteinase_k")
-    args = ["space_group=" + str(space_group), "seed=0"]
+    args = ["space_group=" + str(space_group), "seed=0", f"engine={engine}"]
     for i in [1, 2, 3, 4, 5, 7, 8, 10]:
         args.append(mcp.join("experiments_%d.json" % i).strpath)
         args.append(mcp.join("reflections_%d.pickle" % i).strpath)


### PR DESCRIPTION
Features
--------

- ``dials.cosym``: Significantly faster via improved computation of functional, gradients and curvatures (#1639)
- ``dials.integrate``: Added parameter ``valid_foreground_threshold=``, to require a minimum fraction of valid pixels before profile fitting is attempted (#1640)


Bugfixes
--------

- ``dials.cosym``: Cache cases where Rij is undefined, rather than recalculating each time. This can have significant performance benefits when handling large numbers of sparse data sets. (#1634)
- ``dials.cosym``: Fix factor of 2 error when calculating target weights (#1635)
- ``dials.cosym``: Fix broken ``engine=scipy`` option (#1636)
- ``dials.integrate``: Reject reflections with a high number of invalid pixels, which were being integrated since 3.4.0. This restores better merging statistics, and prevents many reflections being incorrect profiled as zero-intensity. (#1640)
- Fix rare crash in symmetry calculations when no resolution limit could be calculated (#1641)