### PR TITLE
Faster numpy-based matching of miller indices

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -24,6 +24,7 @@ conda-forge::msgpack-c
 conda-forge::msgpack-python
 conda-forge::numpy>=1.16
 conda-forge::orderedset
+conda-forge::pandas
 conda-forge::pillow>=5.4.1
 conda-forge::pip
 conda-forge::procrunner>=2.2.0

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -25,6 +25,7 @@ conda-forge::msgpack-c
 conda-forge::msgpack-python
 conda-forge::numpy>=1.16
 conda-forge::orderedset
+conda-forge::pandas
 conda-forge::pillow>=5.4.1
 conda-forge::pip
 conda-forge::procrunner>=2.2.0

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -24,6 +24,7 @@ conda-forge::msgpack-c
 conda-forge::msgpack-python
 conda-forge::numpy>=1.16
 conda-forge::orderedset
+conda-forge::pandas
 conda-forge::pillow>=5.4.1
 conda-forge::pip
 conda-forge::procrunner>=2.2.0

--- a/algorithms/symmetry/cosym/__init__.py
+++ b/algorithms/symmetry/cosym/__init__.py
@@ -81,9 +81,10 @@ minimization {
     .type = int(value_min=0)
 }
 
-nproc = 1
+nproc = None
   .type = int(value_min=1)
