### PR TITLE
Rename flatten_reflections

### DIFF
--- a/command_line/anvil_correction.py
+++ b/command_line/anvil_correction.py
@@ -37,7 +37,7 @@ from dials.util.multi_dataset_handling import (
     parse_multiple_datasets,
     sort_tables_to_experiments_order,
 )
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, flatten_experiments, renumber_reflections
 
 try:
     from typing import List, Sequence, SupportsFloat
@@ -326,7 +326,7 @@ def run(args: List[str] = None, phil: libtbx.phil.scope = phil_scope) -> None:
 
     # These functions are commonly used to collate the input.
     experiments = flatten_experiments(params.input.experiments)
-    reflections_list = flatten_reflections(params.input.reflections)
+    reflections_list = renumber_reflections(params.input.reflections)
     # Work around parse_multiple_datasets dropping unindexed reflections.
     unindexed = flex.reflection_table()
     for r_table in reflections_list:

--- a/command_line/image_viewer.py
+++ b/command_line/image_viewer.py
@@ -8,7 +8,7 @@ import iotbx.phil
 
 import dials.util.log
 from dials.util.image_viewer.spotfinder_wrap import spot_wrapper
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, flatten_experiments, renumber_reflections
 
 help_message = """
 
@@ -183,7 +183,7 @@ def run(args=None):
     )
     params, options = parser.parse_args(args, show_diff_phil=True)
     experiments = [x.data for x in params.input.experiments]
-    reflections = flatten_reflections(params.input.reflections)
+    reflections = renumber_reflections(params.input.reflections)
 
     if len(experiments) == 0:
         parser.print_help()

--- a/command_line/missing_reflections.py
+++ b/command_line/missing_reflections.py
@@ -24,7 +24,7 @@ import dials.util.log
 from dials.report.analysis import scaled_data_as_miller_array
 from dials.util import missing_reflections, tabulate
 from dials.util.filter_reflections import filtered_arrays_from_experiments_reflections
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, flatten_experiments, renumber_reflections
 from dials.util.version import dials_version
 
 logger = logging.getLogger("dials.missing_reflections")
@@ -68,7 +68,7 @@ def run(args: List[str] = None, phil: libtbx.phil.scope = phil_scope) -> None:
         logger.info("The following parameters have been modified:\n%s", diff_phil)
 
     experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections = renumber_reflections(params.input.reflections)
 
     if not experiments or not reflections:
         parser.print_help()

--- a/command_line/reflection_viewer.py
+++ b/command_line/reflection_viewer.py
@@ -29,12 +29,12 @@ class Script:
 
     def run(self, args=None):
 
-        from dials.util.options import flatten_reflections
+        from dials.util.options import renumber_reflections
         from dials.viewer.viewer_interface import extract_n_show
 
         # Parse the command line
         params, options = self.parser.parse_args(args, show_diff_phil=True)
-        table = flatten_reflections(params.input.reflections)
+        table = renumber_reflections(params.input.reflections)
         if len(table) == 0:
             self.parser.print_help()
             return

--- a/command_line/sort_reflections.py
+++ b/command_line/sort_reflections.py
@@ -56,11 +56,11 @@ class Sort:
 
     def run(self, args=None):
         """Execute the script."""
-        from dials.util.options import flatten_reflections
+        from dials.util.options import renumber_reflections
 
         # Parse the command line
         params, options = self.parser.parse_args(args, show_diff_phil=True)
-        reflections = flatten_reflections(params.input.reflections)
+        reflections = renumber_reflections(params.input.reflections)
         if not reflections:
             self.parser.print_help()
             return

--- a/doc/examples/boilerplate.py
+++ b/doc/examples/boilerplate.py
@@ -28,9 +28,9 @@ from dials.array_family import flex
 
 # The DIALS option parser is based on the (old) standard Python option parser,
 # but contains customisations such as the parsing of PHIL parameters.
-# flatten_experiments & flatten_reflections are useful for combining multiple input
+# flatten_experiments & renumber_reflections are useful for combining multiple input
 # experiment lists and reflection tables into a single instance of each.
-from dials.util.options import OptionParser, flatten_experiments, flatten_reflections
+from dials.util.options import OptionParser, flatten_experiments, renumber_reflections
 
 # Useful to know what version of DIALS we are running
 from dials.util.version import dials_version
@@ -146,7 +146,7 @@ def run(args: List[str] = None, phil: libtbx.phil.scope = phil_scope) -> None:
 
     # These functions are commonly used to collate the input.
     experiments = flatten_experiments(params.input.experiments)
-    reflections = flatten_reflections(params.input.reflections)
+    reflections = renumber_reflections(params.input.reflections)
 
     # You might well wish to check here that the command-line input is appropriate.
     if len(reflections) != 1:

--- a/doc/examples/read_experiment_and_data/experiment_data.py
+++ b/doc/examples/read_experiment_and_data/experiment_data.py
@@ -42,7 +42,7 @@ class Script:
         params, options = self.parser.parse_args(show_diff_phil=True)
 
         experiments = dials.util.options.flatten_experiments(params.input.experiments)
-        reflections = dials.util.options.flatten_reflections(params.input.reflections)
+        reflections = dials.util.options.renumber_reflections(params.input.reflections)
 
         if len(experiments) == 0:
             self.parser.print_help()

--- a/newsfragments/XXX.removal
+++ b/newsfragments/XXX.removal
@@ -1,0 +1,1 @@
+dials.util.flatten_reflections has been renamed renumber_reflections

--- a/test/algorithms/integration/test_filter_overlaps.py
+++ b/test/algorithms/integration/test_filter_overlaps.py
@@ -18,7 +18,7 @@ def test_for_overlaps(dials_regression):
     def is_overlap(code):
         return (code & code_overlap) == code_overlap
 
-    from dials.util.options import Importer, flatten_experiments, flatten_reflections
+    from dials.util.options import Importer, flatten_experiments, renumber_reflections
 
     # test data
     refl_path = os.path.join(
@@ -41,7 +41,7 @@ def test_for_overlaps(dials_regression):
         check_format=False,
     )
 
-    reflections = flatten_reflections(importer.reflections)
+    reflections = renumber_reflections(importer.reflections)
     experiments = flatten_experiments(importer.experiments)
 
     from dials.algorithms.integration.overlaps_filter import OverlapsFilterMultiExpt

--- a/test/util/test_options.py
+++ b/test/util/test_options.py
@@ -12,8 +12,8 @@ from dials.test.util import mock_reflection_file_object, mock_two_reflection_fil
 from dials.util import Sorry
 from dials.util.options import (
     OptionParser,
-    flatten_reflections,
     reflections_and_experiments_from_files,
+    renumber_reflections,
 )
 
 
@@ -34,7 +34,7 @@ def test_flatten_experiments_updating_id_values():
     """
     # Test the case of two single reflection tables.
     file_list = [mock_reflection_file_object(id_=0), mock_reflection_file_object(id_=0)]
