### PR TITLE
sort the filenames first to preserve tag order

### DIFF
--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -570,7 +570,8 @@ class Script:
 
         else:
             basenames = OrderedDict()
-            for filename in sorted(all_paths):
+            sorted_paths = sorted(all_paths)
+            for filename in sorted_paths:
                 basename = os.path.splitext(os.path.basename(filename))[0]
                 if basename in basenames:
                     basenames[basename] += 1
@@ -588,7 +589,7 @@ class Script:
                     or tag in self.params.input.image_tag
                 ):
                     tags.append(tag)
-                    all_paths2.append(all_paths[i])
+                    all_paths2.append(sorted_paths[i])
             all_paths = all_paths2
 
             # Wrapper function

--- a/newsfragments/1814.bugfix
+++ b/newsfragments/1814.bugfix
@@ -1,0 +1,1 @@
+``dials.stils_process``: A simple bookkeeping bugfix.

--- a/newsfragments/1814.bugfix
+++ b/newsfragments/1814.bugfix
@@ -1,1 +1,1 @@
-``dials.stils_process``: A simple bookkeeping bugfix.
+``dials.stills_process``: A simple bookkeeping bugfix.


### PR DESCRIPTION
Without this the experiment list filenames wont always agree with what's stored in imageset.get_path(0), however such agreement seems to be the original code's intent.