### PR TITLE
DIALS 3.5.4

### DIFF
--- a/algorithms/scaling/algorithm.py
+++ b/algorithms/scaling/algorithm.py
@@ -261,9 +261,10 @@ class ScalingAlgorithm:
             or self.params.scaling_options.target_mtz
             or self.params.scaling_options.only_target
         ):
-            self.experiments = self.experiments[:-1]
-            self.reflections = self.reflections[:-1]
-
+            # now remove things that were used as the target:
+            n_target = len(self.experiments) - len(self.scaler.active_scalers)
+            self.experiments = self.experiments[:-n_target]
+            self.reflections = self.reflections[:-n_target]
         # remove any bad datasets:
         removed_ids = self.scaler.removed_datasets
         if removed_ids:

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -570,7 +570,8 @@ class Script:
 
         else:
             basenames = OrderedDict()
-            for filename in sorted(all_paths):
+            sorted_paths = sorted(all_paths)
+            for filename in sorted_paths:
                 basename = os.path.splitext(os.path.basename(filename))[0]
                 if basename in basenames:
                     basenames[basename] += 1
@@ -588,7 +589,7 @@ class Script:
                     or tag in self.params.input.image_tag
                 ):
                     tags.append(tag)
-                    all_paths2.append(all_paths[i])
+                    all_paths2.append(sorted_paths[i])
             all_paths = all_paths2
 
             # Wrapper function

--- a/newsfragments/1814.bugfix
+++ b/newsfragments/1814.bugfix
@@ -1,0 +1,1 @@
+``dials.stills_process``: Fix case where imagesets and experiment filenames could potentially disagree

--- a/newsfragments/1815.bugfix
+++ b/newsfragments/1815.bugfix
@@ -1,0 +1,1 @@
+``dials.scale``: Fix incorrect output files, for targeted scaling with more than one target dataset.

--- a/newsfragments/1818.bugfix
+++ b/newsfragments/1818.bugfix
@@ -1,0 +1,1 @@
+``dials.image_viewer``: Fix opening datasets with ``load_models=False``

--- a/tests/algorithms/scaling/test_scale.py
+++ b/tests/algorithms/scaling/test_scale.py
@@ -888,6 +888,11 @@ def test_targeted_scaling(dials_data, tmpdir):
 
     extra_args = ["model=KB", "only_target=True"]
     run_one_scaling(tmpdir, [refl_2, scaled_refl, expt_2, scaled_exp] + extra_args)
+    scaled_exp = tmpdir.join("scaled.expt").strpath
+    scaled_refl = tmpdir.join("scaled.refl").strpath
+    experiments_list = load.experiment_list(scaled_exp, check_format=False)
+    assert len(experiments_list.scaling_models()) == 1
+    assert experiments_list.scaling_models()[0].id_ == "KB"
 
 
 def test_incremental_scale_workflow(dials_data, tmpdir):

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -100,6 +100,9 @@ class SpotFrame(XrayFrame):
         for experiment_list in self.experiments:
             for experiment in experiment_list:
                 detector = experiment.detector
+                if not detector:
+                    self.params.projection = None
+                    continue
                 if len(detector) == 24 and detector[0].get_image_size() == (2463, 195):
                     self.params.projection = None
                 elif len(detector) == 120 and detector[0].get_image_size() == (


### PR DESCRIPTION
Bugfixes
--------

- ``dials.stills_process``: Fix case where imagesets and experiment filenames could potentially disagree (#1814)
- ``dials.scale``: Fix incorrect output files, for targeted scaling with more than one target dataset. (#1815)
- ``dials.image_viewer``: Fix opening datasets with ``load_models=False`` (#1818)