### PR TITLE
Added default flux and transmission values to tests in test_show.py

### DIFF
--- a/newsfragments/2019.misc
+++ b/newsfragments/2019.misc
@@ -1,0 +1,1 @@
+Update test_show.py to include flux and transmission.

--- a/tests/command_line/test_show.py
+++ b/tests/command_line/test_show.py
@@ -48,6 +48,8 @@ Beam:
     sigma divergence: 0
     polarization normal: {0,1,0}
     polarization fraction: 0.999
+    flux: 0
+    transmission: 1
 Beam centre:
     mm: (212.48,220.00)
     px: (1235.34,1279.08)
@@ -120,6 +122,8 @@ Beam:
     sigma divergence: 0
     polarization normal: {0,1,0}
     polarization fraction: 0.999
+    flux: 0
+    transmission: 1
 Beam centre:
     mm: (210.76,205.28)
     px: (1225.35,1193.47)
@@ -177,6 +181,8 @@ Beam:
     sigma divergence: 0
     polarization normal: {0,1,0}
     polarization fraction: 0.999
+    flux: 0
+    transmission: 1
 Beam centre:
     mm: (212.48,220.00)
     px: (1235.34,1279.08)
@@ -260,6 +266,8 @@ Beam:
     sigma divergence: 0
     polarization normal: {0,1,0}
     polarization fraction: 0.999
+    flux: 0
+    transmission: 1
 Beam centre:
     mm: panel 12, (191.95,7.22)
     px: panel 12, (1116.00,41.96)


### PR DESCRIPTION
This adds missing default flux and transmission values to tests in `test_show.py`, now required due to [488 in dxtbx](https://github.com/cctbx/dxtbx/commit/361fe69796162d9bbae6822b42dad3f258176f4a).