### PR TITLE
Clear rings display in `dials.image_viewer`

### DIFF
--- a/newsfragments/1777.bugfix
+++ b/newsfragments/1777.bugfix
@@ -1,1 +1,1 @@
-Add buttons to clear unit cell and generic ring display in ``dials.image_viewer``.
+``dials.image_viewer``: Add buttons to clear unit cell and generic ring display

--- a/newsfragments/1777.bugfix
+++ b/newsfragments/1777.bugfix
@@ -1,0 +1,1 @@
+Add buttons to clear unit cell and generic ring display in ``dials.image_viewer``.

--- a/util/image_viewer/slip_viewer/ring_frame.py
+++ b/util/image_viewer/slip_viewer/ring_frame.py
@@ -133,6 +133,10 @@ class RingSettingsPanel(wx.Panel):
         )
         self.Bind(EVT_FLOATSPIN, self.OnSpinCenter, self.spinner_slow)
 
+        self.clear_button = wx.Button(self, -1, "Clear")
+        box.Add(self.clear_button, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.Bind(wx.EVT_BUTTON, self.OnClear, self.clear_button)
+
         sizer.Add(box)
 
         self.DrawRing()
@@ -140,6 +144,7 @@ class RingSettingsPanel(wx.Panel):
     def __del__(self):
         if hasattr(self, "_ring_layer") and self._ring_layer is not None:
             self._pyslip.DeleteLayer(self._ring_layer)
+            self._ring_layer = None
 
     def OnSlide(self, event):
         # Keep slider and spinner synchronized.
@@ -247,6 +252,9 @@ class RingSettingsPanel(wx.Panel):
             self._center[1] = obj.GetValue()
 
         self.DrawRing()
+
+    def OnClear(self, event):
+        self.__del__()
 
     def _draw_ring_layer(self, dc, data, map_rel):
         """Draw a points layer.

--- a/util/image_viewer/slip_viewer/uc_frame.py
+++ b/util/image_viewer/slip_viewer/uc_frame.py
@@ -283,12 +283,19 @@ class UCSettingsPanel(wx.Panel):
             wx.ALL | wx.ALIGN_CENTER_VERTICAL,
             5,
         )
+        sizer.Add(box)
+
+        box = wx.BoxSizer(wx.HORIZONTAL)
+        self.clear_button = wx.Button(self, -1, "Clear")
+        box.Add(self.clear_button, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.Bind(wx.EVT_BUTTON, self.OnClear, self.clear_button)
+        sizer.Add(box)
+
         origin_box = wx.BoxSizer(wx.HORIZONTAL)
         self.origin = wx.StaticText(self, label="")
         origin_box.Add(self.origin, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         self.Bind(EVT_FLOATSPIN, self.OnSpinCenter, self.spinner_slow)
 
-        sizer.Add(box)
         sizer.Add(origin_box)
 
         self.DrawRings()
@@ -296,6 +303,7 @@ class UCSettingsPanel(wx.Panel):
     def __del__(self):
         if hasattr(self, "_ring_layer") and self._ring_layer is not None:
             self._pyslip.DeleteLayer(self._ring_layer)
+            self._ring_layer = None
 
     def OnSpinCenter(self, event):
         obj = event.EventObject
@@ -324,6 +332,9 @@ class UCSettingsPanel(wx.Panel):
         self._spacegroup = obj.GetValue()
 
         self.DrawRings()
+
+    def OnClear(self, event):
+        self.__del__()
 
     def _draw_rings_layer(self, dc, data, map_rel):
         """Draw a points layer.


### PR DESCRIPTION
Adds buttons to unit cell and generic ring display to allow clearing their display. Fixes #1777 