### PR TITLE
DIALS 3.4.3

### DIFF
--- a/algorithms/scaling/active_parameter_managers.py
+++ b/algorithms/scaling/active_parameter_managers.py
@@ -74,6 +74,12 @@ class active_parameter_manager:
         """Get method for refinement engine access."""
         return self.x
 
+    def get_param_names(self):
+        l = []
+        for name, data in self.components.items():
+            l.extend([name + f"_param{j}" for j in range(data["n_params"])])
+        return l
+
     def calculate_model_state_uncertainties(self, var_cov):
         """Set var_cov matrices for each component to allow later calculation
         of errors."""
@@ -171,6 +177,13 @@ class multi_active_parameter_manager(TargetInterface):
     def get_param_vals(self):
         """Get method for refinement engine access."""
         return self.x
+
+    def get_param_names(self):
+        l = []
+        for i, apm in enumerate(self.apm_list):
+            for name, data in apm.components.items():
+                l.extend([name + f"_expt{i}_param{j}" for j in range(data["n_params"])])
+        return l
 
     def set_param_esds(self, esds):
         """Set the estimated standard deviations of the parameters."""

--- a/algorithms/scaling/scaler.py
+++ b/algorithms/scaling/scaler.py
@@ -45,6 +45,7 @@ from dials.algorithms.scaling.scaling_library import (
 )
 from dials.algorithms.scaling.scaling_refiner import scaling_refinery
 from dials.algorithms.scaling.scaling_utilities import (
+    BadDatasetForScalingException,
     DialsMergingStatisticsError,
     log_memory_usage,
 )
@@ -885,6 +886,8 @@ class MultiScalerBase(ScalerBase):
         #    self._experiment = scalers[0].experiments
         assert len(scalers) == initial_number - len(n_list)
         logger.info("Removed datasets: %s", n_list)
+        if not self.active_scalers:
+            raise ValueError("No datasets remain after filtering out bad datasets.")
 
     def get_free_set_reflections(self):
         """Get all reflections in the free set if it exists."""
@@ -1293,19 +1296,31 @@ class MultiScalerBase(ScalerBase):
             logger.info(tabulate(rows, header))
 
         elif self.params.reflection_selection.method == "intensity_ranges":
