### PR TITLE
Preserve imageset_id information, and unindexed reflections, in dials.combine_experiments

### DIFF
--- a/command_line/combine_experiments.py
+++ b/command_line/combine_experiments.py
@@ -517,8 +517,10 @@ class Script:
         ):
             refs = ref_wrapper.data
             exps = exp_wrapper.data
+
             # Record initial mapping of ids for updating later.
             ids_map = dict(refs.experiment_identifiers())
+
             for k in refs.experiment_identifiers().keys():
                 del refs.experiment_identifiers()[k]
             for i, exp in enumerate(exps):
@@ -540,12 +542,13 @@ class Script:
 
                 nrefs_per_exp.append(n_sub_ref)
                 sub_ref["id"] = flex.int(len(sub_ref), global_id)
+
                 # now update identifiers if set.
                 if i in ids_map:
                     sub_ref.experiment_identifiers()[global_id] = ids_map[i]
                 if params.output.delete_shoeboxes and "shoebox" in sub_ref:
                     del sub_ref["shoebox"]
-                reflections.extend(sub_ref)
+
                 try:
                     experiments.append(combine(exp))
                 except ComparisonError as e:
@@ -557,6 +560,18 @@ class Script:
                             index, path, str(e)
                         )
                     )
+
+                # Get the index of the imageset for this experiment and record how it changed
+                new_imageset_id = experiments.imagesets().index(
+                    experiments[-1].imageset
+                )
+
+                # Update the imageset_id field if it exists
+                if "imageset_id" in sub_ref:
+                    assert len(set(sub_ref["imageset_id"])) == 1
+                    sub_ref["imageset_id"] = flex.int(len(sub_ref), new_imageset_id)
+
+                reflections.extend(sub_ref)
 
                 global_id += 1
 

--- a/newsfragments/1093.bugfix
+++ b/newsfragments/1093.bugfix
@@ -1,0 +1,1 @@
+``dials.combine_experiments``: Correctly preserve mapping to images. This affects ``dials.image_viewer`` and ``dial.reciprocal_lattice_viewer``.

--- a/newsfragments/1760.feature
+++ b/newsfragments/1760.feature
@@ -1,0 +1,1 @@
+``dials.combine_experiments``: Unindexed reflections are now included in the combined output

--- a/tests/command_line/test_combine_experiments.py
+++ b/tests/command_line/test_combine_experiments.py
@@ -425,11 +425,6 @@ def test_failed_tolerance_error(dials_regression, monkeypatch):
     print("Got (expected) error message:", exc.value)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    raises=AssertionError,
-    reason="https://github.com/dials/dials/issues/1093",
-)
 def test_combine_imagesets(dials_data, tmp_path):
     data = dials_data("vmxi_proteinase_k_sweeps", pathlib=True)
     args = [

--- a/tests/command_line/test_combine_experiments.py
+++ b/tests/command_line/test_combine_experiments.py
@@ -426,16 +426,18 @@ def test_failed_tolerance_error(dials_regression, monkeypatch):
 
 
 def test_combine_imagesets(dials_data, tmp_path):
-    data = dials_data("vmxi_proteinase_k_sweeps", pathlib=True)
+    data = dials_data("l_cysteine_dials_output", pathlib=True)
     args = [
-        *data.glob("*_[0123].expt"),
-        *data.glob("*_[0123].refl"),
+        *sorted(data.glob("*_integrated.pickle")),
+        *sorted(data.glob("*_integrated_experiments.json")),
         f"experiments_filename={tmp_path}/combined.expt",
         f"reflections_file={tmp_path}/combined.refl",
     ]
     combine_experiments.run([str(x) for x in args])
 
     comb = flex.reflection_table.from_file(tmp_path / "combined.refl")
-    iset = comb["imageset_id"]
 
-    assert set(iset) == {0, 1, 2, 3}
+    assert set(comb["imageset_id"]) == {0, 1, 2, 3}
+
+    # Check that we have preserved unindexed reflections for all of these
+    assert set(comb.select(comb["id"] == -1)["imageset_id"]) == {0, 1, 2, 3}


### PR DESCRIPTION
Previously, the `"imageset_id"` column of the reflection table became meaningless after `dials.combine_experiments` because the mapping between imageset and reflection was lost for unindexed reflections. In addition, `dials.image_viewer` and `dials.reciprocal_lattice_viewer` relied on this mapping for indexed reflections, leading to #1093.

This change preserves the mapping by working out what the old and new indexes were, and rewrites the reflections. Because this mapping is preserved, unindexed reflections can now be carried over to the combined file.

I've also rewritten the test to use the `l_cysteine_dials_output` test output instead of `vmxi_proteinase_k_sweeps`, because the latter does not include unindexed reflections.

Partially #1093 fix. `dials.scale` probably also requires separate attention.

