### PR TITLE
DIALS 3.4.2

### DIFF
--- a/algorithms/integration/image_integrator.py
+++ b/algorithms/integration/image_integrator.py
@@ -6,6 +6,7 @@ import dials.algorithms.integration
 from dials.algorithms.integration.processor import job
 from dials.model.data import ImageVolume, MultiPanelImageVolume, make_image
 from dials.util import log
+from dials.util.log import rehandle_cached_records
 from dials.util.mp import multi_node_parallel_map
 from dials_algorithms_integration_integrator_ext import ReflectionManagerPerImage
 
@@ -71,8 +72,7 @@ class ProcessorImage:
         if mp_nproc > 1:
 
             def process_output(result):
-                for message in result[1]:
-                    logger.handle(message)
+                rehandle_cached_records(result[1])
                 self.manager.accumulate(result[0])
                 result[0].reflections = None
                 result[0].data = None
@@ -82,7 +82,7 @@ class ProcessorImage:
                 result = task()
                 handlers = logging.getLogger("dials").handlers
                 assert len(handlers) == 1, "Invalid number of logging handlers"
-                return result, handlers[0].messages()
+                return result, handlers[0].records
 
             multi_node_parallel_map(
                 func=execute_task,

--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -15,6 +15,7 @@ import dials.util.log
 from dials.array_family import flex
 from dials.model.data import make_image
 from dials.util import tabulate
+from dials.util.log import rehandle_cached_records
 from dials.util.mp import available_cores, multi_node_parallel_map
 from dials_algorithms_integration_integrator_ext import (
     Executor,
@@ -208,7 +209,7 @@ def execute_parallel_task(task):
     result = task()
     handlers = logging.getLogger("dials").handlers
     assert len(handlers) == 1, "Invalid number of logging handlers"
-    return result, handlers[0].messages()
+    return result, handlers[0].records
 
 
 class _Processor:
@@ -283,8 +284,7 @@ class _Processor:
         if mp_njobs * mp_nproc > 1:
 
             def process_output(result):
-                for message in result[1]:
-                    logger.handle(message)
+                rehandle_cached_records(result[1])
                 self.manager.accumulate(result[0])
 
             multi_node_parallel_map(

--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -17,6 +17,7 @@ from dxtbx.model import ExperimentList
 from dials.array_family import flex
 from dials.model.data import PixelList, PixelListLabeller
 from dials.util import Sorry, log
+from dials.util.log import rehandle_cached_records
 from dials.util.mp import available_cores, batch_multi_node_parallel_map
 
 logger = logging.getLogger(__name__)
@@ -253,7 +254,7 @@ class ExtractSpotsParallelTask:
         result = self.function(task)
         handlers = logging.getLogger("dials").handlers
         assert len(handlers) == 1, "Invalid number of logging handlers"
-        return result, handlers[0].messages()
+        return result, handlers[0].records
 
 
 def pixel_list_to_shoeboxes(
@@ -497,8 +498,7 @@ class ExtractSpots:
         if mp_nproc > 1 or mp_njobs > 1:
 
             def process_output(result):
-                for message in result[1]:
-                    logger.handle(message)
+                rehandle_cached_records(result[1])
                 assert len(pixel_labeller) == len(result[0]), "Inconsistent size"
                 for plabeller, plist in zip(pixel_labeller, result[0]):
                     plabeller.add(plist)

--- a/newsfragments/1645.bugfix
+++ b/newsfragments/1645.bugfix
@@ -1,0 +1,1 @@
+Log messages from spot finding and integration no longer ignore logging level when using ``nproc > 1``. This mainly affects usage of dials from outside contexts.

--- a/test/util/test_log.py
+++ b/test/util/test_log.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Any, List
 
 import dials.util.log
+from dials.util.mp import batch_multi_node_parallel_map, multi_node_parallel_map
 
 
 def test_LoggingContext():
@@ -33,3 +35,70 @@ def test_LoggingContext():
     # check logging levels are as they were before
     assert idx_logger.getEffectiveLevel() == logging.DEBUG
     assert dials_logger.getEffectiveLevel() == logging.DEBUG
+
+
+def test_cached_log_records(caplog):
+    test_log_message = "Here's a test log message."
+
+    def log_something(_: Any) -> List[logging.LogRecord]:
+        """
+        Create a dummy info log record.
+
+        A little dummy function to pass to the dials.util.mp parallel map functions,
+        which simply logs a single info message.
+
+        Args:
+            _:  Absorb the expected argument and do nothing with it.
+
+        Returns:
+            The log records created during the calling of this function.
+        """
+        dials.util.log.config_simple_cached()
+        logger = logging.getLogger("dials")
+        logger.info(test_log_message)
+        (handler,) = logger.handlers
+        return handler.records
+
+    # Generate some cached log messages in easy_mp child processes.
+    results = multi_node_parallel_map(
+        log_something,
+        iterable=range(5),
+        njobs=2,
+        nproc=2,
+        cluster_method="multiprocessing",
+    )
+    # Get all the resulting log records in a single flattened list.
+    results = [record for records in results for record in records]
+
+    results_batch = batch_multi_node_parallel_map(
+        log_something,
+        range(5),
+        njobs=2,
+        nproc=2,
+        cluster_method="multiprocessing",
+        callback=lambda _: None,
+    )
+    # Get all the resulting log records in a single flattened list.
+    results_batch = [
+        record for batch in results_batch for records in batch for record in records
+    ]
+
+    # Check that re-handling the messages in a logger in this process with a
+    # threshold severity of WARNING results in no log records being emitted.
+    with dials.util.log.LoggingContext("dials", logging.WARNING):
+        dials.util.log.rehandle_cached_records(results)
+        assert not caplog.records
+
+        dials.util.log.rehandle_cached_records(results_batch)
+        assert not caplog.records
+
+    # Check that re-handling the messages in a logger in this process with a
+    # threshold severity of INFO results in all the log records being emitted.
+    with dials.util.log.LoggingContext("dials", logging.INFO):
+        dials.util.log.rehandle_cached_records(results)
+        assert caplog.records == results
+        caplog.clear()
+
+        dials.util.log.rehandle_cached_records(results_batch)
+        assert caplog.records == results_batch
+        caplog.clear()

--- a/util/log.py
+++ b/util/log.py
@@ -2,6 +2,7 @@ import logging.config
 import os
 import sys
 import time
+from typing import List
 
 try:
     from colorlog import ColoredFormatter
@@ -101,7 +102,7 @@ class CacheHandler(logging.Handler):
         Initialise the handler
         """
         super().__init__()
-        self._messages = []
+        self.records = []
 
     def emit(self, record):
         """
@@ -109,10 +110,7 @@ class CacheHandler(logging.Handler):
 
         :param record: The log record
         """
-        self._messages.append(record)
-
-    def messages(self):
-        return self._messages
+        self.records.append(record)
 
 
 def config_simple_cached():
@@ -133,6 +131,23 @@ def config_simple_cached():
             },
         }
     )
+
+
+def rehandle_cached_records(records: List[logging.LogRecord]) -> None:
+    """
+    Submit cached log records to the relevant loggers for handling.
+
+    Because the relevant logger's threshold log level may be higher than when the
+    original log message was created and cached, the record will only be re-handled
+    if its level meets the new threshold.
+
+    Args:
+        records:  Cached log records.
+    """
+    for record in records:
+        record_logger = logging.getLogger(record.name)
+        if record_logger.isEnabledFor(record.levelno):
+            record_logger.handle(record)
 
 
 _banner = (


### PR DESCRIPTION
Bugfixes
--------

- Log messages from spot finding and integration no longer ignore logging level when using ``nproc > 1``. This mainly affects usage of dials from outside contexts. (#1645)