### PR TITLE
Compute threshold with models

### DIFF
--- a/algorithms/spot_finding/finder.py
+++ b/algorithms/spot_finding/finder.py
@@ -92,7 +92,7 @@ class ExtractPixelsFromImage:
         # Add the images to the pixel lists
         num_strong = 0
         average_background = 0
-        for im, mk in zip(image, mask):
+        for i_panel, (im, mk) in enumerate(zip(image, mask)):
             if self.region_of_interest is not None:
                 x0, x1, y0, y1 = self.region_of_interest
                 height, width = im.all()
@@ -104,11 +104,19 @@ class ExtractPixelsFromImage:
                 assert y1 <= height, "y1 <= height"
                 im_roi = im[y0:y1, x0:x1]
                 mk_roi = mk[y0:y1, x0:x1]
-                tm_roi = self.threshold_function.compute_threshold(im_roi, mk_roi)
+                tm_roi = self.threshold_function.compute_threshold(
+                    im_roi,
+                    mk_roi,
+                    imageset=self.imageset,
+                    i_panel=i_panel,
+                    region_of_interest=self.region_of_interest,
+                )
                 threshold_mask = flex.bool(im.accessor(), False)
                 threshold_mask[y0:y1, x0:x1] = tm_roi
             else:
-                threshold_mask = self.threshold_function.compute_threshold(im, mk)
+                threshold_mask = self.threshold_function.compute_threshold(
+                    im, mk, imageset=self.imageset, i_panel=i_panel
+                )
 
             # Add the pixel list
             plist = PixelList(frame, im, threshold_mask)

--- a/extensions/dispersion_extended_spotfinder_threshold_ext.py
+++ b/extensions/dispersion_extended_spotfinder_threshold_ext.py
@@ -32,12 +32,13 @@ class DispersionExtendedSpotFinderThresholdExt:
         """
         self.params = params
 
-    def compute_threshold(self, image, mask):
+    def compute_threshold(self, image, mask, **kwargs):
         """
         Compute the threshold.
 
         :param image: The image to process
         :param mask: The pixel mask on the image
+        :**kwargs: Arbitrary keyword arguments
         :returns: A boolean mask showing foreground/background pixels
         """
 

--- a/extensions/dispersion_spotfinder_threshold_ext.py
+++ b/extensions/dispersion_spotfinder_threshold_ext.py
@@ -73,12 +73,13 @@ class DispersionSpotFinderThresholdExt:
         """
         self.params = params
 
-    def compute_threshold(self, image, mask):
+    def compute_threshold(self, image, mask, **kwargs):
         """
         Compute the threshold.
 
         :param image: The image to process
         :param mask: The pixel mask on the image
+        :**kwargs: Arbitrary keyword arguments
         :returns: A boolean mask showing foreground/background pixels
         """
 

--- a/newsfragments/xxx.misc
+++ b/newsfragments/xxx.misc
@@ -1,0 +1,1 @@
+Enable future spot-finding threshold algorithms to use experimental models.


### PR DESCRIPTION
Pass relevant experimental models into `compute_threshold` for future use.
    
The existing implementations of `compute_threshold` take `**kwargs`, which they ignore. A future implementation can make use of the `imageset`, panel number and ROI definition, all of which are needed to identify exactly which pixels we are trying to threshold. Fixes #2001.