### PR TITLE
In profile-fitted integration, don't integrate reflections with a high fraction of invalid pixels.

### DIFF
--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -184,6 +184,12 @@ def generate_phil_scope():
           .type = bool
           .help = "Use profile fitting if available"
 
+        valid_foreground_threshold = 0.6
+          .type = float(value_min=0, value_max=1)
+          .help = "The minimum fraction of foreground pixels that must be valid"
+                  "in order for a reflection to be integrated by profile fitting."
+          .expert_level = 2
+
         sigma_b_multiplier = 2.0
           .type = float(value_min=1.0)
           .help = "Background box expansion factor"
@@ -356,6 +362,7 @@ class Parameters:
         def __init__(self):
             self.fitting = True
             self.sigma_b_multiplier = 2.0
+            self.valid_foreground_threshold = 0.6
             self.validation = Parameters.Profile.Validation()
 
     def __init__(self):
@@ -421,6 +428,9 @@ class Parameters:
 
         # Profile parameters
         result.profile.sigma_b_multiplier = params.profile.sigma_b_multiplier
+        result.profile.valid_foreground_threshold = (
+            params.profile.valid_foreground_threshold
+        )
 
         # Get the min zeta filter
         result.filter.min_zeta = params.filter.min_zeta
@@ -807,7 +817,9 @@ class IntegratorExecutor(Executor):
     The class to process the integration data
     """
 
-    def __init__(self, experiments, profile_fitter=None):
+    def __init__(
+        self, experiments, profile_fitter=None, valid_foreground_threshold=0.6
+    ):
         """
         Initialize the executor
 
@@ -816,6 +828,7 @@ class IntegratorExecutor(Executor):
         self.experiments = experiments
         self.overlaps = None
         self.profile_fitter = profile_fitter
+        self.valid_foreground_threshold = valid_foreground_threshold
         super().__init__()
 
     def initialize(self, frame0, frame1, reflections):
@@ -880,15 +893,24 @@ class IntegratorExecutor(Executor):
         # Check for invalid pixels in foreground/background
         reflections.contains_invalid_pixels()
 
+        # Exclude reflections where a high fraction of the foreground is masked
+        # e.g. due to a panel edge, as this will make the fitting unreliable.
+        sbox = reflections["shoebox"]
+        nvalfg = sbox.count_mask_values(MaskCode.Valid | MaskCode.Foreground)
+        nforeg = sbox.count_mask_values(MaskCode.Foreground)
+        fraction_valid = nvalfg.as_double() / nforeg.as_double()
+        selection = fraction_valid < self.valid_foreground_threshold
+        reflections.set_flags(selection, reflections.flags.dont_integrate)
+
         # Process the data
         reflections.compute_background(self.experiments)
         reflections.compute_centroid(self.experiments)
+
         reflections.compute_summed_intensity()
         if self.profile_fitter:
             reflections.compute_fitted_intensity(self.profile_fitter)
 
         # Compute the number of background/foreground pixels
