### PR TITLE
DIALS 3.7.2

### DIFF
--- a/algorithms/integration/processor.py
+++ b/algorithms/integration/processor.py
@@ -71,20 +71,22 @@ def assess_available_memory(params):
     available_swap = psutil.swap_memory().free
 
     # https://htcondor.readthedocs.io/en/latest/users-manual/services-for-jobs.html#extra-environment-variables-htcondor-sets-for-jobs
-    condor_machine_ad = os.environ.get("_CONDOR_MACHINE_AD")
-    if condor_machine_ad:
+    condor_job_ad = os.environ.get("_CONDOR_JOB_AD")
+    if condor_job_ad:
         try:
-            classad = dials.util.parse_htcondor_classad(pathlib.Path(condor_machine_ad))
+            job_classad = dials.util.parse_htcondor_job_classad(
+                pathlib.Path(condor_job_ad)
+            )
         except Exception as e:
             logger.error(
-                f"Error parsing _CONDOR_MACHINE_AD {condor_machine_ad}: {e}",
+                f"Error parsing _CONDOR_JOB_AD {condor_job_ad}: {e}",
                 exc_info=True,
             )
         else:
-            if classad.memory_provisioned:
+            if job_classad.memory_provisioned:
                 # Convert MB to bytes
                 available_memory = min(
-                    available_memory, classad.memory_provisioned * 1024 ** 2
+                    available_memory, job_classad.memory_provisioned * 1024 ** 2
                 )
 
     available_incl_swap = available_memory + available_swap

--- a/newsfragments/1943.feature
+++ b/newsfragments/1943.feature
@@ -1,0 +1,2 @@
+``dials.integrate``: When determining available memory, take into account ``MemoryProvisioned`` from HTCondor machine ad if the ``_CONDOR_MACHINE_AD`` environment variable is set.
+``nproc=auto``: Take into account ``CpusProvisioned`` from HTCondor machine ad.

--- a/newsfragments/1943.feature
+++ b/newsfragments/1943.feature
@@ -1,2 +1,2 @@
-``dials.integrate``: When determining available memory, take into account ``MemoryProvisioned`` from HTCondor machine ad if the ``_CONDOR_MACHINE_AD`` environment variable is set.
+``dials.integrate``: When determining available memory, take into account ``MemoryProvisioned`` from HTCondor machine ad if the ``_CONDOR_JOB_AD`` environment variable is set.
 ``nproc=auto``: Take into account ``CpusProvisioned`` from HTCondor machine ad.

--- a/newsfragments/1945.bugfix
+++ b/newsfragments/1945.bugfix
@@ -1,0 +1,1 @@
+Read ``_CONDOR_JOB_AD`` not ``_CONDOR_MACHINE_AD``

