### PR TITLE
dials.refine: update polarization vector

### DIFF
--- a/algorithms/refinement/parameterisation/beam_parameters.py
+++ b/algorithms/refinement/parameterisation/beam_parameters.py
@@ -40,7 +40,7 @@ class BeamMixin:
         return p_list
 
     @staticmethod
-    def _compose_core(is0, mu1, mu2, nu, mu1_axis, mu2_axis):
+    def _compose_core(is0, ipn, mu1, mu2, nu, mu1_axis, mu2_axis):
 
         # convert angles to radians
         mu1rad, mu2rad = mu1 / 1000.0, mu2 / 1000.0
@@ -55,6 +55,7 @@ class BeamMixin:
         # compose new state
         Mu21 = Mu2 * Mu1
         s0_new_dir = (Mu21 * is0).normalize()
+        pn_new_dir = (Mu21 * ipn).normalize()
         s0 = nu * s0_new_dir
 
         # calculate derivatives of the beam direction wrt angles:
@@ -74,7 +75,7 @@ class BeamMixin:
             s0_new_dir,
         ]
 
-        return s0, ds0_dval
+        return (s0, pn_new_dir), ds0_dval
 
 
 class BeamParameterisation(ModelParameterisation, BeamMixin):
@@ -96,7 +97,8 @@ class BeamParameterisation(ModelParameterisation, BeamMixin):
         """
         # The state of the beam model consists of the s0 vector that it is
         # modelling. The initial state is the direction of this vector at the point
-        # of initialisation. Future states are composed by rotations around axes
+        # of initialisation, plus the direction of the orthogonal polarisation
+        # normal vector. Future states are composed by rotations around axes
         # perpendicular to that direction and normalisation specified by the
         # wavenumber (inverse wavelength).
 
@@ -104,8 +106,10 @@ class BeamParameterisation(ModelParameterisation, BeamMixin):
         if experiment_ids is None:
             experiment_ids = [0]
         s0 = matrix.col(beam.get_s0())
-        s0dir = matrix.col(beam.get_unit_s0())
-        istate = s0dir
+        istate = {
+            "unit_s0": matrix.col(beam.get_unit_s0()),
+            "polarization_normal": matrix.col(beam.get_polarization_normal()),
+        }
 
         # build the parameter list
         p_list = self._build_p_list(s0, goniometer)
@@ -123,18 +127,26 @@ class BeamParameterisation(ModelParameterisation, BeamMixin):
     def compose(self):
 
         # extract direction from the initial state
-        is0 = self._initial_state
+        ius0 = self._initial_state["unit_s0"]
+        ipn = self._initial_state["polarization_normal"]
 
         # extract parameters from the internal list
         mu1, mu2, nu = self._param
 
         # calculate new s0 and derivatives
-        s0, self._dstate_dp = self._compose_core(
-            is0, mu1.value, mu2.value, nu.value, mu1_axis=mu1.axis, mu2_axis=mu2.axis
+        (s0, pn), self._dstate_dp = self._compose_core(
+            ius0,
+            ipn,
+            mu1.value,
+            mu2.value,
+            nu.value,
+            mu1_axis=mu1.axis,
+            mu2_axis=mu2.axis,
         )
 
-        # now update the model with its new s0
+        # now update the model with its new s0 and polarisation vector
         self._model.set_s0(s0)
+        self._model.set_polarization_normal(pn)
 
         return
 

--- a/algorithms/refinement/parameterisation/beam_parameters.py
+++ b/algorithms/refinement/parameterisation/beam_parameters.py
@@ -97,7 +97,7 @@ class BeamParameterisation(ModelParameterisation, BeamMixin):
         """
         # The state of the beam model consists of the s0 vector that it is
         # modelling. The initial state is the direction of this vector at the point
-        # of initialisation, plus the direction of the orthogonal polarisation
+        # of initialisation, plus the direction of the orthogonal polarization
         # normal vector. Future states are composed by rotations around axes
         # perpendicular to that direction and normalisation specified by the
         # wavenumber (inverse wavelength).
@@ -144,7 +144,7 @@ class BeamParameterisation(ModelParameterisation, BeamMixin):
             mu2_axis=mu2.axis,
         )
 
-        # now update the model with its new s0 and polarisation vector
+        # now update the model with its new s0 and polarization vector
         self._model.set_s0(s0)
         self._model.set_polarization_normal(pn)
 

