### PR TITLE
Reword a docstring slightly

### DIFF
--- a/command_line/anvil_correction.py
+++ b/command_line/anvil_correction.py
@@ -100,13 +100,14 @@ def goniometer_rotation(
     denoted R, here denoted R' to avoid confusion with the notation of
     dxtbx/model/goniometer.h) can be calculated as R' = S ∘ R ∘ F.
     Here:
-        * S is the 'setting rotation', the operator denoting the position of all parent
-        axes of the scan axis, which hence defines the orientation of the scan axis;
+        * S is the static 'setting rotation', the operator denoting the position of all
+        parent axes of the scan axis, which hence defines the orientation of the scan
+        axis;
         * R is the the operator denoting the scan rotation as if it were performed with
         all parent axes at zero datum, it has a different value for each reflection,
-        recording the scan position corresponding to the reflection centroid.
-        * F is the 'fixed rotation', denoting the orientation of all child axes of the
-        scan axis as if they were performed with all parent axes at zero datum.
+        recording the scan position corresponding to each reflection centroid;
+        * F is the static 'fixed rotation', denoting the orientation of all child axes
+        of the scan axis as if they were performed with all other axes at zero datum.
 
     Args:
         experiment:  The DXTBX experiment object corresponding to the scan.

--- a/command_line/anvil_correction.py
+++ b/command_line/anvil_correction.py
@@ -104,7 +104,7 @@ def goniometer_rotation(
         axes of the scan axis, which hence defines the orientation of the scan axis;
         * R is the the operator denoting the scan rotation as if it were performed with
         all parent axes at zero datum, it has a different value for each reflection,
-        according to the reflection centroid positions.
+        recording the scan position corresponding to the reflection centroid.
         * F is the 'fixed rotation', denoting the orientation of all child axes of the
         scan axis as if they were performed with all parent axes at zero datum.
 

--- a/newsfragments/1907.misc
+++ b/newsfragments/1907.misc
@@ -1,0 +1,1 @@
+Reword the docstring of ``dials.command_line.anvil_correction.goniometer_rotation`` to make its meaning slightly clearer.


### PR DESCRIPTION
It looks like I never acted on https://github.com/cctbx/dxtbx/issues/128, but instead dumped my knowledge of the DXTBX goniometer rotation operator convention in `dials.command_line.anvil_correction.goniometer_rotation.__doc__`.  Here's a small edit to that docstring to make it more readable.