### PR TITLE
Bad pixel format

### DIFF
--- a/command_line/find_bad_pixels.py
+++ b/command_line/find_bad_pixels.py
@@ -183,7 +183,7 @@ def run(args=None):
     hot_pixels = hot_mask.iselection()
 
     for h in hot_pixels:
-        print("    mask[%d, %d] = 8" % (h % nfast, h // nfast))
+        print("    mask[%d, %d] = 16" % (h // nfast, h % nfast))
 
 
 if __name__ == "__main__":

--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,2 @@
+dials.find_bad_pixels: change output pixel format to write out input to Diamond
+bad pixel mask program correctly (C ordering, 16 which indicates noisy pixel)


### PR DESCRIPTION
Details at https://jira.diamond.ac.uk/browse/I04-575

Changing output format from this to be more useful (TODO should write this out as e.g. JSON to be more portable, but that is for a different day)