### PR TITLE
Allow finding dials_regression from environment

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -53,6 +53,10 @@ def pytest_configure(config):
 def dials_regression():
     """Return the absolute path to the dials_regression module as a string.
     Skip the test if dials_regression is not installed."""
+
+    if "DIALS_REGRESSION" in os.environ:
+        return os.environ["DIALS_REGRESSION"]
+
     try:
         import dials_regression as dr
 

--- a/newsfragments/1674.misc
+++ b/newsfragments/1674.misc
@@ -1,0 +1,1 @@
+Optionally find ``dials_regression`` from the environment variable ``DIALS_REGRESSION``


### PR DESCRIPTION
As an alternative to copying into multiple places, or softlinking manually, it makes sense to follow the example of [dials-data](https://github.com/dials/data/blob/e17760480c363df08654e60dfc31de981c30419f/dials_data/datasets.py#L73) and let the be environment-configured so that we never need to think of it again, once it is setup.

Same change as https://github.com/cctbx/dxtbx/pull/350, but in dials, since this logic is duplicated for package-independence.