### PR TITLE
DIALS 3.6.2

### DIFF
--- a/array_family/flex_ext.py
+++ b/array_family/flex_ext.py
@@ -1238,8 +1238,12 @@ Found %s"""
         self["rlp"] = cctbx.array_family.flex.vec3_double(len(self))
         panel_numbers = cctbx.array_family.flex.size_t(self["panel"])
 
+        # crystal_frame is not used in indexing, but is a feature of the
+        # reciprocal lattice viewer -> but if we are looking at the crystal
+        # coordinate frame we need to look at the experiments independently
+
         for i, expt in enumerate(experiments):
-            if "imageset_id" in self:
+            if not crystal_frame and "imageset_id" in self:
                 sel_expt = self["imageset_id"] == i
             else:
                 sel_expt = self["id"] == i

--- a/newsfragments/1868.bugfix
+++ b/newsfragments/1868.bugfix
@@ -1,0 +1,1 @@
+``dials.reciprocal_lattice_viewer``: In cases with multiple lattices, "Crystal Frame" now aligns all crystal frames, rather than just the first. Unindexed reflections are no longer shown in this mode.


### PR DESCRIPTION
Bugfixes
--------

- ``dials.reciprocal_lattice_viewer``: In cases with multiple lattices, "Crystal Frame" now aligns all crystal frames, rather than just the first. Unindexed reflections are no longer shown in this mode. (#1868)