### PR TITLE
Remove various deprecations for DIALS 3.6

### DIFF
--- a/algorithms/refinement/reflection_manager.py
+++ b/algorithms/refinement/reflection_manager.py
@@ -4,7 +4,6 @@ principally ReflectionManager."""
 import logging
 import math
 import random
-import warnings
 
 import libtbx
 from libtbx.phil import parse
@@ -81,10 +80,6 @@ phil_str = (
               "if they are included."
       .type = float(value_min=0,value_max=5)
       .expert_level = 1
-
-    trim_scan_edges = None
-      .type = float(value_min=0,value_max=5)
-      .help = Deprecated. Use scan_margin instead
 
     weighting_strategy
       .help = "Parameters to configure weighting strategy overrides"
@@ -311,14 +306,6 @@ class ReflectionManagerFactory:
             weighting_strategy = ConstantWeightingStrategy(
                 *params.weighting_strategy.constants, stills=do_stills
             )
-
-        # Check for deprecated parameter
-        if params.trim_scan_edges is not None:
-            warnings.warn(
-                "The parameter trim_scan_edges is deprecated and will be removed shortly",
-                FutureWarning,
-            )
-            params.scan_margin = params.trim_scan_edges
 
         return refman(
             reflections=reflections,

--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -5,7 +5,6 @@ Contains implementation interface for finding spots on one or many images
 import logging
 import math
 import pickle
-import warnings
 from typing import Iterable, Tuple
 
 import libtbx
@@ -664,14 +663,6 @@ class SpotFinder:
         self.no_shoeboxes_2d = no_shoeboxes_2d
         self.min_chunksize = min_chunksize
         self.is_stills = is_stills
-
-    def __call__(self, experiments):
-        warnings.warn(
-            "Please use Spotfinder.find_spots to run spotfinding.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.find_spots(experiments)
 
     def find_spots(self, experiments: ExperimentList) -> flex.reflection_table:
         """