-  .help = "The number of processes to use."
+  .help = "Deprecated"
+  .deprecated = True
 """
 )
 
@@ -199,7 +200,6 @@ class CosymAnalysis(symmetry_base, Subject):
             lattice_group=self.lattice_group,
             dimensions=dimensions,
             weights=self.params.weights,
-            nproc=self.params.nproc,
         )
 
     def _determine_dimensions(self):

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -264,7 +264,7 @@ class Target:
                                     intensities_i[isel_i],
                                     intensities_j[isel_j],
                                 )
-                            if np.isnan(cc):
+                            if cc is not None and np.isnan(cc):
                                 cc = None
                                 n = None
 

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -203,7 +203,7 @@ class Target:
                 column = np.ravel_multi_index((i, j), (n_sym_ops, n_lattices))
                 all_intensities[column, mil_ind[selection]] = intensities[selection]
 
-        rij = DataFrame(all_intensities).T.corr().values
+        rij = DataFrame(all_intensities).T.dropna(how="all").corr().values
         np.nan_to_num(rij, copy=False)
 
         if self._weights:

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -220,11 +220,9 @@ class Target:
 
             # For each correlation coefficient, set the weight equal to the size of
             # the sample used to calculate that coefficient.
-            pairwise_combinations = itertools.combinations(
-                np.isfinite(all_intensities), 2
-            )
+            pairwise_combos = itertools.combinations(np.isfinite(all_intensities), 2)
             sample_size = lambda x, y: np.count_nonzero(x & y)
-            wij[right_up] = list(itertools.starmap(sample_size, pairwise_combinations))
+            wij[right_up] = list(itertools.starmap(sample_size, pairwise_combos))
 
             if self._weights == "standard_error":
                 # Set each weights as the reciprocal of the standard error on the

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -204,9 +204,9 @@ class Target:
             for j, selection in enumerate(slices):
                 column = np.ravel_multi_index((i, j), (n_sym_ops, n_lattices))
                 valid = eps[selection] == 1
-                all_intensities[column, mil_ind[selection][valid]] = intensities[
-                    selection
-                ][valid]
+                valid_mil_ind = mil_ind[selection][valid]
+                valid_intensities = intensities[selection][valid]
+                all_intensities[column, valid_mil_ind] = valid_intensities
 
         rij = pd.DataFrame(all_intensities).T.dropna(how="all").corr().values
         # Set any NaN correlation coefficients to zero.

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -215,13 +215,14 @@ class Target:
         np.fill_diagonal(rij, 0)
 
         if self._weights:
-            # Set the weight for each correlation coefficient equal to the size of
-            # the sample used to calculate that coefficient.
             wij = np.zeros_like(rij)
             right_up = np.triu_indices_from(wij, k=1)
 
-            sample_size = lambda x, y: np.count_nonzero(~np.isnan([x, y]).any(axis=0))
-            wij[right_up] = list(starmap(sample_size, combinations(all_intensities, 2)))
+            # For each correlation coefficient, set the weight equal to the size of
+            # the sample used to calculate that coefficient.
+            pairwise_combinations = combinations(np.isfinite(all_intensities), 2)
+            sample_size = lambda x, y: np.count_nonzero(x & y)
+            wij[right_up] = list(starmap(sample_size, pairwise_combinations))
 
             if self._weights == "standard_error":
                 # Set each weights as the reciprocal of the standard error on the

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -1,6 +1,7 @@
 """Target function for cosym analysis."""
 
 import copy
+import itertools
 import logging
 import warnings
 
@@ -210,8 +211,6 @@ class Target:
             wij = np.zeros((NN, NN))
         else:
             wij = None
-
-        import itertools
 
         indices_lower = self._lattices[np.arange(n_lattices)]
         indices_upper = np.append(indices_lower[1:], intensities.size)

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -5,8 +5,8 @@ import logging
 import warnings
 
 import numpy as np
-from numpy import ma
 from orderedset import OrderedSet
+from pandas import DataFrame
 
 import cctbx.sgtbx.cosets
 from cctbx import miller, sgtbx
@@ -196,12 +196,14 @@ class Target:
         all_intensities = np.empty((NN, np.prod(dims)))
         all_intensities.fill(np.nan)
 
+        slices = np.append(self._lattices, intensities.size)
+        slices = map(slice, slices[:-1], slices[1:])
         for i, mil_ind in enumerate(indices.values()):
-            for j, lattice in enumerate(self._lattices):
+            for j, selection in enumerate(slices):
                 column = np.ravel_multi_index((i, j), (n_sym_ops, n_lattices))
-                all_intensities[column, mil_ind] = intensities[lattice]
+                all_intensities[column, mil_ind[selection]] = intensities[selection]
 
-        rij = ma.corrcoef(ma.masked_invalid(all_intensities))
+        rij = DataFrame(all_intensities).T.corr().values
 
         if self._weights:
             wij = np.zeros((NN, NN))

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -216,7 +216,7 @@ class Target:
             # Set the weight for each correlation coefficient equal to the size of
             # the sample used to calculate that coefficient.
             sample_size = lambda x, y: np.count_nonzero(~np.isnan([x, y]).any(axis=0))
-            wij = all_intensities.corr(method=sample_size)
+            wij = all_intensities.corr(method=sample_size).values
 
             # Similarly, set the diagonal elements to the number of
             diag = np.diag_indices_from(wij)

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -206,6 +206,8 @@ class Target:
         rij = DataFrame(all_intensities).T.dropna(how="all").corr().values
         np.nan_to_num(rij, copy=False)
 
+        # TODO: Reinstate the now broken weights calculation.
+
         if self._weights:
             wij = np.zeros((NN, NN))
         else:

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -197,13 +197,13 @@ class Target:
         all_intensities.fill(np.nan)
 
         slices = np.append(self._lattices, intensities.size)
-        slices = map(slice, slices[:-1], slices[1:])
+        slices = list(map(slice, slices[:-1], slices[1:]))
         for i, mil_ind in enumerate(indices.values()):
             for j, selection in enumerate(slices):
                 column = np.ravel_multi_index((i, j), (n_sym_ops, n_lattices))
                 all_intensities[column, mil_ind[selection]] = intensities[selection]
 
-        rij = DataFrame(all_intensities).T.corr().values
+        rij = DataFrame(all_intensities).T.corr().fillna(0).values
 
         if self._weights:
             wij = np.zeros((NN, NN))

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -1,9 +1,9 @@
 """Target function for cosym analysis."""
 
 import copy
+import itertools
 import logging
 import warnings
-from itertools import combinations, starmap
 
 import numpy as np
 import pandas as pd
@@ -220,9 +220,11 @@ class Target:
 
             # For each correlation coefficient, set the weight equal to the size of
             # the sample used to calculate that coefficient.
-            pairwise_combinations = combinations(np.isfinite(all_intensities), 2)
+            pairwise_combinations = itertools.combinations(
+                np.isfinite(all_intensities), 2
+            )
             sample_size = lambda x, y: np.count_nonzero(x & y)
-            wij[right_up] = list(starmap(sample_size, pairwise_combinations))
+            wij[right_up] = list(itertools.starmap(sample_size, pairwise_combinations))
 
             if self._weights == "standard_error":
                 # Set each weights as the reciprocal of the standard error on the

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -148,15 +148,6 @@ class Target:
 
         return operators
 
-    def _lattice_lower_upper_index(self, lattice_id):
-        lower_index = int(self._lattices[lattice_id])
-        upper_index = None
-        if lattice_id < len(self._lattices) - 1:
-            upper_index = int(self._lattices[lattice_id + 1])
-        else:
-            assert lattice_id == len(self._lattices) - 1
-        return lower_index, upper_index
-
     def _compute_rij_wij(self, use_cache=True):
         """Compute the rij_wij matrix.
 

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -218,9 +218,8 @@ class Target:
             sample_size = lambda x, y: np.count_nonzero(~np.isnan([x, y]).any(axis=0))
             wij = all_intensities.corr(method=sample_size).values
 