-            for scaler in self.active_scalers:
-                overall_scaling_selection = calculate_scaling_subset_ranges_with_E2(
-                    scaler.reflection_table, scaler.params
-                )
-                scaler.scaling_selection = overall_scaling_selection.select(
-                    scaler.suitable_refl_for_scaling_sel
-                )
-                if self._free_Ih_table:
-                    scaler.scaling_selection.set_selected(
-                        scaler.free_set_selection, False
+            datasets_to_remove = []
+            for i, scaler in enumerate(self.active_scalers):
+                try:
+                    overall_scaling_selection = calculate_scaling_subset_ranges_with_E2(
+                        scaler.reflection_table, scaler.params
                     )
-                scaler.scaling_subset_sel = copy.deepcopy(scaler.scaling_selection)
-                scaler.scaling_selection &= ~scaler.outliers
+                except BadDatasetForScalingException:
+                    datasets_to_remove.append(i)
+                else:
+                    scaler.scaling_selection = overall_scaling_selection.select(
+                        scaler.suitable_refl_for_scaling_sel
+                    )
+                    if self._free_Ih_table:
+                        scaler.scaling_selection.set_selected(
+                            scaler.free_set_selection, False
+                        )
+                    scaler.scaling_subset_sel = copy.deepcopy(scaler.scaling_selection)
+                    scaler.scaling_selection &= ~scaler.outliers
+            if datasets_to_remove:
+                self.remove_datasets(self.active_scalers, datasets_to_remove)
+                # Reinitialise the global datastructures for the reduced dataset.
+                (
+                    self._global_Ih_table,
+                    self._free_Ih_table,
+                ) = self._create_global_Ih_table(self.params.anomalous)
         elif self.params.reflection_selection.method == "use_all":
             block = self.global_Ih_table.Ih_table_blocks[0]
             n_mult = (block.calc_nh() > 1).count(True)

--- a/algorithms/scaling/scaler_factory.py
+++ b/algorithms/scaling/scaler_factory.py
@@ -188,8 +188,12 @@ class SingleScalerFactory(ScalerFactory):
                 reflection_table = calc_crystal_frame_vectors(
                     reflection_table, experiment
                 )
-
-        return SingleScaler(params, experiment, reflection_table, for_multi)
+        try:
+            scaler = SingleScaler(params, experiment, reflection_table, for_multi)
+        except BadDatasetForScalingException as e:
+            raise ValueError(e)
+        else:
+            return scaler
 
 
 class NullScalerFactory(ScalerFactory):

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -775,6 +775,31 @@ def test_multi_scale_exclude_images(dials_data, tmpdir):
     assert nd2_scaled > 2800
 
 
+def test_scale_handle_bad_dataset(dials_data, tmpdir):
+    """Set command line parameters such that one dataset does not meet the
+    criteria for inclusion in scaling. Check that this is excluded and the
+    scaling job completes without failure."""
+    location = dials_data("multi_crystal_proteinase_k")
+    command = [
+        "dials.scale",
+        "reflection_selection.method=intensity_ranges",
+        "Isigma_range=90.0,1000",
+    ]
+    for i in range(1, 6):
+        command.append(location.join("experiments_" + str(i) + ".json").strpath)
+        command.append(location.join("reflections_" + str(i) + ".pickle").strpath)
+
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert not result.returncode and not result.stderr
+
+    scaled_exp = tmpdir.join("scaled.expt").strpath
+    scaled_refl = tmpdir.join("scaled.refl").strpath
+    reflections = flex.reflection_table.from_file(scaled_refl)
+    expts = load.experiment_list(scaled_exp, check_format=False)
+    assert len(expts) == 4
+    assert len(reflections.experiment_identifiers()) == 4
+
+
 def test_targeted_scaling(dials_data, tmpdir):
     """Test the targeted scaling workflow."""
     location = dials_data("l_cysteine_4_sweeps_scaled")

--- a/algorithms/scaling/test_scale.py
+++ b/algorithms/scaling/test_scale.py
@@ -475,6 +475,21 @@ def test_scale_physical(dials_data, tmpdir):
     assert result.overall.n_obs > 2300  # at 07/01/19, was 2336, at 22/05/19 was 2311
 
 
+def test_scale_normal_equations_failure(dials_data, tmpdir):
+    location = dials_data("l_cysteine_dials_output")
+    refl = location.join("20_integrated.pickle").strpath
+    expt = location.join("20_integrated_experiments.json").strpath
+
+    # exclude a central region of data to force the failure of the full matrix
+    # minimiser due to indeterminate solution of the normal equations. In this
+    # case, the error should be caught and scaling can proceed.
+    command = ["dials.scale", refl, expt, "exclude_images=800:1400"]
+    result = procrunner.run(command, working_directory=tmpdir)
+    assert not result.returncode and not result.stderr
+    assert tmpdir.join("scaled.refl").check()
+    assert tmpdir.join("scaled.expt").check()
+
+
 def test_scale_and_filter_image_group_mode(dials_data, tmpdir):
     """Test the scale and filter command line program."""
     location = dials_data("multi_crystal_proteinase_k")

--- a/command_line/find_spots_server.py
+++ b/command_line/find_spots_server.py
@@ -107,6 +107,11 @@ indexing_min_spots = 10
     # no need to write the hot mask in the server/client
     params.spotfinder.write_hot_mask = False
     experiments = ExperimentListFactory.from_filenames([filename])
+    if params.spotfinder.scan_range and len(experiments) > 1:
+        # This means we've imported a sequence of still image: select
+        # only the experiment, i.e. image, we're interested in
+        ((start, end),) = params.spotfinder.scan_range
+        experiments = experiments[start - 1 : end]
     t0 = time.time()
     reflections = flex.reflection_table.from_observations(experiments, params)
     t1 = time.time()

--- a/newsfragments/1653.bugfix
+++ b/newsfragments/1653.bugfix
@@ -1,0 +1,1 @@
+``dials.scale``: Fix crash when full-matrix minimisation is unsuccessful due to indeterminate normal equations.

--- a/newsfragments/1654.bugfix
+++ b/newsfragments/1654.bugfix
@@ -1,0 +1,1 @@
+``dials.scale``: Fix crash when no reflections remain after initial filtering.

--- a/newsfragments/1656.bugfix
+++ b/newsfragments/1656.bugfix
@@ -1,0 +1,1 @@
+``dials.export``: Fix error observed with ``format=mmcif`` for narrow sweeps with low symmetry

--- a/newsfragments/1660.bugfix
+++ b/newsfragments/1660.bugfix
@@ -1,0 +1,1 @@
+Fix image numbering inconsistency in ascii histogram of per-image spot counts

--- a/newsfragments/1665.bugfix
+++ b/newsfragments/1665.bugfix
@@ -1,0 +1,1 @@
+``dials.find_spots_server``: Significant performance improvement for HDF5 grid scans.

--- a/test/util/test_ascii_art.py
+++ b/test/util/test_ascii_art.py
@@ -95,3 +95,32 @@ oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 1 image 10"""
     output = "\n".join(line.rstrip() for line in output.splitlines())
     assert output == expected_output
+
+    # If we do spotfinding on the first 3 images, then the spot centroids will be in the
+    # range z=0.5 to z=2.5
+    output = ascii_art.spot_counts_per_image_plot(
+        refl.select(refl["xyzobs.px.value"].parts()[2] <= 2.5),
+        char="#",
+        width=10,
+        height=15,
+    )
+    expected_output = """\
+624 spots found on 3 images (max 294 / bin)
+#
+#
+#
+#
+#
+#
+##
+###
+###
+###
+###
+###
+###
+###
+###
+1 3"""
+    output = "\n".join(line.rstrip() for line in output.splitlines())
+    assert output == expected_output

--- a/util/ascii_art.py
+++ b/util/ascii_art.py
@@ -1,3 +1,5 @@
+import math
+
 from dials.array_family import flex
 
 
@@ -24,8 +26,8 @@ def flex_histogram(z, char="*", width=60, height=10):
     z += epsilon
 
     # image numbers to display on x-axis label
-    xmin = int(round(min_z + 1e-16))
-    xmax = int(round(max_z))
+    xmin = math.ceil(min_z)
+    xmax = math.ceil(max_z)
 
     # estimate the total number of images
     image_count = xmax - xmin + 1

--- a/util/export_mmcif.py
+++ b/util/export_mmcif.py
@@ -321,6 +321,7 @@ class MMCIFOutputFile:
                 crystal_symmetry=crystal_symmetry,
                 use_internal_variance=False,
                 eliminate_sys_absent=False,
+                assert_is_not_unique_set_under_symmetry=False,
             )
             merged_block = iotbx.cif.model.block()
             merged_block["_reflns.pdbx_ordinal"] = 1


### PR DESCRIPTION
Bugfixes
--------

- ``dials.scale``: Fix crash when full-matrix minimisation is unsuccessful due to indeterminate normal equations. (#1653)
- ``dials.scale``: Fix crash when no reflections remain after initial filtering. (#1654)
- ``dials.export``: Fix error observed with ``format=mmcif`` for narrow sweeps with low symmetry (#1656)
- Fix image numbering inconsistency in ascii histogram of per-image spot counts (#1660)
- ``dials.find_spots_server``: Significant performance improvement for HDF5 grid scans. (#1665)