### PR TITLE
DIALS 3.7.1

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -34,7 +34,7 @@ conda-forge::cryptography=35.0.0
 conda-forge::cxx-compiler=1.3.0
 conda-forge::cycler=0.11.0
 conda-forge::dials-data=2.2.17
-conda-forge::docutils=0.18
+conda-forge::docutils
 conda-forge::eigen=3.4.0
 conda-forge::execnet=1.9.0
 conda-forge::expat=2.4.1

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -37,7 +37,7 @@ conda-forge::cryptography=35.0.0
 conda-forge::cxx-compiler=1.3.0
 conda-forge::cycler=0.11.0
 conda-forge::dials-data=2.2.17
-conda-forge::docutils=0.18
+conda-forge::docutils
 conda-forge::eigen=3.4.0
 conda-forge::execnet=1.9.0
 conda-forge::expat=2.4.1

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -26,7 +26,7 @@ conda-forge::cryptography=35.0.0
 conda-forge::cxx-compiler=1.3.0
 conda-forge::cycler=0.11.0
 conda-forge::dials-data=2.2.17
-conda-forge::docutils=0.18
+conda-forge::docutils
 conda-forge::eigen=3.4.0
 conda-forge::execnet=1.9.0
 conda-forge::freetype=2.10.4

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -545,7 +545,8 @@ def run(args=None):
     try:
         exporter(params, experiments, reflections)
     except Exception as e:
-        sys.exit(e)
+        logger.error(f"Error: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/command_line/export.py
+++ b/command_line/export.py
@@ -510,7 +510,7 @@ def run(args=None):
     # do auto interpreting of intensity choice:
     # note that this may still fail certain checks further down the processing,
     # but these are the defaults to try
-    if params.intensity in ([None], [Auto], ["auto"]) and reflections:
+    if params.intensity in ([None], [Auto], ["auto"], Auto) and reflections:
         if ("intensity.scale.value" in reflections[0]) and (
             "intensity.scale.variance" in reflections[0]
         ):

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -1,5 +1,6 @@
 import copy
 import itertools
+import json
 import math
 
 import numpy as np
@@ -2223,6 +2224,10 @@ class Analyser:
                 rlist, experiments
             )
             resolution_plots.update(rplots)
+            json_data["resolution_graphs"] = resolution_plots
+            json_data["batch_graphs"] = batch_plots
+            json_data["misc_graphs"] = misc_plots
+            json_data["scaled_intensity_graphs"] = scaled_intensity_plots
 
         if self.params.output.html is not None:
 
@@ -2272,10 +2277,8 @@ class Analyser:
                 f.write(html.encode("utf-8", "xmlcharrefreplace"))
 
         if self.params.output.json is not None:
-            import json
-
             print(f"Writing json data to: {self.params.output.json}")
-            with open(self.params.output.json, "wb") as f:
+            with open(self.params.output.json, "w") as f:
                 json.dump(json_data, f)
 
     def experiments_table(self, experiments):

--- a/newsfragments/1915.bugfix
+++ b/newsfragments/1915.bugfix
@@ -1,0 +1,1 @@
+``dials.export``: No longer allow (erroneous) MTZ export for multiple experiments with multiple space groups.

--- a/newsfragments/1926.bugfix
+++ b/newsfragments/1926.bugfix
@@ -1,0 +1,1 @@
+``dials.export``: No longer fails for XDS_ASCII and SADABS export with ``intensity=auto``.

--- a/newsfragments/1932.bugfix
+++ b/newsfragments/1932.bugfix
@@ -1,0 +1,1 @@
+``dials.report``: Fix broken json output option. Include more graphs in json output.

--- a/tests/command_line/test_report.py
+++ b/tests/command_line/test_report.py
@@ -1,16 +1,17 @@
 """Tests for dials.report"""
+import json
 
 import procrunner
 
 
 def test_report_integrated_data(dials_data, tmpdir):
     """Simple test to check that dials.report completes when given integrated data."""
-
+    data_dir = dials_data("l_cysteine_dials_output", pathlib=True)
     result = procrunner.run(
         [
             "dials.report",
-            dials_data("l_cysteine_dials_output") / "20_integrated_experiments.json",
-            dials_data("l_cysteine_dials_output") / "20_integrated.pickle",
+            data_dir / "20_integrated_experiments.json",
+            data_dir / "20_integrated.pickle",
         ],
         working_directory=tmpdir,
     )
@@ -20,13 +21,32 @@ def test_report_integrated_data(dials_data, tmpdir):
 
 def test_report_scaled_data(dials_data, tmpdir):
     """Test that dials.report works on scaled data."""
+    data_dir = dials_data("l_cysteine_4_sweeps_scaled", pathlib=True)
     result = procrunner.run(
         [
             "dials.report",
-            dials_data("l_cysteine_4_sweeps_scaled") / "scaled_30.refl",
-            dials_data("l_cysteine_4_sweeps_scaled") / "scaled_30.expt",
+            data_dir / "scaled_30.refl",
+            data_dir / "scaled_30.expt",
+            f"json={tmpdir}/report.json",
         ],
         working_directory=tmpdir,
     )
     assert not result.returncode and not result.stderr
     assert tmpdir.join("dials.report.html").check()
+    report_json = tmpdir.join("report.json")
+    assert report_json.check()
+    expected_keys = {
+        "strong",
+        "centroid",
+        "intensity",
+        "reference",
+        "scan_varying",
+        "scaling_model",
+        "resolution_graphs",
+        "batch_graphs",
+        "misc_graphs",
+        "scaled_intensity_graphs",
+    }
+    with report_json.open() as fh:
+        d = json.load(fh)
+        assert not expected_keys - set(d.keys())

--- a/util/export_mtz.py
+++ b/util/export_mtz.py
@@ -438,6 +438,10 @@ def export_mtz(
                 "Experiment crystals differ. Using first experiment crystal for file-level data."
             )
 
+        # At least, all experiments must have the same space group
+        if len({x.crystal.get_space_group().make_tidy() for x in experiment_list}) != 1:
+            raise ValueError("Experiments do not have a unique space group")
+
         wavelengths = match_wavelengths(experiment_list)
         if len(wavelengths) > 1:
             logger.info(


### PR DESCRIPTION
Bugfixes
--------

- ``dials.export``: No longer allow (erroneous) MTZ export for multiple experiments with multiple space groups. (#1915)
- ``dials.export``: No longer fails for XDS_ASCII and SADABS export with ``intensity=auto``. (#1926)
- ``dials.report``: Fix broken json output option. Include more graphs in json output. (#1932)