### PR TITLE
Update Azure builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,3 +1,6 @@
+variables:
+  CACHE_VERSION: 20201102
+
 schedules:
   # nightly builds to populate caches
   - cron: "3 0 * * Mon"
@@ -85,6 +88,6 @@ jobs:
 
   - template: .azure-pipelines/azure-pipelines-linux.yml
 
-#  - template: .azure-pipelines/azure-pipelines-mac.yml
+  - template: .azure-pipelines/azure-pipelines-mac.yml
 
-#  - template: .azure-pipelines/azure-pipelines-windows.yml
+  - template: .azure-pipelines/azure-pipelines-windows.yml

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -89,6 +89,6 @@ jobs:
 
   - template: .azure-pipelines/azure-pipelines-linux.yml
 
-  - template: .azure-pipelines/azure-pipelines-mac.yml
+#  - template: .azure-pipelines/azure-pipelines-mac.yml
 
-  - template: .azure-pipelines/azure-pipelines-windows.yml
+#  - template: .azure-pipelines/azure-pipelines-windows.yml

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,7 +1,3 @@
-variables:
-  CACHE_VERSION: 20201102
-  ENABLE_CACHE: 0
-
 schedules:
   # nightly builds to populate caches
   - cron: "3 0 * * Mon"

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -20,7 +20,6 @@ jobs:
   steps:
   # Dependencies required for building gltbx
   - script: |
-      sudo apt-get update
       sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev
     displayName: Install dependencies
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -3,8 +3,7 @@ jobs:
   pool:
     vmImage: ubuntu-20.04
   dependsOn: setup
-  condition: and(eq(variables['ENABLE_CACHE'], '1'),
-                 eq(dependencies.setup.outputs['constants.NEWSFRAGMENT_WAITING'], 'false'))
+  condition: eq(dependencies.setup.outputs['constants.NEWSFRAGMENT_WAITING'], 'false')
   variables:
     CURRENT_WEEK: $[ dependencies.setup.outputs['constants.CURRENT_WEEK'] ]
     TODAY_ISO: $[ dependencies.setup.outputs['constants.TODAY_ISO'] ]
@@ -12,37 +11,10 @@ jobs:
     matrix:
       python36:
         PYTHON_VERSION: 3.6
-      python37:
-        PYTHON_VERSION: 3.7
-      python38:
-        PYTHON_VERSION: 3.8
-  timeoutInMinutes: 150
-
-  steps:
-  # Dependencies required for building gltbx
-  - script: |
-      sudo apt-get update
-      sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev
-    displayName: Install dependencies
-
-  - template: unix-build.yml
-    parameters:
-      conda_environment: .conda-envs/linux.txt
-
-- job: linux_uncached
-  pool:
-    vmImage: ubuntu-20.04
-  dependsOn: setup
-  condition: and(eq(variables['ENABLE_CACHE'], '0'),
-                 eq(dependencies.setup.outputs['constants.NEWSFRAGMENT_WAITING'], 'false'))
-  variables:
-    CURRENT_WEEK: $[ dependencies.setup.outputs['constants.CURRENT_WEEK'] ]
-    TODAY_ISO: $[ dependencies.setup.outputs['constants.TODAY_ISO'] ]
-    PYTHON_VERSION: 3.6
-    REPOSITORIES_CACHED: false
-    BASE_CACHED: false
-    BUILD_CACHED: false
-    DATA_CACHED: false
+#      python37:
+#        PYTHON_VERSION: 3.7
+#      python38:
+#        PYTHON_VERSION: 3.8
   timeoutInMinutes: 150
 
   steps:

--- a/.azure-pipelines/azure-pipelines-mac.yml
+++ b/.azure-pipelines/azure-pipelines-mac.yml
@@ -3,8 +3,7 @@ jobs:
   pool:
     vmImage: macOS-latest
   dependsOn: setup
-  condition: and(eq(variables['ENABLE_CACHE'], '1'),
-                 eq(dependencies.setup.outputs['constants.NEWSFRAGMENT_WAITING'], 'false'))
+  condition: eq(dependencies.setup.outputs['constants.NEWSFRAGMENT_WAITING'], 'false')
   variables:
     CURRENT_WEEK: $[ dependencies.setup.outputs['constants.CURRENT_WEEK'] ]
     TODAY_ISO: $[ dependencies.setup.outputs['constants.TODAY_ISO'] ]
@@ -13,31 +12,10 @@ jobs:
     matrix:
       python36:
         PYTHON_VERSION: 3.6
