### PR TITLE
Change ignore_unhandled to default as true

### DIFF
--- a/command_line/dials_import.py
+++ b/command_line/dials_import.py
@@ -94,9 +94,9 @@ phil_scope = parse(
 
   input {
 
-    ignore_unhandled = False
+    ignore_unhandled = True
       .type = bool
-      .help = "Don't throw exception if some args are unhandled"
+      .help = "Ignore unhandled input (e.g. log files)"
 
     template = None
       .type = str

--- a/newsfragments/XXX.feature
+++ b/newsfragments/XXX.feature
@@ -1,0 +1,2 @@
+dials.import: change default of ignore_unhandled from false to true: now running import on a directory full of CBF files with a log file in will simply ignore the log files.
+


### PR DESCRIPTION
Fixes #1879

This is probably what user would expect anyway: now get

```
graeme@sleeper-service:~/data/i19-1-nff/foo$ dials.import ../
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
DIALS 3.dev.568-ge7d14238f
The following parameters have been modified:

input {
  experiments = <image files>
}

Unable to handle the following arguments:
  ../bar

--------------------------------------------------------------------------------
  format: <class 'dxtbx.format.FormatCBFFullPilatus.FormatCBFFullPilatus'>
  num images: 3450
  sequences:
    still:    0
    sweep:    4
  num stills: 0
--------------------------------------------------------------------------------
Writing experiments to imported.expt
```