--- a/algorithms/refinement/parameterisation/scan_varying_beam_parameters.py
+++ b/algorithms/refinement/parameterisation/scan_varying_beam_parameters.py
@@ -38,8 +38,10 @@ class ScanVaryingBeamParameterisation(ScanVaryingModelParameterisation, BeamMixi
 
         # Set up the initial state
         s0 = matrix.col(beam.get_s0())
-        s0dir = matrix.col(beam.get_unit_s0())
-        istate = s0dir
+        istate = {
+            "unit_s0": matrix.col(beam.get_unit_s0()),
+            "polarization_normal": matrix.col(beam.get_polarization_normal()),
+        }
         self._s0_at_t = s0
 
         # Factory function to provide to _build_p_list
@@ -60,7 +62,8 @@ class ScanVaryingBeamParameterisation(ScanVaryingModelParameterisation, BeamMixi
         """calculate state and derivatives for model at image number t"""
 
         # extract direction from the initial state
-        is0 = self._initial_state
+        ius0 = self._initial_state["unit_s0"]
+        ipn = self._initial_state["polarization_normal"]
 
         # extract parameter sets from the internal list
         mu1_set, mu2_set, nu_set = self._param
@@ -76,8 +79,8 @@ class ScanVaryingBeamParameterisation(ScanVaryingModelParameterisation, BeamMixi
         dnu_dp = nu_weights * (1.0 / nu_sumweights)
 
         # calculate new s0 and its derivatives wrt the values mu1, mu2 and nu
-        self._s0_at_t, ds0_dval = self._compose_core(
-            is0, mu1, mu2, nu, mu1_axis=mu1_set.axis, mu2_axis=mu2_set.axis
+        (self._s0_at_t, _), ds0_dval = self._compose_core(
+            ius0, ipn, mu1, mu2, nu, mu1_axis=mu1_set.axis, mu2_axis=mu2_set.axis
         )
 
         # calculate derivatives of state wrt underlying smoother parameters

--- a/newsfragments/1939.bugfix
+++ b/newsfragments/1939.bugfix
@@ -1,0 +1,1 @@
+``dials.refine``: ensure beam polarization is updated along with the beam direction

--- a/newsfragments/1939.bugfix
+++ b/newsfragments/1939.bugfix
@@ -1,1 +1,1 @@
-Prevent ``dials.refine`` from introducing an unphysical beam polarization vector.
+``dials.refine`` could in some rare cases introducing an unphysical beam polarization vector.

--- a/newsfragments/1939.bugfix
+++ b/newsfragments/1939.bugfix
@@ -1,1 +1,1 @@
-``dials.refine``: ensure beam polarization is updated along with the beam direction
+Prevent ``dials.refine`` from introducing an unphysical beam polarization vector.

--- a/tests/algorithms/refinement/test_beam_parameters.py
+++ b/tests/algorithms/refinement/test_beam_parameters.py
@@ -34,10 +34,12 @@ def test_beam_parameters():
     for i in range(attempts):
 
         # make a random beam vector and parameterise it
-        s0 = bf.make_beam(
-            matrix.col.random(3, 0.5, 1.5), wavelength=random.uniform(0.8, 1.5)
-        )
-        s0p = BeamParameterisation(s0)
+        sample_to_source = matrix.col.random(3, 0.5, 1.5).normalize()
+        beam = bf.make_beam(sample_to_source, wavelength=random.uniform(0.8, 1.5))
+        # Ensure consistent polarization (https://github.com/cctbx/dxtbx/issues/454)
+        beam.set_polarization_normal(sample_to_source.ortho().normalize())
+
+        s0p = BeamParameterisation(beam)
 
         # apply a random parameter shift
         p_vals = s0p.get_param_vals()
@@ -63,3 +65,14 @@ def test_beam_parameters():
                 print("so that difference fd_ds_dp - an_ds_dp =")
                 print(fd_ds_dp[j] - an_ds_dp[j])
                 raise
+
+        # Ensure the polarization normal vector remains orthogonal to the beam
+        # (https://github.com/dials/dials/issues/1939)
+        assert (
+            abs(
+                matrix.col(beam.get_unit_s0()).dot(
+                    matrix.col(beam.get_polarization_normal())
+                )
+            )
+            < 1e-10
+        )


### PR DESCRIPTION
Ensure the polarization normal vector is updated when `dials.refine` changes the beam direction, so that it remains orthogonal to **s<sub>0</sub>**.