-      python37:
-        PYTHON_VERSION: 3.7
-      python38:
-        PYTHON_VERSION: 3.8
-  timeoutInMinutes: 150
-
-  steps:
-  - template: unix-build.yml
-    parameters:
-      conda_environment: .conda-envs/macos.txt
-
-- job: macos_uncached
-  pool:
-    vmImage: macOS-latest
-  dependsOn: setup
-  condition: and(eq(variables['ENABLE_CACHE'], '0'),
-                 eq(dependencies.setup.outputs['constants.NEWSFRAGMENT_WAITING'], 'false'))
-  variables:
-    CURRENT_WEEK: $[ dependencies.setup.outputs['constants.CURRENT_WEEK'] ]
-    TODAY_ISO: $[ dependencies.setup.outputs['constants.TODAY_ISO'] ]
-    PYTHON_VERSION: 3.6
-    REPOSITORIES_CACHED: false
-    BASE_CACHED: false
-    BUILD_CACHED: false
-    DATA_CACHED: false
+#     python37:
+#       PYTHON_VERSION: 3.7
+#     python38:
+#       PYTHON_VERSION: 3.8
   timeoutInMinutes: 150
 
   steps:

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -23,11 +23,11 @@ steps:
 # Create a new conda environment using the bootstrap script
 - script: |
     set -eux
-    python modules/dials/installer/bootstrap.py base --python $(PYTHON_VERSION)
+    python modules/dials/installer/bootstrap.py base --mamba --python $(PYTHON_VERSION)
 
     # Immediately recover disk space used by miniconda installation
-    du -sh miniconda
-    rm -r miniconda
+    du -sh micromamba
+    rm -r micromamba
   displayName: Create python $(PYTHON_VERSION) environment
   workingDirectory: $(Pipeline.Workspace)
 

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -23,11 +23,7 @@ steps:
 # Create a new conda environment using the bootstrap script
 - script: |
     set -eux
-    python modules/dials/installer/bootstrap.py base --mamba --python $(PYTHON_VERSION)
-
-    # Immediately recover disk space used by miniconda installation
-    du -sh micromamba
-    rm -r micromamba
+    python modules/dials/installer/bootstrap.py base --mamba --clean --python $(PYTHON_VERSION)
   displayName: Create python $(PYTHON_VERSION) environment
   workingDirectory: $(Pipeline.Workspace)
 

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -1,4 +1,5 @@
 # Variables:
+#   CACHE_VERSION: unique cache identifier
 #   CURRENT_WEEK: weekly changing cache identifier
 #   PYTHON_VERSION: string in the form of "3.x"
 #   TODAY_ISO: today's date in ISO format, eg. "20200531"

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -43,7 +43,7 @@ steps:
     cp -av /usr/lib/x86_64-linux-gnu/libGLU.so* modules/lib
   displayName: Set up GL/GLU libraries and headers
   workingDirectory: $(Pipeline.Workspace)
-  condition: eq(variables['Agent.OS'], 'Linux')
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
 # Build DIALS using the bootstrap script
 - bash: |
@@ -55,9 +55,10 @@ steps:
 # Ensure we are using up-to-date testing packages.
 # Extract the dials-data version so we can correctly cache regression data.
 - bash: |
-    set -eux
+    set -e
     . dials
     conda install -p conda_base -y dials-data pytest-azurepipelines pytest-cov pytest-timeout
+    set -ux
     dials.data info -v
     echo "##vso[task.setvariable variable=DIALS_DATA_VERSION_FULL]$(dials.data info -v | grep version.full)"
     echo "##vso[task.setvariable variable=DIALS_DATA_VERSION]$(dials.data info -v | grep version.major)"
@@ -88,9 +89,10 @@ steps:
 
 # Finally, run the full regression test suite
 - bash: |
-    set -eux
-    export DIALS_DATA=${PWD}/data
+    set -e
     . dials
+    set -ux
+    export DIALS_DATA=${PWD}/data
     cd modules/dials
     pytest -v -ra -n auto --basetemp="$(Pipeline.Workspace)/tests" --durations=10 \
         --cov=$(pwd) --cov-report=html --cov-report=xml --cov-branch \
@@ -108,6 +110,7 @@ steps:
 # Recover disk space after testing
 # This is only relevant if we had cache misses, as free disk space is required to create cache archives
 - bash: |
+    set -eux
     echo Disk space usage:
     df -h
     du -sh *
@@ -117,4 +120,4 @@ steps:
     rm -rf tests
   displayName: Recover disk space
   workingDirectory: $(Pipeline.Workspace)
-  condition: ne(variables.DATA_CACHED, 'true')
+  condition: and(succeeded(), ne(variables.DATA_CACHED, 'true'))

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -97,7 +97,7 @@ steps:
   workingDirectory: $(Pipeline.Workspace)
 
 - bash: |