-            # Similarly, set the diagonal elements to the number of
-            diag = np.diag_indices_from(wij)
-            wij[diag] = np.count_nonzero(~np.isnan(all_intensities.values), axis=0)
+            # Cosym does not make use of the on-diagonal correlation coefficients.
+            np.fill_diagonal(wij, 0)
 
             if self._weights == "standard_error":
                 # http://www.sjsu.edu/faculty/gerstman/StatPrimer/correlation.pdf
@@ -234,7 +233,6 @@ class Target:
                 )
 
                 wij = reciprocal_se + reciprocal_se.T
-                wij[diag] = np.inf
         else:
             wij = None
 

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -214,10 +214,12 @@ class Target:
             .values
         )
         np.nan_to_num(rij, copy=False)
+        np.fill_diagonal(rij, 0)
 
         if self._weights:
             valid = np.isfinite(all_intensities).astype(int)
             counts = valid.dot(valid.T)
+            np.fill_diagonal(counts, 0)
             if self._weights == "standard_error":
                 # http://www.sjsu.edu/faculty/gerstman/StatPrimer/correlation.pdf
                 sel = np.where((counts > 2) & (rij < 1))

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -203,7 +203,8 @@ class Target:
                 column = np.ravel_multi_index((i, j), (n_sym_ops, n_lattices))
                 all_intensities[column, mil_ind[selection]] = intensities[selection]
 
-        rij = DataFrame(all_intensities).T.corr().fillna(0).values
+        rij = DataFrame(all_intensities).T.corr().values
+        np.nan_to_num(rij, copy=False)
 
         if self._weights:
             wij = np.zeros((NN, NN))

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -31,7 +31,7 @@ class Target:
         min_pairs=3,
         lattice_group=None,
         dimensions=None,
-        nproc=1,
+        nproc=None,
     ):
         r"""Intialise a Target object.
 
@@ -55,13 +55,15 @@ class Target:
             in the analysis. If not set, then the number of dimensions used is
             equal to the greater of 2 or the number of symmetry operations in the
             lattice group.
-          nproc (int): number of processors to use for computing the rij matrix.
+          nproc (int): Deprecated
         """
