### PR TITLE
DIALS 3.5.2

### DIFF
--- a/newsfragments/1734.bugfix
+++ b/newsfragments/1734.bugfix
@@ -1,0 +1,1 @@
+``dials.image_viewer``: Fix display of spotfinding intermediates (threshold, dispersion, etc) when viewing multiple still experiments

--- a/newsfragments/1758.bugfix
+++ b/newsfragments/1758.bugfix
@@ -1,0 +1,1 @@
+``dials.image_viewer``: Stacking images no longer gives incorrect results for multi-sweep data beyond the first sweep

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -175,7 +175,8 @@ class SpotFrame(XrayFrame):
         self._mask_frame = None
 
         self.display_foreground_circles_patch = False  # hard code this option, for now
-        self._dispersion_debug_memo = {}
+
+        self._kabsch_debug_list_hash = 0
 
         if (
             self.experiments is not None
@@ -962,28 +963,34 @@ class SpotFrame(XrayFrame):
         return image_data
 
     def _calculate_dispersion_debug(self, image):
-        request = {}
-        request["index"] = image.index
-        request["sum"] = self.params.stack_images
-        request["gain_value"] = self.settings.gain
-        request["nsigma_b"] = self.settings.nsigma_b
-        request["nsigma_s"] = self.settings.nsigma_s
-        request["global_threshold"] = self.settings.global_threshold
-        request["min_local"] = self.settings.min_local
-        request["size"] = self.settings.kernel_size
-        request["extended"] = self.settings.dispersion_extended
 
-        # If the request was already cached, return the result
-        # NOTE this is broken when I page through images in e.g. threshold mode or when I update the threshold params
-        if not self.viewing_stills and request == self._dispersion_debug_memo:
+        # hash current settings
+
+        kabsch_debug_list_hash = hash(
+            (
+                image.index,
+                self.images.selected.image_set,
+                self.settings.gain,
+                self.settings.nsigma_b,
+                self.settings.nsigma_s,
+                self.settings.global_threshold,
+                self.settings.min_local,
+                tuple(self.settings.kernel_size),
+                self.settings.dispersion_extended,
+            )
+        )
+
+        # compare current settings to last calculation of "Kabsch debug" list
+
+        if kabsch_debug_list_hash == self._kabsch_debug_list_hash:
             return self._kabsch_debug_list
 
         detector = image.get_detector()
         image_mask = self.get_mask(image)
         image_data = image.get_image_data()
-        assert request["gain_value"] > 0
+        assert self.settings.gain > 0
         gain_map = [
-            flex.double(image_data[i].accessor(), request["gain_value"])
+            flex.double(image_data[i].accessor(), self.settings.gain)
             for i in range(len(detector))
         ]
         if self.settings.dispersion_extended:
@@ -1005,9 +1012,8 @@ class SpotFrame(XrayFrame):
                     self.settings.min_local,
                 )
             )
-        # Store the request in cache and return the result
-        self._dispersion_debug_memo = request
         self._kabsch_debug_list = kabsch_debug_list
+        self._kabsch_debug_list_hash = kabsch_debug_list_hash
         return kabsch_debug_list
 
     def show_filters(self):

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -875,7 +875,7 @@ class SpotFrame(XrayFrame):
             i_frame = self.image_chooser.GetClientData(
                 self.image_chooser.GetSelection()
             ).index
-            imageset = self.image_chooser.GetClientData(i_frame).image_set
+            imageset = self.images.selected.image_set
 
             for i in range(1, self.params.stack_images):
                 if (i_frame + i) >= len(imageset):


### PR DESCRIPTION
Bugfixes
--------

- ``dials.image_viewer``: Fix display of spotfinding intermediates (threshold, dispersion, etc) when viewing multiple still experiments (#1734)
- ``dials.image_viewer``: Stacking images no longer gives incorrect results for multi-sweep data beyond the first sweep (#1758)