### PR TITLE
Specifying intensity_choice=auto fails for some dials.export output formats

### DIFF
--- a/command_line/export.py
+++ b/command_line/export.py
@@ -510,7 +510,7 @@ def run(args=None):
     # do auto interpreting of intensity choice:
     # note that this may still fail certain checks further down the processing,
     # but these are the defaults to try
-    if params.intensity in ([None], [Auto], ["auto"]) and reflections:
+    if params.intensity in ([None], [Auto], ["auto"], Auto) and reflections:
         if ("intensity.scale.value" in reflections[0]) and (
             "intensity.scale.variance" in reflections[0]
         ):

--- a/newsfragments/1926.bugfix
+++ b/newsfragments/1926.bugfix
@@ -1,1 +1,1 @@
-``dials.export``: bugfix for XDS_ASCII and SADABS export when intensity=auto is on command line
+``dials.export``: No longer fails for XDS_ASCII and SADABS export with ``intensity=auto``.

--- a/newsfragments/1926.bugfix
+++ b/newsfragments/1926.bugfix
@@ -1,0 +1,1 @@
+``dials.export``: bugfix for XDS_ASCII and SADABS export when intensity=auto is on command line


### PR DESCRIPTION
Some of the output formats for `dials.export` fail when `intensity_choice=auto` is specified on the command line with the cryptic error:

```
argument of type 'AutoType' is not iterable
```

This change fixes that. 