+        if nproc is not None:
+            warnings.warn("nproc is deprecated", DeprecationWarning)
+
         if weights is not None:
             assert weights in ("count", "standard_error")
         self._weights = weights
         self._min_pairs = min_pairs
-        self._nproc = nproc
 
         data = intensities.customized_copy(anomalous_flag=False)
         cb_op_to_primitive = data.change_of_basis_op_to_primitive_setting()

--- a/algorithms/symmetry/cosym/target.py
+++ b/algorithms/symmetry/cosym/target.py
@@ -210,7 +210,12 @@ class Target:
                 valid_intensities = intensities[selection][valid]
                 all_intensities[column, valid_mil_ind] = valid_intensities
 
-        rij = pd.DataFrame(all_intensities).T.dropna(how="all").corr().values
+        rij = (
+            pd.DataFrame(all_intensities)
+            .T.dropna(how="all")
+            .corr(min_periods=self._min_pairs)
+            .values
+        )
         # Set any NaN correlation coefficients to zero.
         np.nan_to_num(rij, copy=False)
         # Cosym does not make use of the on-diagonal correlation coefficients.

--- a/command_line/cosym.py
+++ b/command_line/cosym.py
@@ -156,7 +156,7 @@ class cosym(Subject):
         )
 
         datasets = [
-            ma.as_anomalous_array().merge_equivalents().array() for ma in datasets
+            ma.as_non_anomalous_array().merge_equivalents().array() for ma in datasets
         ]
         self.cosym_analysis = CosymAnalysis(datasets, self.params)
 

--- a/libtbx_config
+++ b/libtbx_config
@@ -10,6 +10,7 @@
         "Jinja2",
         "msgpack",
         "orderedset",
+        "pandas",
         "procrunner>=1.0.2",
         "psutil",
         "pytest>=4.5,<5.0",

--- a/newsfragments/1693.feature
+++ b/newsfragments/1693.feature
@@ -1,0 +1,1 @@
+``dials.cosym``: Faster calculation of Rij matrix of pairwise correlation coefficients

--- a/newsfragments/1693.feature
+++ b/newsfragments/1693.feature
@@ -1,1 +1,1 @@
-``dials.cosym``: Significantly faster calculation of Rij matrix of pairwise correlation coefficients; deprecation of ``nproc`` parameter
+``dials.cosym``: Significantly faster calculation of Rij matrix of pairwise correlation coefficients

--- a/newsfragments/1693.feature
+++ b/newsfragments/1693.feature
@@ -1,1 +1,1 @@
-``dials.cosym``: Faster calculation of Rij matrix of pairwise correlation coefficients
+``dials.cosym``: Faster calculation of Rij matrix of pairwise correlation coefficients; deprecation of ``nproc`` parameter

--- a/newsfragments/1693.feature
+++ b/newsfragments/1693.feature
@@ -1,1 +1,1 @@
-``dials.cosym``: Faster calculation of Rij matrix of pairwise correlation coefficients; deprecation of ``nproc`` parameter
+``dials.cosym``: Significantly faster calculation of Rij matrix of pairwise correlation coefficients; deprecation of ``nproc`` parameter

--- a/newsfragments/1693.removal
+++ b/newsfragments/1693.removal
@@ -1,0 +1,1 @@
+``dials.cosym``: ``nproc=`` parameter is deprecated. The algorithm is much faster on single cores.


### PR DESCRIPTION
Replace use of the cctbx `match_miller_indices()` method with a faster numpy-based approach.

1. Pre-calculate a mapping of miller indices to a 1D array (using `np.ravel_multi_index()`)
2. Pre-calculate epsilons
3. For each CC1/2 calculation, identify the matching pairs of indices using `np.intersect1d()`

Using a multi-crystal example with 133 datasets in `P 3 2 1` (i.e. an Rij matrix of size `(12 * 133) ** 2 == 2547216`), this PR improves the time taken to calculated the Rij matrix from 126 seconds to 79 seconds.