--- a/tests/algorithms/integration/test_processor.py
+++ b/tests/algorithms/integration/test_processor.py
@@ -71,9 +71,9 @@ def test_runtime_error_raised_when_not_enough_memory(
     mock_flex_max.assert_called_with(manager.jobs.shoebox_memory.return_value)
 
 
-def test_assess_available_memory_condor_machine_ad(mocker, monkeypatch, tmp_path):
-    machine_ad = tmp_path / "condor_machine_ad"
-    monkeypatch.setenv("_CONDOR_MACHINE_AD", os.fspath(machine_ad))
+def test_assess_available_memory_condor_job_ad(mocker, monkeypatch, tmp_path):
+    job_ad = tmp_path / ".job.ad"
+    monkeypatch.setenv("_CONDOR_JOB_AD", os.fspath(job_ad))
 
     # Test that we handle gracefully absence of file
     params = mocker.Mock()
@@ -82,7 +82,7 @@ def test_assess_available_memory_condor_machine_ad(mocker, monkeypatch, tmp_path
     assert available_memory and available_memory != 123
 
     # Now write something sensible to the file
-    machine_ad.write_text(
+    job_ad.write_text(
         """\
 MemoryProvisioned = 123
 """
@@ -91,7 +91,7 @@ MemoryProvisioned = 123
     assert available_memory == params.block.max_memory_usage * 123 * 1024 ** 2
 
     # Now check it is robust against parsing failures
-    machine_ad.write_text(
+    job_ad.write_text(
         """\
 MemoryProvisioned =
 """

--- a/tests/util/test_htcondor_classad.py
+++ b/tests/util/test_htcondor_classad.py
@@ -1,0 +1,16 @@
+from dials.util import parse_htcondor_classad
+
+
+def test_parse_htcondor_classad(tmp_path):
+    machine_ad = tmp_path / "condor_machine_ad"
+    machine_ad.write_text(
+        """\
+NumShadowStarts = 1
+MemoryProvisioned = 4096
+CpusProvisioned = 8
+TransferIn = false
+"""
+    )
+    class_ad = parse_htcondor_classad(machine_ad)
+    assert class_ad.cpus_provisioned == 8
+    assert class_ad.memory_provisioned == 4096

--- a/tests/util/test_htcondor_job_classad.py
+++ b/tests/util/test_htcondor_job_classad.py
@@ -1,8 +1,8 @@
-from dials.util import parse_htcondor_classad
+from dials.util import parse_htcondor_job_classad
 
 
-def test_parse_htcondor_classad(tmp_path):
-    machine_ad = tmp_path / "condor_machine_ad"
+def test_parse_htcondor_job_classad(tmp_path):
+    machine_ad = tmp_path / "condor_job_ad"
     machine_ad.write_text(
         """\
 NumShadowStarts = 1
@@ -11,6 +11,6 @@ CpusProvisioned = 8
 TransferIn = false
 """
     )
-    class_ad = parse_htcondor_classad(machine_ad)
+    class_ad = parse_htcondor_job_classad(machine_ad)
     assert class_ad.cpus_provisioned == 8
     assert class_ad.memory_provisioned == 4096

--- a/tests/util/test_mp.py
+++ b/tests/util/test_mp.py
@@ -18,16 +18,16 @@ def test_available_cores_nslots(monkeypatch):
     assert dials.util.mp.available_cores() == true_cores + 1
 
 
-def test_available_cores_condor_machine_ad(monkeypatch, tmp_path):
+def test_available_cores_condor_job_ad(monkeypatch, tmp_path):
     true_cores = dials.util.mp.available_cores()
-    machine_ad = tmp_path / "condor_machine_ad"
-    monkeypatch.setenv("_CONDOR_MACHINE_AD", os.fspath(machine_ad))
+    job_ad = tmp_path / ".job.ad"
+    monkeypatch.setenv("_CONDOR_JOB_AD", os.fspath(job_ad))
 
     # Test that we handle gracefully absence of file
     assert dials.util.mp.available_cores() == true_cores
 
     # Now write something sensible to the file
-    machine_ad.write_text(
+    job_ad.write_text(
         f"""\
 CpusProvisioned = {true_cores + 1}
 """
@@ -35,7 +35,7 @@ CpusProvisioned = {true_cores + 1}
     assert dials.util.mp.available_cores() == true_cores + 1
 
     # Now check it is robust against parsing failures
-    machine_ad.write_text(
+    job_ad.write_text(
         """\
 CpusProvisioned =
 """

--- a/tests/util/test_mp.py
+++ b/tests/util/test_mp.py
@@ -1,16 +1,43 @@
+import os
+
 import dials.util.mp
 
 
-def test_core_detection():
+def test_available_cores():
     # We can't make any assumptions about the testing environment,
     # but we know there will be at least one available core, and
     # the function must return a positive integer in any case.
     assert dials.util.mp.available_cores() >= 1
 
 
-def test_core_detection_override(monkeypatch):
+def test_available_cores_nslots(monkeypatch):
     # For now at least the NSLOTS environment variable should
     # override whatever available_cores() returns otherwise.
     true_cores = dials.util.mp.available_cores()
     monkeypatch.setenv("NSLOTS", str(true_cores + 1))
     assert dials.util.mp.available_cores() == true_cores + 1
+
+
+def test_available_cores_condor_machine_ad(monkeypatch, tmp_path):
+    true_cores = dials.util.mp.available_cores()
+    machine_ad = tmp_path / "condor_machine_ad"
+    monkeypatch.setenv("_CONDOR_MACHINE_AD", os.fspath(machine_ad))
+
+    # Test that we handle gracefully absence of file
+    assert dials.util.mp.available_cores() == true_cores
+
+    # Now write something sensible to the file
+    machine_ad.write_text(
+        f"""\
+CpusProvisioned = {true_cores + 1}
+"""
+    )
+    assert dials.util.mp.available_cores() == true_cores + 1
+
+    # Now check it is robust against parsing failures
+    machine_ad.write_text(
+        """\
+CpusProvisioned =
+"""
+    )
+    assert dials.util.mp.available_cores() == true_cores

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -214,12 +214,12 @@ def show_mail_handle_errors():
 
 
 @dataclasses.dataclass
-class HTCondorClassAd:
+class HTCondorJobClassAd:
     cpus_provisioned: Optional[int] = None
     memory_provisioned: Optional[float] = None
 
 
-def parse_htcondor_classad(filepath: pathlib.Path) -> HTCondorClassAd:
+def parse_htcondor_job_classad(filepath: pathlib.Path) -> HTCondorJobClassAd:
     with filepath.open() as fh:
         memory_provisioned = None
         cpus_provisioned = None
@@ -229,7 +229,7 @@ def parse_htcondor_classad(filepath: pathlib.Path) -> HTCondorClassAd:
                 memory_provisioned = float(line.split("=")[1])
             elif line.startswith("cpusprovisioned") and "=" in line:
                 cpus_provisioned = int(line.split("=")[1])
-        return HTCondorClassAd(
+        return HTCondorJobClassAd(
             cpus_provisioned=cpus_provisioned,
             memory_provisioned=memory_provisioned,
         )

--- a/util/mp.py
+++ b/util/mp.py
@@ -1,10 +1,16 @@
 import itertools
+import logging
 import os
+import pathlib
 import warnings
 
 import psutil
 
 import libtbx.easy_mp
+
+import dials.util
+
+logger = logging.getLogger(__name__)
 
 
 def available_cores() -> int:
@@ -15,6 +21,20 @@ def available_cores() -> int:
     which may not be available on a specific OS and/or version of Python. So try
     them in order and return the first successful one.
     """
+
+    # https://htcondor.readthedocs.io/en/latest/users-manual/services-for-jobs.html#extra-environment-variables-htcondor-sets-for-jobs
+    condor_machine_ad = os.environ.get("_CONDOR_MACHINE_AD")
+    if condor_machine_ad:
+        try:
+            classad = dials.util.parse_htcondor_classad(pathlib.Path(condor_machine_ad))
+        except Exception as e:
+            logger.error(
+                f"Error parsing _CONDOR_MACHINE_AD {condor_machine_ad}: {e}",
+                exc_info=True,
+            )
+        else:
+            if classad.cpus_provisioned:
+                return classad.cpus_provisioned
 
     nproc = os.environ.get("NSLOTS", 0)
     try:

--- a/util/mp.py
+++ b/util/mp.py
@@ -23,13 +23,13 @@ def available_cores() -> int:
     """
 
     # https://htcondor.readthedocs.io/en/latest/users-manual/services-for-jobs.html#extra-environment-variables-htcondor-sets-for-jobs
-    condor_machine_ad = os.environ.get("_CONDOR_MACHINE_AD")
-    if condor_machine_ad:
+    condor_job_ad = os.environ.get("_CONDOR_JOB_AD")
+    if condor_job_ad:
         try:
-            classad = dials.util.parse_htcondor_classad(pathlib.Path(condor_machine_ad))
+            classad = dials.util.parse_htcondor_job_classad(pathlib.Path(condor_job_ad))
         except Exception as e:
             logger.error(
-                f"Error parsing _CONDOR_MACHINE_AD {condor_machine_ad}: {e}",
+                f"Error parsing _CONDOR_JOB_AD {condor_job_ad}: {e}",
                 exc_info=True,
             )
         else:


### PR DESCRIPTION
Features
--------

- ``dials.integrate``: When determining available memory, take into account ``MemoryProvisioned`` from HTCondor machine ad if the ``_CONDOR_JOB_AD`` environment variable is set. ``nproc=auto``: Take into account ``CpusProvisioned`` from HTCondor machine ad. (#1943)


Bugfixes
--------

- Read ``_CONDOR_JOB_AD`` not ``_CONDOR_MACHINE_AD`` (#1945)