-        sbox = reflections["shoebox"]
         reflections["num_pixels.valid"] = sbox.count_mask_values(MaskCode.Valid)
         reflections["num_pixels.background"] = sbox.count_mask_values(
             MaskCode.Valid | MaskCode.Background
@@ -896,9 +918,7 @@ class IntegratorExecutor(Executor):
         reflections["num_pixels.background_used"] = sbox.count_mask_values(
             MaskCode.Valid | MaskCode.Background | MaskCode.BackgroundUsed
         )
-        reflections["num_pixels.foreground"] = sbox.count_mask_values(
-            MaskCode.Valid | MaskCode.Foreground
-        )
+        reflections["num_pixels.foreground"] = nvalfg
 
         # Print some info
         fmt = " Integrated % 5d (sum) + % 5d (prf) / %5d reflections on image %d"
@@ -1174,7 +1194,11 @@ class Integrator:
         logger.info("")
 
         # Create the data processor
-        executor = IntegratorExecutor(self.experiments, profile_fitter)
+        executor = IntegratorExecutor(
+            self.experiments,
+            profile_fitter,
+            self.params.profile.valid_foreground_threshold,
+        )
 
         # determine the max memory needed during integration
         def _determine_max_memory_needed(experiments, reflections):

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -362,7 +362,7 @@ class Parameters:
         def __init__(self):
             self.fitting = True
             self.sigma_b_multiplier = 2.0
-            self.valid_foreground_threshold = 0.6
+            self.valid_foreground_threshold = 0.75
             self.validation = Parameters.Profile.Validation()
 
     def __init__(self):
@@ -818,7 +818,7 @@ class IntegratorExecutor(Executor):
     """
 
     def __init__(
-        self, experiments, profile_fitter=None, valid_foreground_threshold=0.6
+        self, experiments, profile_fitter=None, valid_foreground_threshold=0.75
     ):
         """
         Initialize the executor

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -901,6 +901,10 @@ class IntegratorExecutor(Executor):
         fraction_valid = nvalfg.as_double() / nforeg.as_double()
         selection = fraction_valid < self.valid_foreground_threshold
         reflections.set_flags(selection, reflections.flags.dont_integrate)
+        logger.debug(
+            f"{selection.count(True)} reflections have"
+            " a fraction of valid pixels below the valid foreground threshold"
+        )
 
         # Process the data
         reflections.compute_background(self.experiments)

--- a/algorithms/integration/integrator.py
+++ b/algorithms/integration/integrator.py
@@ -184,7 +184,7 @@ def generate_phil_scope():
           .type = bool
           .help = "Use profile fitting if available"
 
-        valid_foreground_threshold = 0.6
+        valid_foreground_threshold = 0.75
           .type = float(value_min=0, value_max=1)
           .help = "The minimum fraction of foreground pixels that must be valid"
                   "in order for a reflection to be integrated by profile fitting."

--- a/algorithms/integration/report.py
+++ b/algorithms/integration/report.py
@@ -148,7 +148,7 @@ def generate_integration_report(experiment, reflections, n_resolution_bins=20):
 
         try:
             report["rmsd_xy"] = list(
-                indexer_sum.mean(data["xyz.rmsd"].select(data["int"]))
+                indexer_sum.mean(data["xyz.rmsd"].select(data["sum"]))
             )
         except Exception:
             report["rmsd_xy"] = [0.0] * len(binner)

--- a/newsfragments/1640.bugfix
+++ b/newsfragments/1640.bugfix
@@ -1,2 +1,1 @@
-``dials.integrate``: Place a lower limit (0.75) on the fraction of a reflection's pixels
-that must be valid (not masked) in order for it to be profile-fitted in integration.
+``dials.integrate``: Reject reflections with a high number of invalid pixels, which were being integrated since 3.4.0. This restores better merging statistics, and prevents many reflections being incorrect profiled as zero-intensity.

--- a/newsfragments/1640.bugfix
+++ b/newsfragments/1640.bugfix
@@ -1,0 +1,2 @@
+``dials.integrate``: Place a lower limit (0.75) on the fraction of a reflection's pixels
+that must be valid (not masked) in order for it to be profile-fitted in integration.

--- a/newsfragments/1640.feature
+++ b/newsfragments/1640.feature
@@ -1,0 +1,1 @@
+``dials.integrate``: Added parameter ``valid_foreground_threshold=``, to require a minimum fraction of valid pixels before profile fitting is attempted


### PR DESCRIPTION
For profile-fitted integration, only integrate reflections that have a high fraction of valid foreground pixels (currently set to ~~0.6~~ 0.75). Controlled by parameter valid_foreground_threshold (range 0 -> 1). For #1638.

This is intended so that reflections which have centroids in the panel gaps are not integrated by profile fitting. In my opinion the default parameter should be at least 0.5 so that the peak centre is approximately observed. Perhaps a higher threshold such as 0.75 is more appropriate, I plan to investigate how the data quality is affected depending on the threshold value.