### PR TITLE
Parallelise outlier rejection in refinement

### DIFF
--- a/algorithms/refinement/outlier_detection/mcd.py
+++ b/algorithms/refinement/outlier_detection/mcd.py
@@ -17,6 +17,7 @@ class MCD(CentroidOutlier):
         separate_experiments=True,
         separate_panels=True,
         block_width=None,
+        nproc=1,
         alpha=0.5,
         max_n_groups=5,
         min_group_size=300,
@@ -36,6 +37,7 @@ class MCD(CentroidOutlier):
             separate_experiments=separate_experiments,
             separate_panels=separate_panels,
             block_width=block_width,
+            nproc=nproc,
         )
 
         # Keep the FastMCD options here

--- a/algorithms/refinement/outlier_detection/outlier_base.py
+++ b/algorithms/refinement/outlier_detection/outlier_base.py
@@ -275,9 +275,14 @@ outlier
 {
   algorithm = null *auto mcd tukey sauter_poon
     .help = "Outlier rejection algorithm. If auto is selected, the algorithm is"
-            "chosen automatically"
+            "chosen automatically."
     .type = choice
     .short_caption = "Outlier rejection algorithm"
+
+  nproc = Auto
+    .help = "Number of processes over which to split outlier identification."
+    .type = int(value_min=1)
+    .expert_level = 1
 
   minimum_number_of_reflections = 20
     .help = "The minimum number of input observations per outlier rejection"

--- a/algorithms/refinement/outlier_detection/outlier_base.py
+++ b/algorithms/refinement/outlier_detection/outlier_base.py
@@ -297,8 +297,9 @@ outlier
     .type = choice
     .short_caption = "Outlier rejection algorithm"
 
-  nproc = Auto
+  nproc = 1
     .help = "Number of processes over which to split outlier identification."
+            "If set to Auto, DIALS will choose automatically."
     .type = int(value_min=1)
     .expert_level = 1
 

--- a/algorithms/refinement/outlier_detection/sauter_poon.py
+++ b/algorithms/refinement/outlier_detection/sauter_poon.py
@@ -14,6 +14,7 @@ class SauterPoon(CentroidOutlier):
         separate_experiments=True,
         separate_panels=True,
         block_width=None,
+        nproc=1,
         px_sz=(1, 1),
         verbose=False,
         pdf=None,
@@ -28,6 +29,7 @@ class SauterPoon(CentroidOutlier):
             separate_experiments=separate_experiments,
             separate_panels=separate_panels,
             block_width=block_width,
+            nproc=nproc,
         )
 
         self._px_sz = px_sz

--- a/algorithms/refinement/outlier_detection/tukey.py
+++ b/algorithms/refinement/outlier_detection/tukey.py
@@ -16,6 +16,7 @@ class Tukey(CentroidOutlier):
         separate_experiments=True,
         separate_panels=True,
         block_width=None,
+        nproc=1,
         iqr_multiplier=1.5,
     ):
 
@@ -27,6 +28,7 @@ class Tukey(CentroidOutlier):
             min_num_obs=min_num_obs,
             separate_experiments=separate_experiments,
             block_width=block_width,
+            nproc=nproc,
             separate_panels=separate_panels,
         )
 

--- a/command_line/refine.py
+++ b/command_line/refine.py
@@ -101,6 +101,8 @@ phil_overrides = libtbx.phil.parse(
   refinement
   {
     parameterisation.scan_varying = Auto
+
+    reflections.outlier.nproc = Auto
   }
 """
 )

--- a/newsfragments/1427.feature
+++ b/newsfragments/1427.feature
@@ -1,0 +1,1 @@
+``dials.refine``: parallelise outlier rejection to reduce overall run times.

--- a/tests/command_line/test_refine.py
+++ b/tests/command_line/test_refine.py
@@ -38,6 +38,7 @@ def test1(dials_regression, tmpdir):
         "reflections_per_degree=100",
         "outlier.separate_blocks=False",
         "scan_varying=False",
+        "reflections.outlier.nproc=1",
         experiments_path,
         pickle_path,
     )
@@ -106,6 +107,7 @@ def test2(dials_regression, tmpdir):
             "crystal.orientation.smoother.interval_width_degrees=36.0",
             "crystal.unit_cell.smoother.interval_width_degrees=36.0",
             "set_scan_varying_errors=True",
+            "reflections.outlier.nproc=1",
         ),
         working_directory=tmpdir,
     )
@@ -159,6 +161,7 @@ def test3(dials_regression, tmpdir):
             "output.history=history.json",
             "crystal.orientation.smoother.interval_width_degrees=auto",
             "crystal.unit_cell.smoother.interval_width_degrees=auto",
+            "reflections.outlier.nproc=1",
         ),
         working_directory=tmpdir,
     )


### PR DESCRIPTION
Fixes #1427 

The new PHIL parameter `outlier.nproc` is set to `1` by default when using the `Refiner` as a library, but overridden to be `Auto` in `dials.refine`. I'll tag @rjgildea and @phyy-nx for review, as they may also want to set `outlier.nproc` to something other than `1` in some uses of refinement in `dials.index`, `stills_process` etc.