### PR TITLE
Fix a format-truncation compiler warning.

### DIFF
--- a/newsfragments/1836.misc
+++ b/newsfragments/1836.misc
@@ -1,0 +1,1 @@
+Fix a compiler warning

--- a/viewer/fonts_2D.h
+++ b/viewer/fonts_2D.h
@@ -353,7 +353,7 @@ int get_digits(double nm, int (&dgt_num)[15]) {
   char asc_str[15];
 
   std::string str;
-  snprintf(asc_str, 15, "               ");
+  snprintf(asc_str, 15, "              ");
   snprintf(asc_str, 15, "%g", nm);
 
   // std::cout << "asc_str = <<" << asc_str << ">>\n\n";


### PR DESCRIPTION
gcc compiler produces a warning: 'snprintf' output truncated before the last format character,
and a note: 'snprintf' output 16 bytes into a destination of size 15.
The fix is to adjust the format string to 14 whitespaces, allowing the
15th position to be used for null-termination.