-    bash <(curl -s https://codecov.io/bash) -v -n "Python $(PYTHON_VERSION) $(Agent.OS)"
+    bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
   displayName: Publish coverage stats
   continueOnError: True
   timeoutInMinutes: 2

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -9,15 +9,13 @@ steps:
 # Obtain a shallow clone of the DIALS repository.
 # DIALS will not be able to report proper version numbers
 - checkout: self
-  path: ./dials-checkout
+  path: ./modules/dials
   fetchDepth: 1
   displayName: Checkout $(Build.SourceBranch)
 
 # Download source repositories using the bootstrap script
 - bash: |
     set -eux
-    mkdir -p modules
-    ln -nsf ../dials-checkout modules/dials
     python modules/dials/installer/bootstrap.py update
   displayName: Repository checkout
   workingDirectory: $(Pipeline.Workspace)

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -12,20 +12,9 @@ steps:
   fetchDepth: 1
   displayName: Checkout $(Build.SourceBranch)
 
-# Copy libGL/libGLU into a place where they can be found during the
-# build. We don't include system libraries so that we don't accidentally
-# pick up libc and friends
-- bash: |
-    mkdir -p modules/lib
-    cp -av /usr/lib/x86_64-linux-gnu/libGL.so* modules/lib
-    cp -av /usr/lib/x86_64-linux-gnu/libGLU.so* modules/lib
-  displayName: Set up GL/GLU libraries
-  workingDirectory: $(Pipeline.Workspace)
-  condition: eq(variables['Agent.OS'], 'Linux')
-
 # Download source repositories using the bootstrap script
 - bash: |
-    set -e
+    set -eux
     mkdir -p modules
     ln -nsf ../dials-checkout modules/dials
     python modules/dials/installer/bootstrap.py update
@@ -34,7 +23,7 @@ steps:
 
 # Create a new conda environment using the bootstrap script
 - script: |
-    set -e
+    set -eux
     python modules/dials/installer/bootstrap.py base --python $(PYTHON_VERSION)
 
     # Immediately recover disk space used by miniconda installation
@@ -47,26 +36,27 @@ steps:
 # build. We don't include system headers so that we don't accidentally
 # pick up libc and friends
 - bash: |
-    set -e
-    mkdir -p build/include
+    set -eux
+    mkdir -p modules/lib build/include
     cp -av /usr/include/GL build/include
     cp -av /usr/include/KHR build/include
-  displayName: Set up GL/GLU headers
+    cp -av /usr/lib/x86_64-linux-gnu/libGL.so* modules/lib
+    cp -av /usr/lib/x86_64-linux-gnu/libGLU.so* modules/lib
+  displayName: Set up GL/GLU libraries and headers
   workingDirectory: $(Pipeline.Workspace)
   condition: eq(variables['Agent.OS'], 'Linux')
 
 # Build DIALS using the bootstrap script
 - bash: |
-    set -e
+    set -eux
     python modules/dials/installer/bootstrap.py build
-    cp -v dials build/activate  # ensure a copy is kept in the cache
   displayName: DIALS build
   workingDirectory: $(Pipeline.Workspace)
 
 # Ensure we are using up-to-date testing packages.
 # Extract the dials-data version so we can correctly cache regression data.
 - bash: |
-    set -e
+    set -eux
     . dials
     conda install -p conda_base -y dials-data pytest-azurepipelines pytest-cov pytest-timeout
     dials.data info -v
@@ -99,8 +89,8 @@ steps:
 
 # Finally, run the full regression test suite
 - bash: |
-    set -e
-    export DIALS_DATA=$(pwd)/data
+    set -eux
+    export DIALS_DATA=${PWD}/data
     . dials
     cd modules/dials
     pytest -v -ra -n auto --basetemp="$(Pipeline.Workspace)/tests" --durations=10 \

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -1,5 +1,4 @@
 # Variables:
-#   CACHE_VERSION: unique cache identifier
 #   CURRENT_WEEK: weekly changing cache identifier
 #   PYTHON_VERSION: string in the form of "3.x"
 #   TODAY_ISO: today's date in ISO format, eg. "20200531"
@@ -13,19 +12,6 @@ steps:
   fetchDepth: 1
   displayName: Checkout $(Build.SourceBranch)
 
-# Get all other source repositories from cache if available
-# Allow day-to-day incremental cache updates
-# Flush the cache once a week and whenever the bootstrap script is modified
-- task: Cache@2
-  inputs:
-    key: '"repositories" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | installer/bootstrap.py | "$(TODAY_ISO)"'
-    restoreKeys: |
-      "repositories" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | installer/bootstrap.py
-    path: $(Pipeline.Workspace)/modules
-    cacheHitVar: REPOSITORIES_CACHED
-  condition: eq(variables['ENABLE_CACHE'], '1')
-  displayName: Restore repository cache
-
 # Copy libGL/libGLU into a place where they can be found during the
 # build. We don't include system libraries so that we don't accidentally
 # pick up libc and friends
@@ -37,48 +23,16 @@ steps:
   workingDirectory: $(Pipeline.Workspace)
   condition: eq(variables['Agent.OS'], 'Linux')
 
-# If other source repositories are not cached then download
-# them using the bootstrap script
+# Download source repositories using the bootstrap script
 - bash: |
     set -e
     mkdir -p modules
     ln -nsf ../dials-checkout modules/dials
     python modules/dials/installer/bootstrap.py update
-  displayName: Repository checkout (initial)
+  displayName: Repository checkout
   workingDirectory: $(Pipeline.Workspace)
-  condition: eq(variables.REPOSITORIES_CACHED, 'false')
 
-# Update the cctbx_project and dxtbx repositories now,
-# unless they were just freshly cloned
-- bash: |
-    set -e
-    echo "##[command]Updating cctbx_project"
-    cd $(Pipeline.Workspace)/modules/cctbx_project
-    git fetch upstream master --depth=1
-    git checkout FETCH_HEAD
-    echo "##[command]Updating dxtbx"
-    cd $(Pipeline.Workspace)/modules/dxtbx
-    git fetch origin main --depth=1
-    git checkout FETCH_HEAD
-  displayName: Repository update (incremental)
-  condition: ne(variables.REPOSITORIES_CACHED, 'false')
-
-# Get a ready-made DIALS conda environment from cache if available
-# Allow day-to-day incremental cache updates
-# Flush the cache once a week and whenever the environment specification is modified
-# Cache is not shared across operating systems and python versions
-- task: Cache@2
-  inputs:
-    key: '"base" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(Agent.OS)-$(Agent.Version)-$(Pipeline.Workspace)" | "$(PYTHON_VERSION)" | ${{ parameters.conda_environment }} | "$(TODAY_ISO)"'
-    restoreKeys: |
-      "base" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(Agent.OS)-$(Agent.Version)-$(Pipeline.Workspace)" | "$(PYTHON_VERSION)" | ${{ parameters.conda_environment }}
-    path: $(Pipeline.Workspace)/conda_base
-    cacheHitVar: BASE_CACHED
-  condition: eq(variables['ENABLE_CACHE'], '1')
-  displayName: Restore environment cache
-
-# If the conda environment could not be loaded from cache then
-# create a new one using the bootstrap script
+# Create a new conda environment using the bootstrap script
 - script: |
     set -e
     python modules/dials/installer/bootstrap.py base --python $(PYTHON_VERSION)
@@ -88,22 +42,6 @@ steps:
     rm -r miniconda
   displayName: Create python $(PYTHON_VERSION) environment
   workingDirectory: $(Pipeline.Workspace)
-  condition: eq(variables.BASE_CACHED, 'false')
-
-# Get a ready-made DIALS build directory from cache if available
-# Allow day-to-day incremental cache updates
-# Flush the cache once a week and whenever the environment specification
-# or the bootstrap script is modified.
-# Cache is not shared across operating systems and python versions
-- task: Cache@2
-  inputs:
-    key: '"build" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(Agent.OS)-$(Agent.Version)-$(Pipeline.Workspace)" | "$(PYTHON_VERSION)" | installer/bootstrap.py | ${{ parameters.conda_environment }} | "$(TODAY_ISO)"'
-    restoreKeys: |
-      "build" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(Agent.OS)-$(Agent.Version)-$(Pipeline.Workspace)" | "$(PYTHON_VERSION)" | installer/bootstrap.py | ${{ parameters.conda_environment }}
-    path: $(Pipeline.Workspace)/build
-    cacheHitVar: BUILD_CACHED
-  condition: eq(variables['ENABLE_CACHE'], '1')
-  displayName: Restore cached build
 
 # Copy GL/GLU/KHR headers into a place where they can be found during the
 # build. We don't include system headers so that we don't accidentally
@@ -115,30 +53,15 @@ steps:
     cp -av /usr/include/KHR build/include
   displayName: Set up GL/GLU headers
   workingDirectory: $(Pipeline.Workspace)
-  condition: and(eq(variables.BUILD_CACHED, 'false'),
-                 eq(variables['Agent.OS'], 'Linux'))
+  condition: eq(variables['Agent.OS'], 'Linux')
 
-# If the build directory could not be loaded from cache then
-# create a new one using the bootstrap script
+# Build DIALS using the bootstrap script
 - bash: |
     set -e
     python modules/dials/installer/bootstrap.py build
     cp -v dials build/activate  # ensure a copy is kept in the cache
-  displayName: DIALS build (initial)
+  displayName: DIALS build
   workingDirectory: $(Pipeline.Workspace)
-  condition: eq(variables.BUILD_CACHED, 'false')
-
-# If the build directory was loaded (or kick-started) from cache then
-# do an incremental build
-- bash: |
-    set -e
-    cp -v build/activate dials  # restore copy from the cache
-    . dials
-    cd build
-    make reconf
-  displayName: DIALS build (incremental)
-  workingDirectory: $(Pipeline.Workspace)
-  condition: ne(variables.BUILD_CACHED, 'false')
 
 # Ensure we are using up-to-date testing packages.
 # Extract the dials-data version so we can correctly cache regression data.
@@ -162,6 +85,8 @@ steps:
 # previous cache version.
 # The cache is shared across operating systems and python versions, and flushed
 # once a week and for dials-data major and minor releases (eg. 2.0->2.1).
+# Since dials-data ensures cache coherence this should not be affected by the
+# broken Azure cache bug.
 - task: Cache@2
   inputs:
     key: '"data" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(DIALS_DATA_VERSION)" | "$(TODAY_ISO)" | "$(DIALS_DATA_VERSION_FULL)"'
@@ -170,7 +95,6 @@ steps:
       "data" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(DIALS_DATA_VERSION)"
     path: $(Pipeline.Workspace)/data
     cacheHitVar: DATA_CACHED
-  condition: eq(variables['ENABLE_CACHE'], '1')
   displayName: Restore regression data cache
 
 # Finally, run the full regression test suite
@@ -185,11 +109,11 @@ steps:
   displayName: Run tests
   workingDirectory: $(Pipeline.Workspace)
 
-- script: |
-    bash <(curl -s https://codecov.io/bash) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
-  displayName: 'Publish coverage stats'
+- bash: |
+    bash <(curl -s https://codecov.io/bash) -v -n "Python $(PYTHON_VERSION) $(Agent.OS)"
+  displayName: Publish coverage stats
   continueOnError: True
-  timeoutInMinutes: 3
+  timeoutInMinutes: 2
   workingDirectory: $(Pipeline.Workspace)/modules/dials
 
 # Recover disk space after testing
@@ -204,38 +128,4 @@ steps:
     rm -rf tests
   displayName: Recover disk space
   workingDirectory: $(Pipeline.Workspace)
-  condition: or(ne(variables.BASE_CACHED, 'true'),
-                ne(variables.BUILD_CACHED, 'true'),
-                ne(variables.DATA_CACHED, 'true'),
-                ne(variables.REPOSITORIES_CACHED, 'true'))
-
-# If the downloaded repositories are to be cached then clean them up before the
-# snapshot is made
-- bash: |
-    set -e
-    echo Preparing repository cache
-    for repository in *; do
-      if [[ "${repository}" == "dials" ]]; then
-        echo "  - Skipping dials"
-      elif [ -f ${repository} ]; then
-        echo "  - Deleting file ${repository}"
-        rm ${repository}
-      elif [ -e ${repository}/.git ]; then
-        if [[ "${repository}" == "cctbx_project" ]] || [[ "${repository}" == "dxtbx" ]]; then
-          echo "  - Cleaning up ${repository}"
-          cd ${repository}
-          git reset --hard HEAD
-          git clean -dffxq
-          git repack -a -d
-          cd -
-        else
-          echo "  - Removing version control from ${repository}"
-          rm -rf ${repository}/.git
-        fi
-      fi
-    done
-    echo Completed
-    ls -la
-  displayName: Preparing cache
-  workingDirectory: $(Pipeline.Workspace)/modules
-  condition: ne(variables.REPOSITORIES_CACHED, 'true')
+  condition: ne(variables.DATA_CACHED, 'true')

--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -13,85 +13,24 @@ steps:
   fetchDepth: 1
   displayName: Checkout $(Build.SourceBranch)
 
-# Get all other source repositories from cache if available
-# Allow day-to-day incremental cache updates
-# Flush the cache once a week and whenever the bootstrap script is modified
-- task: Cache@2
-  inputs:
-    key: '"repositories" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | installer/bootstrap.py | "$(TODAY_ISO)"'
-    restoreKeys: |
-      "repositories" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | installer/bootstrap.py
-    path: $(Pipeline.Workspace)/modules
-    cacheHitVar: REPOSITORIES_CACHED
-  displayName: Restore repository cache
-
-# If other source repositories are not cached then download
-# them using the bootstrap script
+# Download source repositories using the bootstrap script
 - powershell: |
     New-Item -Force -ItemType Directory -Path modules
     New-Item -Force -ItemType SymbolicLink -Path modules\dials -Value dials-checkout
     set PYTHONUNBUFFERED=TRUE
     python.exe modules\dials\installer\bootstrap.py update
-  displayName: Repository checkout (initial)
+  displayName: Repository checkout
   failOnStderr: true
   workingDirectory: $(Pipeline.Workspace)
-  condition: eq(variables.REPOSITORIES_CACHED, 'false')
 
-# Update the cctbx_project and dxtbx repositories now,
-# unless they were just freshly cloned
-- script: |
-    echo
-    echo Checking out latest cctbx_project commit
-    cd $(Pipeline.Workspace)/modules/cctbx_project
-    git fetch upstream master --depth=1
-    git checkout FETCH_HEAD
-    echo
-    echo Checking out latest dxtbx commit
-    cd $(Pipeline.Workspace)/modules/dxtbx
-    git fetch origin main --depth=1
-    git checkout FETCH_HEAD
-  displayName: Repository update (incremental)
-  condition: ne(variables.REPOSITORIES_CACHED, 'false')
-
-# # Get a ready-made DIALS conda environment from cache if available
-# # Allow day-to-day incremental cache updates
-# # Flush the cache once a week and whenever the environment specification is modified
-# # Cache is not shared across operating systems and python versions
-# # # Disabled as the generated cache is unrestorable due to some link issues
-# - task: Cache@2
-#   inputs:
-#     key: '"base" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(Agent.OS)-$(Agent.Version)" | "$(PYTHON_VERSION)" | ${{ parameters.conda_environment }} | "$(TODAY_ISO)"'
-#     restoreKeys: |
-#       "base" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(Agent.OS)-$(Agent.Version)" | "$(PYTHON_VERSION)" | ${{ parameters.conda_environment }}
-#     path: $(Pipeline.Workspace)/conda_base
-#     cacheHitVar: BASE_CACHED
-#   displayName: Restore environment cache
-
-# If the conda environment could not be loaded from cache then
-# create a new one using the bootstrap script
+# Create a new conda environment using the bootstrap script
 - script: |
     set PYTHONUNBUFFERED=TRUE
     python modules/dials/installer/bootstrap.py base --python $(PYTHON_VERSION)
   displayName: Create python $(PYTHON_VERSION) environment
   workingDirectory: $(Pipeline.Workspace)
-# condition: eq(variables.BASE_CACHED, 'false')
 
-# Get a ready-made DIALS build directory from cache if available
-# Allow day-to-day incremental cache updates
-# Flush the cache once a week and whenever the environment specification
-# or the bootstrap script is modified.
-# Cache is not shared across operating systems and python versions
-- task: Cache@2
-  inputs:
-    key: '"build" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(Agent.OS)-$(Agent.Version)" | "$(PYTHON_VERSION)" | installer/bootstrap.py | ${{ parameters.conda_environment }} | "$(TODAY_ISO)"'
-    restoreKeys: |
-      "build" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(Agent.OS)-$(Agent.Version)" | "$(PYTHON_VERSION)" | installer/bootstrap.py | ${{ parameters.conda_environment }}
-    path: $(Pipeline.Workspace)/build
-    cacheHitVar: BUILD_CACHED
-  displayName: Restore cached build
-
-# If the build directory could not be loaded from cache then
-# create a new one using the bootstrap script
+# Build DIALS using the bootstrap script
 - script: |
     pushd "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
     for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
@@ -99,29 +38,8 @@ steps:
     call "%VSPATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
 
     python modules/dials/installer/bootstrap.py build
-    REM -- ensure a copy of the environment loader is kept in the cache
-    copy dials.bat build\activate.bat
-  displayName: DIALS build (initial)
+  displayName: DIALS build
   workingDirectory: $(Pipeline.Workspace)
-  condition: eq(variables.BUILD_CACHED, 'false')
-
-# If the build directory was loaded (or kick-started) from cache then
-# do an incremental build
-- script: |
-    pushd "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-    for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
-    popd
-    call "%VSPATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
-
-    REM -- restore copy of the environment loader from the cache
-    copy build\activate.bat dials.bat
-    call dials.bat
-    cd build
-    libtbx.refresh
-    make
-  displayName: DIALS build (incremental)
-  workingDirectory: $(Pipeline.Workspace)
-  condition: ne(variables.BUILD_CACHED, 'false')
 
 # Ensure we are using up-to-date testing packages.
 # Extract the dials-data version so we can correctly cache regression data.
@@ -179,19 +97,19 @@ steps:
 # This is only relevant if we had cache misses, as free disk space is required to create cache archives
 - powershell: |
     echo "Disk space usage:"
-    Get-ChildItem -Directory | ForEach-Object { "{1,10:N2} MB  {0:S}" -f $_, ((Get-ChildItem $_ -Recurse -ErrorAction SilentlyContinue | Measure-Object -Property Length -sum).sum / 1Mb) }
+    Get-ChildItem -Directory | ForEach-Object { "{1,10:N2} MB  {0:S}" -f $_, ((Get-ChildItem $_ -Recurse -ErrorAction SilentlyContinue | Measure-Object -ErrorAction SilentlyContinue -Property Length -sum).sum / 1Mb) }
 
     echo ""
     echo "Build directory:"
     cd build
-    Get-ChildItem -Directory | ForEach-Object { "{1,10:N2} MB  {0:S}" -f $_, ((Get-ChildItem $_ -Recurse -ErrorAction SilentlyContinue | Measure-Object -Property Length -sum).sum / 1Mb) }
+    Get-ChildItem -Directory | ForEach-Object { "{1,10:N2} MB  {0:S}" -f $_, ((Get-ChildItem $_ -Recurse -ErrorAction SilentlyContinue | Measure-Object -ErrorAction SilentlyContinue -Property Length -sum).sum / 1Mb) }
     cd ..
 
     if (Test-Path -Path tests) {
       echo ""
       echo "Test artefacts:"
       cd tests
-      Get-ChildItem -Directory | ForEach-Object { "{1,10:N2} MB  {0:S}" -f $_, ((Get-ChildItem $_ -Recurse -ErrorAction SilentlyContinue | Measure-Object -Property Length -sum).sum / 1Mb) }
+      Get-ChildItem -Directory | ForEach-Object { "{1,10:N2} MB  {0:S}" -f $_, ((Get-ChildItem $_ -Recurse -ErrorAction SilentlyContinue | Measure-Object -ErrorAction SilentlyContinue -Property Length -sum).sum / 1Mb) }
       cd ..
 
       echo ""
@@ -203,37 +121,4 @@ steps:
     dir
   displayName: Recover disk space
   workingDirectory: $(Pipeline.Workspace)
-# condition: or(ne(variables.BASE_CACHED, 'true'),
-#               ne(variables.BUILD_CACHED, 'true'),
-#               ne(variables.DATA_CACHED, 'true'),
-#               ne(variables.REPOSITORIES_CACHED, 'true'))
-
-# If the downloaded repositories are to be cached then clean them up before the
-# snapshot is made
-- powershell: |
-    echo "Preparing repository cache"
-    Get-ChildItem | ForEach-Object {
-      if ($_.Name -match "dials") {
-        echo "  - Skipping dials"
-      } elseif ($_ -is [System.IO.FileInfo]) {
-        echo "  - Deleting file $_.Name"
-        Remove-Item $_
-      } elseif (Test-Path -Path (Join-Path -Path $_ -ChildPath "git")) {
-        if (($_.Name -match "cctbx_project") -or ($_.Name -match "dxtbx")) {
-          echo "  - Cleaning up $_.Name"
-          cd (Join-Path -Path $_ -ChildPath "git")
-          git reset --hard HEAD
-          git clean -dffxq
-          git repack -a -d
-          cd ..\..
-        } else {
-          echo "  - Removing version control from $_.Name"
-          Remove-Item -Path (Join-Path -Path $_ -ChildPath "git") -Recurse -Force
-        }
-      }
-    }
-    echo "Completed"
-    dir
-  displayName: Preparing cache
-  workingDirectory: $(Pipeline.Workspace)/modules
-  condition: ne(variables.REPOSITORIES_CACHED, 'true')
+# condition: ne(variables.DATA_CACHED, 'true')

--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -24,7 +24,7 @@ steps:
 # Create a new conda environment using the bootstrap script
 - script: |
     set PYTHONUNBUFFERED=TRUE
-    python modules/dials/installer/bootstrap.py base --python $(PYTHON_VERSION)
+    python modules/dials/installer/bootstrap.py base --mamba --python $(PYTHON_VERSION)
   displayName: Create python $(PYTHON_VERSION) environment
   workingDirectory: $(Pipeline.Workspace)
 

--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -24,7 +24,7 @@ steps:
 # Create a new conda environment using the bootstrap script
 - script: |
     set PYTHONUNBUFFERED=TRUE
-    python modules/dials/installer/bootstrap.py base --mamba --python $(PYTHON_VERSION)
+    python modules/dials/installer/bootstrap.py base --mamba --clean --python $(PYTHON_VERSION)
   displayName: Create python $(PYTHON_VERSION) environment
   workingDirectory: $(Pipeline.Workspace)
 

--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -9,14 +9,12 @@ steps:
 # Obtain a shallow clone of the DIALS repository.
 # DIALS will not be able to report proper version numbers
 - checkout: self
-  path: dials-checkout
+  path: modules/dials
   fetchDepth: 1
   displayName: Checkout $(Build.SourceBranch)
 
 # Download source repositories using the bootstrap script
 - powershell: |
-    New-Item -Force -ItemType Directory -Path modules
-    New-Item -Force -ItemType SymbolicLink -Path modules\dials -Value dials-checkout
     set PYTHONUNBUFFERED=TRUE
     python.exe modules\dials\installer\bootstrap.py update
   displayName: Repository checkout

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -20,6 +20,7 @@ import socket as pysocket
 import stat
 import subprocess
 import sys
+import tarfile
 import threading
 import time
 import warnings
@@ -51,6 +52,127 @@ def make_executable(filepath):
 
 allowed_ssh_connections = {}
 concurrent_git_connection_limit = threading.Semaphore(5)
+
+
+def install_micromamba(python):
+    """Download and install Micromamba"""
+    if sys.platform.startswith("linux"):
+        conda_platform = "linux"
+        member = "bin/micromamba"
+        url = "https://micromamba.snakepit.net/api/micromamba/linux-64/latest"
+    elif sys.platform == "darwin":
+        conda_platform = "macos"
+        member = "bin/micromamba"
+        url = "https://micromamba.snakepit.net/api/micromamba/osx-64/latest"
+    elif os.name == "nt":
+        conda_platform = "windows"
+        member = "Library/bin/micromamba.exe"
+        url = "https://micromamba.snakepit.net/api/micromamba/win-64/latest"
+    else:
+        raise NotImplementedError(
+            "Unsupported platform %s / %s" % (os.name, sys.platform)
+        )
+    mamba_prefix = os.path.realpath("micromamba")
+    clean_env["MAMBA_ROOT_PREFIX"] = mamba_prefix
+    mamba = os.path.join(mamba_prefix, member.split("/")[-1])
+    print("Downloading {url}:".format(url=url), end=" ")
+    result = download_to_file(url, os.path.join(mamba_prefix, "micromamba.tar.bz2"))
+    if result in (0, -1):
+        sys.exit("Micromamba download failed")
+    with tarfile.open(
+        os.path.join(mamba_prefix, "micromamba.tar.bz2"), "r:bz2"
+    ) as tar, open(mamba, "wb") as fh:
+        fh.write(tar.extractfile(member).read())
+    make_executable(mamba)
+
+    # verify micromamba works and check version
+    conda_info = subprocess.check_output([mamba, "--version"], env=clean_env)
+    if sys.version_info.major > 2:
+        conda_info = conda_info.decode("latin-1")
+    print("Using Micromamba version", conda_info.strip())
+
+    # identify packages required for environment
+    filename = os.path.join(
+        "modules",
+        "dials",
+        ".conda-envs",
+        "{platform}.txt".format(platform=conda_platform),
+    )
+    if not os.path.isfile(filename):
+        raise RuntimeError(
+            "The environment file {filename} is not available".format(filename=filename)
+        )
+
+    # install a new environment or update an existing one
+    prefix = os.path.realpath("conda_base")
+    if os.path.exists(prefix):
+        command = "install"
+        text_messages = ["Updating", "update of"]
+    else:
+        command = "create"
+        text_messages = ["Installing", "installation into"]
+    python_requirement = "conda-forge::python=%s.*" % python
+
+    command_list = [
+        mamba,
+        "--no-env",
+        "--no-rc",
+        "--prefix",
+        prefix,
+        "--root-prefix",
+        mamba_prefix,
+        command,
+        "--file",
+        filename,
+        "--yes",
+        "--channel",
+        "conda-forge",
+        "--override-channels",
+        python_requirement,
+    ]
+
+    print(
+        "{text} dials environment from {filename} with Python {python}".format(
+            text=text_messages[0], filename=filename, python=python
+        )
+    )
+    for retry in range(5):
+        retry += 1
+        try:
+            run_command(
+                command=command_list,
+                workdir=".",
+            )
+        except Exception:
+            print(
+                """
+*******************************************************************************
+There was a failure in constructing the conda environment.
+Attempt {retry} of 5 will start {retry} minute(s) from {t}.
+*******************************************************************************
+""".format(
+                    retry=retry, t=time.asctime()
+                )
+            )
+            time.sleep(retry * 60)
+        else:
+            break
+    else:
+        sys.exit(
+            """
+The conda environment could not be constructed. Please check that there is a
+working network connection for downloading conda packages.
+"""
+        )
+    print("Completed {text}:\n  {prefix}".format(text=text_messages[1], prefix=prefix))
+    with open(os.path.join(prefix, ".condarc"), "w") as fh:
+        fh.write(
+            """
+changeps1: False
+channels:
+  - conda-forge
+""".lstrip()
+        )
 
 
 def install_miniconda(location):
@@ -1102,6 +1224,12 @@ be passed separately with quotes to avoid confusion (e.g
             "Specify as repository@branch, eg. 'dials@dials-next'"
         ),
     )
+    parser.add_argument(
+        "--mamba",
+        help="Use micromamba over miniconda for the base installation step",
+        default=False,
+        action="store_true",
+    )
 
     options = parser.parse_args()
     if os.name == "nt" and options.python == "3.6":
@@ -1115,7 +1243,10 @@ be passed separately with quotes to avoid confusion (e.g
 
     # Build base packages
     if "base" in options.actions:
-        install_conda(options.python)
+        if options.mamba:
+            install_micromamba(options.python)
+        else:
+            install_conda(options.python)
 
     # Configure, make, get revision numbers
     if "build" in options.actions:

--- a/libtbx_refresh.py
+++ b/libtbx_refresh.py
@@ -84,7 +84,7 @@ set PATH=%~dp0build\\bin;%PATH%
         script = """
 #!/bin/bash
 
-if [ -n "${LIBTBX_BUILD_RELOCATION_HINT}" ]; then
+if [ ! -z "${LIBTBX_BUILD_RELOCATION_HINT:-}" ]; then
   # possibly used for some logic in the installer
   LIBTBX_BUILD="${LIBTBX_BUILD_RELOCATION_HINT}"
   LIBTBX_BUILD_RELOCATION_HINT=

--- a/newsfragments/1676.feature
+++ b/newsfragments/1676.feature
@@ -1,0 +1,1 @@
+New bootstrap options ``--mamba`` to install with micromamba and ``--clean`` to remove installation caches straightaway.

--- a/newsfragments/1676.feature
+++ b/newsfragments/1676.feature
@@ -1,1 +1,1 @@
-New bootstrap options ``--mamba`` to install with micromamba and ``--clean`` to remove installation caches straightaway.
+New bootstrap options: ``--mamba`` to install with `micromamba <https://github.com/mamba-org/mamba#micromamba>`_, and ``--clean`` to remove installation caches immediately after completion.

--- a/newsfragments/1676.misc
+++ b/newsfragments/1676.misc
@@ -1,0 +1,1 @@
+Update Azure build scripts


### PR DESCRIPTION
* Remove build caches, because they're not trustworthy anyway (cf. #1582)
* Simplify the build scripts
* Replace miniconda with micromamba (new bootstrap parameter `--mamba`)
* new bootstrap parameter `--clean` to remove the temporary miniconda/micromamba install straightaway

Preparatory step before we look into more complicated testing workflows on Azure (#1671)