### PR TITLE
Changed default image viewer helper message to reflect current controls.

### DIFF
--- a/newsfragments/1869.misc
+++ b/newsfragments/1869.misc
@@ -1,0 +1,1 @@
+Updated default image viewer status bar message to reflect current controls

--- a/newsfragments/1869.misc
+++ b/newsfragments/1869.misc
@@ -1,1 +1,1 @@
-Updated default image viewer status bar message to reflect current controls
+dials.image_viewer: Updated default status bar message to reflect available controls

--- a/util/image_viewer/rstbx_frame.py
+++ b/util/image_viewer/rstbx_frame.py
@@ -260,8 +260,7 @@ class XrayFrame(wx.Frame):
     def update_statusbar(self, info=None):
         if info is None:
             self.statusbar.SetStatusText(
-                "Click and drag to pan; "
-                + "middle-click and drag to plot intensity profile, right-click to zoom"
+                "Click and drag to pan, mouse wheel or double click to zoom"
             )
         else:
             self.statusbar.SetStatusText(info.format())

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -255,8 +255,7 @@ class XrayFrame(XFBaseClass):
             self.statusbar.SetStatusText(posn_str)
         else:
             self.statusbar.SetStatusText(
-                "Click and drag to pan; "
-                + "middle-click and drag to plot intensity profile, right-click to zoom"
+                "Click and drag to pan, mouse wheel or double click to zoom"
             )
             # print "event with no position",event
         return


### PR DESCRIPTION
This just updates the default image viewer helper message, as it seems to be out of date with current controls. 

I can't find anywhere where the intensity plot is used (I'm guessing it's [OnShowPlot](https://github.com/dials/dials/blob/main/util/image_viewer/rstbx_frame.py#L333)), and the right click to zoom in [wx_viewer](https://github.com/dials/dials/blob/main/util/wx_viewer.py#L279) doesn't seem to be in use.