### PR TITLE
Avoid Scan dereference in parallel_integrator and parallel_reference_profiler

### DIFF
--- a/algorithms/integration/parallel_integrator.h
+++ b/algorithms/integration/parallel_integrator.h
@@ -36,7 +36,7 @@ namespace dials { namespace algorithms {
   using dxtbx::model::Detector;
   using dxtbx::model::Goniometer;
   using dxtbx::model::Panel;
-  using dxtbx::model::Scan;
+  using dxtbx::model::ScanBase;
 
   using dxtbx::ImageSequence;
   using dxtbx::format::Image;
@@ -1085,7 +1085,7 @@ namespace dials { namespace algorithms {
       DIALS_ASSERT(imageset.get_detector() != NULL);
       DIALS_ASSERT(imageset.get_scan() != NULL);
       Detector detector = *imageset.get_detector();
-      Scan scan = *imageset.get_scan();
+      ScanBase scan = *imageset.get_scan();
 
       // Get the size of the data buffer needed
       std::size_t zsize = imageset.size();
@@ -1183,7 +1183,7 @@ namespace dials { namespace algorithms {
       DIALS_ASSERT(imageset.get_detector() != NULL);
       DIALS_ASSERT(imageset.get_scan() != NULL);
       Detector detector = *imageset.get_detector();
-      Scan scan = *imageset.get_scan();
+      ScanBase scan = *imageset.get_scan();
       block_size = std::min(block_size, (std::size_t)scan.get_num_images());
       std::size_t nelements = 0;
       for (std::size_t i = 0; i < detector.size(); ++i) {

--- a/algorithms/integration/parallel_integrator.h
+++ b/algorithms/integration/parallel_integrator.h
@@ -1085,7 +1085,8 @@ namespace dials { namespace algorithms {
       DIALS_ASSERT(imageset.get_detector() != NULL);
       DIALS_ASSERT(imageset.get_scan() != NULL);
       Detector detector = *imageset.get_detector();
-      ScanBase scan = *imageset.get_scan();
+
+      boost::shared_ptr<ScanBase> scan = imageset.get_scan();
 
       // Get the size of the data buffer needed
       std::size_t zsize = imageset.size();
@@ -1095,7 +1096,7 @@ namespace dials { namespace algorithms {
       }
 
       // Get the starting frame and the underload/overload values
-      int zstart = scan.get_array_range()[0];
+      int zstart = scan->get_array_range()[0];
       double underload = detector[0].get_trusted_range()[0];
       double overload = detector[0].get_trusted_range()[1];
       DIALS_ASSERT(underload < overload);
@@ -1183,8 +1184,8 @@ namespace dials { namespace algorithms {
       DIALS_ASSERT(imageset.get_detector() != NULL);
       DIALS_ASSERT(imageset.get_scan() != NULL);
       Detector detector = *imageset.get_detector();
-      ScanBase scan = *imageset.get_scan();
-      block_size = std::min(block_size, (std::size_t)scan.get_num_images());
+      boost::shared_ptr<ScanBase> scan = imageset.get_scan();
+      block_size = std::min(block_size, (std::size_t)scan->get_num_images());
       std::size_t nelements = 0;
       for (std::size_t i = 0; i < detector.size(); ++i) {
         std::size_t xsize = detector[i].get_image_size()[0];

--- a/algorithms/integration/parallel_reference_profiler.h
+++ b/algorithms/integration/parallel_reference_profiler.h
@@ -36,7 +36,7 @@ namespace dials { namespace algorithms {
   using dxtbx::model::Detector;
   using dxtbx::model::Goniometer;
   using dxtbx::model::Panel;
-  using dxtbx::model::Scan;
+  using dxtbx::model::ScanBase;
 
   using dxtbx::ImageSequence;
   using dxtbx::format::Image;
@@ -448,7 +448,7 @@ namespace dials { namespace algorithms {
       DIALS_ASSERT(imageset.get_detector() != NULL);
       DIALS_ASSERT(imageset.get_scan() != NULL);
       Detector detector = *imageset.get_detector();
-      Scan scan = *imageset.get_scan();
+      ScanBase scan = *imageset.get_scan();
 
       // Get the size of the data buffer needed
       std::size_t zsize = imageset.size();
@@ -546,7 +546,7 @@ namespace dials { namespace algorithms {
       DIALS_ASSERT(imageset.get_detector() != NULL);
       DIALS_ASSERT(imageset.get_scan() != NULL);
       Detector detector = *imageset.get_detector();
-      Scan scan = *imageset.get_scan();
+      ScanBase scan = *imageset.get_scan();
       block_size = std::min(block_size, (std::size_t)scan.get_num_images());
       std::size_t nelements = 0;
       for (std::size_t i = 0; i < detector.size(); ++i) {

--- a/algorithms/integration/parallel_reference_profiler.h
+++ b/algorithms/integration/parallel_reference_profiler.h
@@ -448,7 +448,7 @@ namespace dials { namespace algorithms {
       DIALS_ASSERT(imageset.get_detector() != NULL);
       DIALS_ASSERT(imageset.get_scan() != NULL);
       Detector detector = *imageset.get_detector();
-      ScanBase scan = *imageset.get_scan();
+      boost::shared_ptr<ScanBase> scan = imageset.get_scan();
 
       // Get the size of the data buffer needed
       std::size_t zsize = imageset.size();
@@ -458,7 +458,7 @@ namespace dials { namespace algorithms {
       }
 
       // Get the starting frame and the underload/overload values
-      int zstart = scan.get_array_range()[0];
+      int zstart = scan->get_array_range()[0];
       double underload = detector[0].get_trusted_range()[0];
       double overload = detector[0].get_trusted_range()[1];
       DIALS_ASSERT(underload < overload);
@@ -546,8 +546,8 @@ namespace dials { namespace algorithms {
       DIALS_ASSERT(imageset.get_detector() != NULL);
       DIALS_ASSERT(imageset.get_scan() != NULL);
       Detector detector = *imageset.get_detector();
-      ScanBase scan = *imageset.get_scan();
-      block_size = std::min(block_size, (std::size_t)scan.get_num_images());
+      boost::shared_ptr<ScanBase> scan = imageset.get_scan();
+      block_size = std::min(block_size, (std::size_t)scan->get_num_images());
       std::size_t nelements = 0;
       for (std::size_t i = 0; i < detector.size(); ++i) {
         std::size_t xsize = detector[i].get_image_size()[0];

--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Changed parallel_integrator.h and parallel_reference_profiler to avoid explicit Scan dereference.


### PR DESCRIPTION
This changes explicit `Scan` dereferences in parallel_integrator.h and parallel_reference_profiler.h to instead call methods from a `ScanBase` pointer. This only make sense if [503](503) is merged.