### PR TITLE
Enumerate experiment index

### DIFF
--- a/algorithms/refinement/refiner.py
+++ b/algorithms/refinement/refiner.py
@@ -196,7 +196,7 @@ def _trim_scans_to_observations(experiments, reflections):
         else:
             obs_start = int(min_exp_z)
             obs_stop = int(math.ceil(max_exp_z))
-            half_deg_in_images = int(math.ceil(0.5 / exp.scan.get_oscillation()[1]))
+            half_deg_in_images = int(math.ceil(0.5 / expt.scan.get_oscillation()[1]))
             obs_start -= half_deg_in_images
             obs_stop += half_deg_in_images
 

--- a/command_line/find_spots.py
+++ b/command_line/find_spots.py
@@ -173,19 +173,19 @@ class Script:
         # ascii spot count per image plot - per imageset
 
         imagesets = []
-        for i, experiment in enumerate(experiments):
+        for experiment in experiments:
             if experiment.imageset not in imagesets:
                 imagesets.append(experiment.imageset)
 
         for imageset in imagesets:
             selected = flex.bool(reflections.nrows(), False)
-            for i, experiment in enumerate(experiments):
-                if experiment.imageset is not imageset:
+            for expt in experiments:
+                if expt.imageset is not imageset:
                     continue
-                selected.set_selected(reflections["id"] == i, True)
+                selected.set_selected(reflections["id"] == expt.index, True)
             ascii_plot = spot_counts_per_image_plot(reflections.select(selected))
             if len(ascii_plot):
-                logger.info("\nHistogram of per-image spot count for imageset %i:", i)
+                logger.info("\nHistogram of per-image spot count for imageset %i:", expt.index)
                 logger.info(ascii_plot)
 
         # Save the reflections to file
@@ -217,9 +217,9 @@ class Script:
 
         # Print some per image statistics
         if params.per_image_statistics:
-            for i, experiment in enumerate(experiments):
-                logger.info("Number of centroids per image for imageset %i:", i)
-                refl = reflections.select(reflections["id"] == i)
+            for expt in experiments:
+                logger.info("Number of centroids per image for imageset %i:", expt.index)
+                refl = reflections.select(reflections["id"] == expt.index)
                 refl.centroid_px_to_mm([experiment])
                 refl.map_centroids_to_reciprocal_space([experiment])
                 stats = per_image_analysis.stats_per_image(

--- a/command_line/frame_orientations.py
+++ b/command_line/frame_orientations.py
@@ -85,16 +85,16 @@ plot_filename = None
             "Angles between beam\nand axes a, b, c (deg)",
             "Angle from\nprevious image (deg)",
         ]
-        for iexp, exp in enumerate(experiments):
-            print(f"For Experiment id = {iexp}")
-            print(exp.beam)
-            print(exp.crystal)
-            print(exp.scan)
+        for expt in experiments:
+            print(f"For Experiment id = {expt.index}")
+            print(expt.beam)
+            print(expt.crystal)
+            print(expt.scan)
 
             if self.params.scale == "ewald_sphere_radius":
                 scale = 1.0 / exp.beam.get_wavelength()
             elif self.params.scale == "max_cell":
-                uc = exp.crystal.get_unit_cell()
+                uc = expt.crystal.get_unit_cell()
                 scale = max(uc.parameters()[0:3])
             else:
                 scale = 1.0
@@ -103,7 +103,7 @@ plot_filename = None
                 "calculate zone axis\n".format(self.params.scale, scale)
             )
 
-            dat = extract_experiment_data(exp, scale)
+            dat = extract_experiment_data(expt, scale)
             images = dat["images"]
             directions = dat["directions"]
             zone_axes = dat["zone_axes"]

--- a/command_line/index.py
+++ b/command_line/index.py
@@ -172,8 +172,8 @@ def index(experiments, reflections, params):
             max_workers=params.indexing.nproc
         ) as pool:
             futures = []
