### PR TITLE
Handle d_max more gracefully

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -42,7 +42,7 @@ conda-forge::requests
 conda-forge::scikit-learn
 conda-forge::scipy
 conda-forge::scons
-conda-forge::setuptools
+conda-forge::setuptools<60
 conda-forge::six
 conda-forge::sphinx>=4
 conda-forge::sqlite

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -45,7 +45,7 @@ conda-forge::requests
 conda-forge::scikit-learn
 conda-forge::scipy
 conda-forge::scons
-conda-forge::setuptools
+conda-forge::setuptools<60
 conda-forge::six
 conda-forge::sphinx>=4
 conda-forge::sqlite

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -42,7 +42,7 @@ conda-forge::requests
 conda-forge::scikit-learn
 conda-forge::scipy
 conda-forge::scons
-conda-forge::setuptools
+conda-forge::setuptools<60
 conda-forge::six
 conda-forge::sphinx>=4
 conda-forge::sqlite

--- a/command_line/check_indexing_symmetry.py
+++ b/command_line/check_indexing_symmetry.py
@@ -172,7 +172,9 @@ def test_crystal_pointgroup_symmetry(reflections, experiment, params):
 
     if params.d_min or params.d_max:
         d_spacings = ms.d_spacings().data()
-        sel = (d_spacings >= params.d_min) & (d_spacings <= params.d_max)
+        sel = d_spacings >= params.d_min
+        if params.d_max > 0:
+            sel = sel & (d_spacings <= params.d_max)
         ms = ms.select(sel)
 
     if params.normalise:

--- a/newsfragments/1957.bugfix
+++ b/newsfragments/1957.bugfix
@@ -1,0 +1,1 @@
+`dials.check_indexing_symmetry`: correctly handle d_max parameter if left at default value when d_min set


### PR DESCRIPTION
If `params.d_min` is set and `d_max == 0` then ignore `d_max`, else additionally filter the selection. This restores expected behaviour. 

Fixes #1956