### PR TITLE
Fix windows builds by removing simtbx

### DIFF
--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -45,6 +45,7 @@ steps:
 # Build DIALS using the bootstrap script
 - bash: |
     set -eux
+    rm -rf modules/cctbx_project/simtbx
     python modules/dials/installer/bootstrap.py build
   displayName: DIALS build
   workingDirectory: $(Pipeline.Workspace)

--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -28,6 +28,9 @@ steps:
   displayName: Create python $(PYTHON_VERSION) environment
   workingDirectory: $(Pipeline.Workspace)
 
+# Remove simtbx as it is broken on windows
+- bash: rm -rf modules/cctbx_project/simtbx
+
 # Build DIALS using the bootstrap script
 - script: |
     pushd "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"

--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -30,6 +30,8 @@ steps:
 
 # Remove simtbx as it is broken on windows
 - bash: rm -rf modules/cctbx_project/simtbx
+  displayName: Remove simtbx
+  workingDirectory: $(Pipeline.Workspace)
 
 # Build DIALS using the bootstrap script
 - script: |

--- a/newsfragments/1845.misc
+++ b/newsfragments/1845.misc
@@ -1,0 +1,1 @@
+Disable building simtbx - fails on windows


### PR DESCRIPTION
Until https://github.com/cctbx/cctbx_project/issues/639 is fixed, this disables simtbx in the Azure builds. simtbx is pulled in by xfel as an `optional_modules`, but does not appear to have direct references from xfel.

Fixes #1845.