-            for i_expt, expt in enumerate(experiments):
-                refl = reflections.select(reflections["imageset_id"] == i_expt)
+            for expt in experiments:
+                refl = reflections.select(reflections["imageset_id"] == expt.index)
                 refl["imageset_id"] = flex.size_t(len(refl), 0)
                 futures.append(
                     pool.submit(

--- a/command_line/plot_scan_varying_model.py
+++ b/command_line/plot_scan_varying_model.py
@@ -115,10 +115,10 @@ class Script:
 
         # cell plot
         dat = []
-        for iexp, exp in enumerate(experiments):
+        for expt in experiments:
 
-            crystal = exp.crystal
-            scan = exp.scan
+            crystal = expt.crystal
+            scan = expt.scan
 
             if crystal.num_scan_points == 0:
                 print("Ignoring scan-static crystal")
@@ -167,10 +167,10 @@ class Script:
 
         # orientation plot
         dat = []
-        for iexp, exp in enumerate(experiments):
+        for expt in experiments:
 
-            crystal = exp.crystal
-            scan = exp.scan
+            crystal = expt.crystal
+            scan = expt.scan
 
             if crystal.num_scan_points == 0:
                 print("Ignoring scan-static crystal")
@@ -207,11 +207,11 @@ class Script:
 
         # beam centre plot
         dat = []
-        for iexp, exp in enumerate(experiments):
+        for expt in experiments:
 
-            beam = exp.beam
-            detector = exp.detector
-            scan = exp.scan
+            beam = expt.beam
+            detector = expt.detector
+            scan = expt.scan
 
             if beam.num_scan_points == 0:
                 print("Ignoring scan-static beam")

--- a/command_line/predict.py
+++ b/command_line/predict.py
@@ -82,7 +82,7 @@ class Script:
 
         predicted_all = flex.reflection_table()
 
-        for i_expt, expt in enumerate(experiments):
+        for expt in experiments:
             if params.buffer_size > 0:
                 # Hack to make the predicter predict reflections outside of the range
                 # of the scan
@@ -106,7 +106,7 @@ class Script:
             predicted = flex.reflection_table.from_predictions(
                 expt, force_static=params.force_static, dmin=params.d_min
             )
-            predicted["id"] = flex.int(len(predicted), i_expt)
+            predicted["id"] = flex.int(len(predicted), expt.index)
             predicted_all.extend(predicted)
 
         # if we are not ignoring shadows, look for reflections in the masked

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -385,16 +385,16 @@ def run(args=None, phil=working_phil):
         # split the crystals
 
         crystal_has_scan = {}
-        for j, e in enumerate(experiments):
-            if e.crystal in crystal_has_scan:
-                if e.scan is not crystal_has_scan[e.crystal]:
+        for expt in experiments:
+            if expt.crystal in crystal_has_scan:
+                if expt.scan is not crystal_has_scan[expt.crystal]:
                     logger.info(
                         "Duplicating crystal model for scan-varying refinement of experiment %d",
-                        j,
+                        expt.index,
                     )
-                    e.crystal = copy.deepcopy(e.crystal)
+                    expt.crystal = copy.deepcopy(expt.crystal)
             else:
-                crystal_has_scan[e.crystal] = e.scan
+                crystal_has_scan[expt.crystal] = expt.scan
 
     # Run refinement
     experiments, reflections, refiner, history = run_dials_refine(

--- a/command_line/search_beam_position.py
+++ b/command_line/search_beam_position.py
@@ -118,12 +118,12 @@ def optimize_origin_offset_local_scope(
             return sum(
                 _get_origin_offset_score(
                     new_origin_offset,
-                    solution_lists[i],
-                    amax_lists[i],
-                    reflection_lists[i],
-                    experiment,
+                    solution_lists[expt.index],
+                    amax_lists[expt.index],
+                    reflection_lists[expt.index],
+                    expt,
                 )
-                for i, experiment in enumerate(experiments)
+                for expt in experiments
             )
 
         scores = flex.double(
@@ -175,13 +175,13 @@ def optimize_origin_offset_local_scope(
             if self.wide_search_offset is not None:
                 trial_origin_offset += self.wide_search_offset
             target = 0
-            for i, experiment in enumerate(experiments):
+            for expt in experiments:
                 target -= _get_origin_offset_score(
                     trial_origin_offset,
-                    solution_lists[i],
-                    amax_lists[i],
-                    reflection_lists[i],
-                    experiment,
+                    solution_lists[expt.index],
+                    amax_lists[expt.index],
+                    reflection_lists[expt.index],
+                    expt,
                 )
             return target
 
@@ -195,13 +195,13 @@ def optimize_origin_offset_local_scope(
             for x in range(-grid, grid + 1):
                 new_origin_offset = x * plot_px_sz * beamr1 + y * plot_px_sz * beamr2
                 score = 0
-                for i, experiment in enumerate(experiments):
+                for expt in experiments:
                     score += _get_origin_offset_score(
                         new_origin_offset,
-                        solution_lists[i],
-                        amax_lists[i],
-                        reflection_lists[i],
-                        experiment,
+                        solution_lists[expt.index],
+                        amax_lists[expt.index],
+                        reflection_lists[expt.index],
+                        expt,
                     )
                 scores.append(score)
 

--- a/command_line/show.py
+++ b/command_line/show.py
@@ -245,8 +245,8 @@ def run(args=None):
 def show_experiments(experiments, show_scan_varying=False):
 
     text = []
-    for i_expt, expt in enumerate(experiments):
-        text.append("Experiment %i:" % i_expt)
+    for expt in experiments:
+        text.append("Experiment %i:" % expt.index)
         format_class = expt.imageset.get_format_class()
         if format_class.__name__ != "Format":
             text.append(f"Format class: {format_class.__name__}")
@@ -323,7 +323,7 @@ def show_image_statistics(experiments, im_type):
         )
 
     print(f"Five number summary of the {im_type} images")
-    for i_expt, expt in enumerate(experiments):
+    for expt in experiments:
         for i in range(len(expt.imageset)):
             identifier = os.path.basename(expt.imageset.get_image_identifier(i))
             if raw:
@@ -349,10 +349,10 @@ def model_connectivity(experiments):
         text.append(f"{model.capitalize()}:")
         models = getattr(experiments, f"{model}s")()
         rows = [[""] + [str(j) for j in range(len(models))]]
-        for j, e in enumerate(experiments):
-            row = ["Experiment %d" % j]
+        for expt in experiments:
+            row = ["Experiment %d" % expt.index]
             for m in models:
-                if getattr(e, model) is m:
+                if getattr(expt, model) is m:
                     row.append("x")
                 else:
                     row.append(".")

--- a/command_line/spot_counts_per_image.py
+++ b/command_line/spot_counts_per_image.py
@@ -74,8 +74,8 @@ def run(args=None):
         reflections = reflections.select(reflections["id"] == params.id)
 
     all_stats = []
-    for i, expt in enumerate(experiments):
-        refl = reflections.select(reflections["id"] == i)
+    for expt in experiments:
+        refl = reflections.select(reflections["id"] == expt.index)
         stats = per_image_analysis.stats_per_image(
             expt, refl, resolution_analysis=params.resolution_analysis
         )

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -243,7 +243,8 @@ def apply_change_of_basis_ops(experiments, reflections, change_of_basis_ops):
 
 
 def eliminate_sys_absent(experiments, reflections):
-    for i, expt in enumerate(experiments):
+    for expt in experiments:
+        i = expt.index
         if expt.crystal.get_space_group().n_ltr() > 1:
             effective_group = (
                 expt.crystal.get_space_group().build_derived_reflection_intensity_group(

--- a/command_line/two_theta_refine.py
+++ b/command_line/two_theta_refine.py
@@ -195,13 +195,13 @@ class Script:
     @staticmethod
     def convert_to_P1(reflections, experiments):
         """Convert the input crystals to P 1 and reindex the reflections"""
-        for iexp, exp in enumerate(experiments):
-            sel = reflections["id"] == iexp
-            xl = exp.crystal
-            sg = xl.get_space_group()
+        for expt in experiments:
+            sel = reflections["id"] == expt.index
+            crystal = expt.crystal
+            sg = crystal.get_space_group()
             op = sg.info().change_of_basis_op_to_primitive_setting()
-            exp.crystal = xl.change_basis(op)
-            exp.crystal.set_space_group(sgtbx.space_group("P 1"))
+            expt.crystal = crystal.change_basis(op)
+            expt.crystal.set_space_group(sgtbx.space_group("P 1"))
             hkl_reindexed = op.apply(reflections["miller_index"].select(sel))
             reflections["miller_index"].set_selected(sel, hkl_reindexed)
         return reflections, experiments

--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Housekeeping: make use of experiment.index feature. 

--- a/test/algorithms/refinement/test_multi_experiment_refinement.py
+++ b/test/algorithms/refinement/test_multi_experiment_refinement.py
@@ -115,6 +115,10 @@ def test(args=[]):
         )
     )
 
+    # assign index as these are being created ab initio
+    for j, expt in enumerate(experiments):
+        expt.index = j
+
     assert len(experiments.detectors()) == 1
 
     ##########################################################


### PR DESCRIPTION
Start making use of experiment.index from https://github.com/cctbx/dxtbx/pull/359

This is largely "housekeeping" however is preliminary work for some other work towards #1029. 

This is work in progress - some of the changes are trivial but some of the instances are more involved. N.B. none of these changes are _critical_ for the `dxtbx` PR (or indeed, even needed) however are important for demonstrating that the changes are correct therein, as the `dials` tests pass. 

Have also identified a lot of cases where the pattern:

```
for j, expt in enumerate(experiments):
  # ignore j
```

is used so those become cleaner. Also found cases where `j` in the above example is clobbered by a loop variable as well. 