### PR TITLE
dials.stills_process performance improvements

### DIFF
--- a/algorithms/integration/boost_python/kapton_ext.cc
+++ b/algorithms/integration/boost_python/kapton_ext.cc
@@ -51,6 +51,9 @@ scitbx::af::shared<double> get_kapton_path_cpp(
       } catch (dxtbx::error) {
         // Do nothing
       }
+      if (intersection_xy_list.size() == 2) {
+        break;
+      }
     }  // kapton faces
     /*
      * Now find out the maximum path length through the kapton. That is the path

--- a/algorithms/integration/kapton_2019_correction.py
+++ b/algorithms/integration/kapton_2019_correction.py
@@ -194,6 +194,7 @@ class KaptonTape_2019:
         from dials.algorithms.integration import get_kapton_path_cpp
 
         # new style, much faster
+        # Note, the last two faces should never be hit by a photon so don't need to check them
         kapton_path_mm = get_kapton_path_cpp(kapton_faces[:4], s1_flex)
         # old style, really slow
         # for s1 in s1_flex:

--- a/algorithms/integration/kapton_2019_correction.py
+++ b/algorithms/integration/kapton_2019_correction.py
@@ -194,7 +194,8 @@ class KaptonTape_2019:
         from dials.algorithms.integration import get_kapton_path_cpp
 
         # new style, much faster
-        kapton_path_mm = get_kapton_path_cpp(kapton_faces, s1_flex)
+        #import ipdb;ipdb.set_trace()
+        kapton_path_mm = get_kapton_path_cpp(kapton_faces[:4], s1_flex)
         # old style, really slow
         # for s1 in s1_flex:
         #  kapton_path_mm.append(self.get_kapton_path_mm(s1))

--- a/algorithms/integration/kapton_2019_correction.py
+++ b/algorithms/integration/kapton_2019_correction.py
@@ -194,7 +194,6 @@ class KaptonTape_2019:
         from dials.algorithms.integration import get_kapton_path_cpp
 
         # new style, much faster
-        #import ipdb;ipdb.set_trace()
         kapton_path_mm = get_kapton_path_cpp(kapton_faces[:4], s1_flex)
         # old style, really slow
         # for s1 in s1_flex:

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -23,6 +23,7 @@ from dials.util import log
 
 logger = logging.getLogger("dials.command_line.stills_process")
 
+SIG_B_CUTOFF = .1
 
 help_message = """
 DIALS script for processing still images. Import, index, refine, and integrate are all done for each image
@@ -1213,6 +1214,24 @@ The detector is reporting a gain of %f but you have also supplied a gain of %f. 
         # Match the predictions with the reference
         # Create the integrator
         experiments = ProfileModelFactory.create(self.params, experiments, indexed)
+        new_experiments = ExperimentList()
+        new_reflections = flex.reflection_table()
+        for expt_id, expt in enumerate(experiments):
+            if expt.profile.sigma_b() < SIG_B_CUTOFF:
+                refls = indexed.select(indexed['id']==expt_id)
+                refls['id'] = flex.int(len(refls), len(new_experiments))
+                #refls.reset_ids()
+                #import ipdb;ipdb.set_trace()
+                del refls.experiment_identifiers()[expt_id]
+                refls.experiment_identifiers()[len(new_experiments)] = expt.identifier
+                new_reflections.extend(refls)
+                new_experiments.append(expt)
+            else:
+                logger.info("Rejected expt %d with sigma_b %f" %(expt_id, expt.profile.sigma_b))
+        experiments = new_experiments
+        indexed = new_reflections
+        if len(experiments)==0:
+            raise RuntimeError('No experiments after filtering by sigma_b')
         logger.info("")
         logger.info("=" * 80)
         logger.info("")
@@ -1249,7 +1268,7 @@ The detector is reporting a gain of %f but you have also supplied a gain of %f. 
                 )()
 
         if self.params.significance_filter.enable:
-            from dxtbx.model.experiment_list import ExperimentList
+            #from dxtbx.model.experiment_list import ExperimentList
 
             from dials.algorithms.integration.stills_significance_filter import (
                 SignificanceFilter,

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -340,8 +340,6 @@ class Script:
         if self.params.input.reference_geometry is None:
             return
 
-        from dxtbx.model.experiment_list import ExperimentListFactory
-
         try:
             ref_experiments = ExperimentListFactory.from_json_file(
                 self.params.input.reference_geometry, check_format=False
@@ -785,7 +783,6 @@ class Processor:
 
         if params.output.composite_output:
             assert composite_tag is not None
-            from dxtbx.model.experiment_list import ExperimentList
 
             self.all_imported_experiments = ExperimentList()
             self.all_strong_reflections = flex.reflection_table()
@@ -1221,7 +1218,6 @@ The detector is reporting a gain of %f but you have also supplied a gain of %f. 
                 refls = indexed.select(indexed['id']==expt_id)
                 refls['id'] = flex.int(len(refls), len(new_experiments))
                 #refls.reset_ids()
-                #import ipdb;ipdb.set_trace()
                 del refls.experiment_identifiers()[expt_id]
                 refls.experiment_identifiers()[len(new_experiments)] = expt.identifier
                 new_reflections.extend(refls)
@@ -1268,8 +1264,6 @@ The detector is reporting a gain of %f but you have also supplied a gain of %f. 
                 )()
 
         if self.params.significance_filter.enable:
-            #from dxtbx.model.experiment_list import ExperimentList
-
             from dials.algorithms.integration.stills_significance_filter import (
                 SignificanceFilter,
             )

--- a/command_line/stills_process.py
+++ b/command_line/stills_process.py
@@ -23,7 +23,7 @@ from dials.util import log
 
 logger = logging.getLogger("dials.command_line.stills_process")
 
-SIG_B_CUTOFF = .1
+SIG_B_CUTOFF = 0.1
 
 help_message = """
 DIALS script for processing still images. Import, index, refine, and integrate are all done for each image
@@ -1215,19 +1215,21 @@ The detector is reporting a gain of %f but you have also supplied a gain of %f. 
         new_reflections = flex.reflection_table()
         for expt_id, expt in enumerate(experiments):
             if expt.profile.sigma_b() < SIG_B_CUTOFF:
-                refls = indexed.select(indexed['id']==expt_id)
-                refls['id'] = flex.int(len(refls), len(new_experiments))
-                #refls.reset_ids()
+                refls = indexed.select(indexed["id"] == expt_id)
+                refls["id"] = flex.int(len(refls), len(new_experiments))
+                # refls.reset_ids()
                 del refls.experiment_identifiers()[expt_id]
                 refls.experiment_identifiers()[len(new_experiments)] = expt.identifier
                 new_reflections.extend(refls)
                 new_experiments.append(expt)
             else:
-                logger.info("Rejected expt %d with sigma_b %f" %(expt_id, expt.profile.sigma_b))
+                logger.info(
+                    "Rejected expt %d with sigma_b %f" % (expt_id, expt.profile.sigma_b)
+                )
         experiments = new_experiments
         indexed = new_reflections
-        if len(experiments)==0:
-            raise RuntimeError('No experiments after filtering by sigma_b')
+        if len(experiments) == 0:
+            raise RuntimeError("No experiments after filtering by sigma_b")
         logger.info("")
         logger.info("=" * 80)
         logger.info("")

--- a/newsfragments/XXX.feature
+++ b/newsfragments/XXX.feature
@@ -1,0 +1,2 @@
+dials.stills_process: Performance improvements in Kapton absorption correction
+and in rare cases of highly mosaic crystals.


### PR DESCRIPTION
* Speed up Kapton correction by returning once two Kapton faces intersecting the beam have been found.
* Filter out rare cases where sigma_b (a spot shape parameter) is nonphysically large. This avoids integration hanging in the Kapton correction step when millions of pixels are inside predicted reflections.

Co-authored-by: Aaron Brewster <asbrewster@lbl.gov>
Co-authored-by: Asmit Bhowmick <abhowmick@lbl.gov>