### PR TITLE
Don't generate phenix dispatchers on DIALS installation

### DIFF
--- a/newsfragments/1576.misc
+++ b/newsfragments/1576.misc
@@ -1,0 +1,1 @@
+No longer generate phenix dispatchers in release installations.


### PR DESCRIPTION
Although these aren't generated for development installs, upon installation libtbx.configure is called during reconfiguration without `--skip_phenix_dispatchers`. Since there isn't a way to do this using the base installer, move the logic into our subclass.

Fixes #1576