-    rs = flatten_reflections(file_list)
+    rs = renumber_reflections(file_list)
     assert rs[0] is file_list[0].data
     assert list(rs[0]["id"]) == [-1, 0, 0]
     assert list(rs[0].experiment_identifiers().keys()) == [0]
@@ -46,7 +46,7 @@ def test_flatten_experiments_updating_id_values():
 
     # Now test the case where one reflection table contains two experiments
     file_list = [mock_two_reflection_file_object(), mock_reflection_file_object(id_=0)]
-    rs = flatten_reflections(file_list)
+    rs = renumber_reflections(file_list)
     assert rs[0] is file_list[0].data
     assert list(rs[0]["id"]) == [-1, 0, 0, 1, 1]
     assert list(rs[0].experiment_identifiers().keys()) == [0, 1]
@@ -60,7 +60,7 @@ def test_flatten_experiments_updating_id_values():
         mock_reflection_file_object(id_=0),
         mock_two_reflection_file_object(ids=[1, 2]),
     ]
-    rs = flatten_reflections(file_list)
+    rs = renumber_reflections(file_list)
     assert rs[0] is file_list[0].data
     assert list(rs[0]["id"]) == [-1, 0, 0]
     assert list(rs[0].experiment_identifiers().keys()) == [0]

--- a/util/options.py
+++ b/util/options.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import sys
 import traceback
+import warnings
 from collections import defaultdict, namedtuple
 from glob import glob
 
@@ -1083,6 +1084,14 @@ class OptionParser(OptionParserBase):
 
 
 def flatten_reflections(filename_object_list):
+    warnings.warn(
+        "flatten_experiments has been renamed renumber_reflections",
+        PendingDeprecationWarning,
+    )
+    return renumber_reflections(filename_object_list)
+
+
+def renumber_reflections(filename_object_list):
     """
     Flatten a list of reflections tables
 
@@ -1120,7 +1129,7 @@ def reflections_and_experiments_from_files(
     If experiment identifiers are set, the order of the reflection tables is
     changed to match the order of experiments.
     """
-    tables = flatten_reflections(reflection_file_object_list)
+    tables = renumber_reflections(reflection_file_object_list)
 
     experiments = flatten_experiments(experiment_file_object_list)
 


### PR DESCRIPTION
Since what it _actually_ does is renumber them, name accordingly, add a
stub with the old name triggering a deprecation warning. For #1681