--- a/command_line/estimate_resolution.py
+++ b/command_line/estimate_resolution.py
@@ -1,5 +1,3 @@
-# LIBTBX_SET_DISPATCHER_NAME dials.estimate_resolution
-# LIBTBX_SET_DISPATCHER_NAME dials.resolutionizer
 """
 Estimate a resolution limit based on merging statistics calculated in resolution bins.
 
@@ -62,7 +60,6 @@ Use cc_ref resolution cutoff::
 import json
 import logging
 import sys
-import warnings
 
 from jinja2 import ChoiceLoader, Environment, PackageLoader
 
@@ -96,13 +93,6 @@ output {
 @show_mail_handle_errors()
 def run(args=None):
     usage = "dials.estimate_resolution [options] (scaled.expt scaled.refl | scaled_unmerged.mtz)"
-
-    import libtbx.load_env
-
-    if libtbx.env.dispatcher_name == "dials.resolutionizer":
-        warnings.warn(
-            "dials.resolutionizer is now deprecated, please use dials.estimate_resolution instead"
-        )
 
     parser = OptionParser(
         usage=usage,

--- a/doc/sphinx/documentation/tutorials/multi_crystal_symmetry_and_scaling.rst
+++ b/doc/sphinx/documentation/tutorials/multi_crystal_symmetry_and_scaling.rst
@@ -76,7 +76,7 @@ To run :samp:`xia2.multiplex`, we must provide the path to the input integrated 
 
 This runs :samp:`dials.cosym` to analyse the Laue symmetry and reindex all datasets
 consistently, scales the data with :samp:`dials.scale`,
-calculates a resolution limit with :samp:`dials.resolutionizer` and reruns
+calculates a resolution limit with :samp:`dials.estimate_resolution` and reruns
 :samp:`dials.scale` with the determined resolution cutoff. The
 final dataset is exported to an unmerged mtz and a
 `HTML report <https://dials.github.io/tutorial_data/master/multi_crystal/xia2.multiplex.html>`_
@@ -126,9 +126,9 @@ Next, the data can be scaled:
 From the merging statistics it is clear that the data quality is good out to the
 furthest resolution (:math:`CC_{1/2} > 0.3`), which can be confirmed by a resolution analysis:
 
-.. dials_tutorial_include:: multi_crystal/dials.resolutionizer.cmd
+.. dials_tutorial_include:: multi_crystal/dials.estimate_resolution.cmd
 
-.. dials_tutorial_include:: multi_crystal/dials.resolutionizer.log
+.. dials_tutorial_include:: multi_crystal/dials.estimate_resolution.log
    :start-at: Resolution cc_half
    :end-at: Resolution cc_half
 
@@ -138,7 +138,7 @@ furthest resolution (:math:`CC_{1/2} > 0.3`), which can be confirmed by a resolu
 
         **Show/Hide Log**
 
-    .. dials_tutorial_include:: multi_crystal/dials.resolutionizer.log
+    .. dials_tutorial_include:: multi_crystal/dials.estimate_resolution.log
 
 
 If the resolution limit was lower than the extent of the data, scaling would

--- a/newsfragments/1330.removal
+++ b/newsfragments/1330.removal
@@ -1,0 +1,1 @@
+The previously deprecated ``dials.resolutionizer`` command has been removed. Please use ``dials.estimate_resolution`` instead.

--- a/newsfragments/1374.removal
+++ b/newsfragments/1374.removal
@@ -1,0 +1,1 @@
+The previously deprecated ``dials.refine`` parameter ``trim_scan_edges`` has been removed. Please use ``scan_margin=...`` instead.

--- a/newsfragments/1484.removal
+++ b/newsfragments/1484.removal
@@ -1,0 +1,1 @@
+The previously deprecated ``Spotfinder()()`` interface has been removed. Please use ``Spotfinder().find_spots()`` instead.

--- a/newsfragments/1569.removal
+++ b/newsfragments/1569.removal
@@ -1,0 +1,1 @@
+The previously deprecated ``dials.util.masking.MaskGenerator`` has been removed. Please use ``dials.util.masking.generate_mask`` instead.

--- a/tests/command_line/test_estimate_resolution.py
+++ b/tests/command_line/test_estimate_resolution.py
@@ -1,5 +1,6 @@
 import json
 
+import procrunner
 import pytest
 
 from dials.command_line import estimate_resolution as cmdline
@@ -78,17 +79,7 @@ def test_multi_sequence_with_batch_range(dials_data, run_in_tmpdir, capsys):
     assert run_in_tmpdir.join("dials.estimate_resolution.html").check(file=1)
 
 
-@pytest.mark.xfail("os.name == 'nt'", reason="warnings do not go to stderr")
 def test_dispatcher_name():
-    import procrunner
-
-    result = procrunner.run(["dials.resolutionizer"])
-    assert not result.returncode
-    assert (
-        b"dials.resolutionizer is now deprecated, please use dials.estimate_resolution instead"
-        in result.stderr
-    )
-
     result = procrunner.run(["dials.estimate_resolution"])
     assert not result.returncode
     assert not result.stderr

--- a/util/masking.py
+++ b/util/masking.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import math
 import time
-import warnings
 from collections import namedtuple
 from typing import Tuple
 
@@ -198,25 +197,6 @@ def _get_resolution_masker(beam, panel):
 
 def _apply_resolution_mask(mask, beam, panel, *args):
     _get_resolution_masker(beam, panel).apply(mask, *args)
-
-
-class MaskGenerator:
-    """
-    Deprecated interface for generating mask.
-
-    To be removed in DIALS 3.5.
-    """
-
-    def __init__(self, params):
-        warnings.warn(
-            "MaskGenerator is deprecated; please use dials.util.masking.generate_mask instead",
-            UserWarning,
-            stacklevel=2,
-        )
-        self.params = params
-
-    def generate(self, imageset):
-        return generate_mask(imageset, self.params)
 
 
 def generate_mask(


### PR DESCRIPTION
- `dials.resolutionizer` (#1330, July 2020)
- `dials.util.masking.MaskGenerator` (#1569, January 2021)
- `Spotfinder()()` interface (#1484, November 2020)
- `dials.refine` `trim_scan_edges=...` parameter (#1374, September 2020)