### PR TITLE
Change default colorscale from Jet to Viridis

### DIFF
--- a/algorithms/scaling/plots.py
+++ b/algorithms/scaling/plots.py
@@ -857,7 +857,7 @@ def normal_probability_plot(data, label=None):
                         "title": "Number of reflections",
                         "titleside": "right",
                     },
-                    "colorscale": "Jet",
+                    "colorscale": "Viridis",
                 },
                 {
                     "x": [-5, 5],

--- a/command_line/report.py
+++ b/command_line/report.py
@@ -627,7 +627,7 @@ ice rings, or poor spot-finding parameters.
                             "title": "Number of reflections",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -666,7 +666,7 @@ ice rings, or poor spot-finding parameters.
                             "title": "Number of reflections",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -836,7 +836,7 @@ class CentroidAnalyser:
                             "title": "Difference in X position (pixels)",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -859,7 +859,7 @@ class CentroidAnalyser:
                             "title": "Difference in Y position (pixels)",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -905,7 +905,7 @@ class CentroidAnalyser:
                             "title": "Number of reflections",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -1348,7 +1348,7 @@ class IntensityAnalyser:
                         "type": "heatmap",
                         "name": f"i_over_sigma_{intensity_type}",
                         "colorbar": {"title": "Log I/σ(I)", "titleside": "right"},
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -1386,7 +1386,7 @@ class IntensityAnalyser:
                             "title": "Number of reflections",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -1462,7 +1462,7 @@ class IntensityAnalyser:
                         "z": z1.transpose().tolist(),
                         "type": "heatmap",
                         "colorbar": {"title": "QE", "titleside": "right"},
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -1894,7 +1894,7 @@ class ReferenceProfileAnalyser:
                             "title": "Number of reflections",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -1989,7 +1989,7 @@ class ReferenceProfileAnalyser:
                             "title": "Correlation with reference profile",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                         "zmin": 0,
                         "zmax": 1,
                     }
@@ -2027,7 +2027,7 @@ class ReferenceProfileAnalyser:
                             "title": "Number of reflections",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {
@@ -2075,7 +2075,7 @@ class ReferenceProfileAnalyser:
                             "title": "Number of reflections",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     }
                 ],
                 "layout": {

--- a/report/plots.py
+++ b/report/plots.py
@@ -166,7 +166,7 @@ def i_over_sig_i_vs_i_plot(intensities, sigmas, label=None):
                         "title": "Number of reflections",
                         "titleside": "right",
                     },
-                    "colorscale": "Jet",
+                    "colorscale": "Viridis",
                 }
             ],
             "layout": {
@@ -1102,7 +1102,7 @@ https://doi.org/10.1107/S0907444905036693
                             "title": "Number of reflections",
                             "titleside": "right",
                         },
-                        "colorscale": "Jet",
+                        "colorscale": "Viridis",
                     },
                     {
                         "x": [-5, 5],


### PR DESCRIPTION
I find it easier to compare data using a perceptually uniform sequential colormap/colorscale as opposed to a colorscale like Jet. Additionally, making this change increases accessibility of the software and the plots for the colorblind. Thanks for the consideration!