### PR TITLE
Remove UUID

### DIFF
--- a/algorithms/scaling/scaling_library.py
+++ b/algorithms/scaling/scaling_library.py
@@ -12,7 +12,6 @@ ExperimentLists.
 from __future__ import annotations
 
 import logging
-import uuid
 from copy import deepcopy
 from unittest.mock import Mock
 
@@ -22,6 +21,7 @@ import pkg_resources
 import iotbx.merging_statistics
 from cctbx import crystal, miller, uctbx
 from dxtbx.model import Experiment
+from dxtbx.util import ersatz_uuid4
 from iotbx import cif, mtz
 from libtbx import Auto, phil
 
@@ -520,7 +520,7 @@ def create_datastructures_for_target_mtz(experiments, mtz_file):
 
     exp = Experiment()
     exp.crystal = deepcopy(experiments[0].crystal)
-    exp.identifier = str(uuid.uuid4())
+    exp.identifier = ersatz_uuid4()
     r_t.experiment_identifiers()[len(experiments)] = exp.identifier
     r_t["id"] = flex.int(r_t.size(), len(experiments))
 
@@ -580,7 +580,7 @@ def create_datastructures_for_structural_model(reflections, experiments, cif_fil
     rt["intensity"] = icalc
     rt["miller_index"] = miller_idx
 
-    exp.identifier = str(uuid.uuid4())
+    exp.identifier = ersatz_uuid4()
     rt.experiment_identifiers()[len(experiments)] = exp.identifier
     rt["id"] = flex.int(rt.size(), len(experiments))
 

--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Use dxtbx method ersatz_uuid4 which gives an implementation of a random 128 bit UUID4

--- a/util/multi_dataset_handling.py
+++ b/util/multi_dataset_handling.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import copy
 import logging
-import uuid
 
 from orderedset import OrderedSet
+
+from dxtbx.util import ersatz_uuid4
 
 from dials.array_family import flex
 
@@ -40,7 +41,7 @@ def generate_experiment_identifiers(experiments, identifier_type="uuid"):
     """Generate unique identifiers for each experiment."""
     if identifier_type == "uuid":
         for expt in experiments:
-            expt.identifier = str(uuid.uuid4())
+            expt.identifier = ersatz_uuid4()
     elif identifier_type == "timestamp":
         pass
 
@@ -240,7 +241,7 @@ def assign_unique_identifiers(experiments, reflections, identifiers=None):
         # it is already set, and reset table id column from 0..n-1
         for i, (exp, refl) in enumerate(zip(experiments, reflections)):
             if exp.identifier == "":
-                strid = str(uuid.uuid4())
+                strid = ersatz_uuid4()
                 exp.identifier = strid
                 refl.experiment_identifiers()[i] = strid
             else:


### PR DESCRIPTION
Use the `dxtbx.util.ersatz_uuid4` method in place of "proper" UUIDs - no change in behaviour expected beyond not importing `uuid` and hence not causing problems with large MPI ranks