### PR TITLE
2nd round of modifications to improve/extend the Kapton correction tool.

### DIFF
--- a/algorithms/integration/kapton_2019_correction.py
+++ b/algorithms/integration/kapton_2019_correction.py
@@ -325,6 +325,7 @@ class KaptonTape_2019:
         kapton_edge_2 = (col(int_edge_pts[2]) - col(int_edge_pts[3])).normalize()
         # Make sure the edges of the detector and the kapton are in the same orientation
         # first for kapton edge 1
+        edge_idx = [0, 1, 2, 3]
         side_1 = (col(edge_pts[edge_idx[0]]) - col(edge_pts[edge_idx[1]])).normalize()
         side_2 = (col(edge_pts[edge_idx[2]]) - col(edge_pts[edge_idx[3]])).normalize()
         v1 = kapton_edge_1.dot(side_1)
@@ -337,19 +338,12 @@ class KaptonTape_2019:
         # Now make sure the edges and the kapton lines are on the right side (i.e not swapped).
         # Let's look at edge_idx[0:2] i,e the first edge of detector parallel to the kapton
         pt1 = edge_pts[edge_idx[0]]
-        pt2 = edge_pts[edge_idx[1]]
         # Now find the distance between each of these points and the kapton lines.
         d1_kapton_1 = self.distance_of_point_from_line(
             pt1, int_edge_pts[0], int_edge_pts[1]
         )
         d1_kapton_2 = self.distance_of_point_from_line(
             pt1, int_edge_pts[2], int_edge_pts[3]
-        )
-        d2_kapton_1 = self.distance_of_point_from_line(
-            pt2, int_edge_pts[0], int_edge_pts[1]
-        )
-        d2_kapton_2 = self.distance_of_point_from_line(
-            pt2, int_edge_pts[2], int_edge_pts[3]
         )
         if d1_kapton_1 < d1_kapton_2:  # closer to max than edge
             pair_values = [

--- a/algorithms/integration/kapton_2019_correction.py
+++ b/algorithms/integration/kapton_2019_correction.py
@@ -323,19 +323,6 @@ class KaptonTape_2019:
         # Sort out the edge points and the int_edge_points which are on the same side
         kapton_edge_1 = (col(int_edge_pts[0]) - col(int_edge_pts[1])).normalize()
         kapton_edge_2 = (col(int_edge_pts[2]) - col(int_edge_pts[3])).normalize()
-        min_loss_func = -999.9
-        edge_idx = None
-        for edge_idx_combo in [(0, 1, 2, 3), (0, 3, 1, 2)]:
-            side_1 = (
-                col(edge_pts[edge_idx_combo[0]]) - col(edge_pts[edge_idx_combo[1]])
-            ).normalize()
-            side_2 = (
-                col(edge_pts[edge_idx_combo[2]]) - col(edge_pts[edge_idx_combo[3]])
-            ).normalize()
-            loss_func = abs(kapton_edge_1.dot(side_1)) + abs(kapton_edge_2.dot(side_2))
-            if loss_func > min_loss_func:
-                edge_idx = edge_idx_combo
-                min_loss_func = loss_func
         # Make sure the edges of the detector and the kapton are in the same orientation
         # first for kapton edge 1
         side_1 = (col(edge_pts[edge_idx[0]]) - col(edge_pts[edge_idx[1]])).normalize()
@@ -365,9 +352,6 @@ class KaptonTape_2019:
             pt2, int_edge_pts[2], int_edge_pts[3]
         )
         if d1_kapton_1 < d1_kapton_2:  # closer to max than edge
-            assert (
-                d2_kapton_1 < d2_kapton_2
-            ), "Distance mismatch. Edge of detector might be on wrong side of kapton tape ... please check"
             pair_values = [
                 (
                     edge_pts[edge_idx[0]],

--- a/newsfragments/1968.bugfix
+++ b/newsfragments/1968.bugfix
@@ -1,0 +1,3 @@
+This round includes modifications to enable Kapton absorption correction
+for higher angles of rotation of the Kapton tape.
+


### PR DESCRIPTION
This round includes modifications to enable Kapton absorption correction
for higher angles of rotation of the Kapton tape.

Note: that in order to see the effects of these modifications, you must also change to cctbx_project branch 'katon_plugin_pt2'.