### PR TITLE
boilerplate it

### DIFF
--- a/command_line/modify_geometry.py
+++ b/command_line/modify_geometry.py
@@ -67,25 +67,11 @@ def run(args: List[str] = None, phil: libtbx.phil.scope = phil_scope) -> None:
         parser.print_help()
         exit(0)
 
-    from dials.command_line.dials_import import ManualGeometryUpdater
+    new_experiments = update(experiments, params)
 
-    update_geometry = ManualGeometryUpdater(params)
-
-    if len(experiments):
-        imagesets = experiments.imagesets()
-
-    for imageset in imagesets:
-        imageset_new = update_geometry(imageset)
-        imageset.set_detector(imageset_new.get_detector())
-        imageset.set_beam(imageset_new.get_beam())
-        imageset.set_goniometer(imageset_new.get_goniometer())
-        imageset.set_scan(imageset_new.get_scan())
-
-    experiments = update(experiments, params)
-
-    if len(experiments):
+    if len(new_experiments):
         print(f"Saving modified experiments to {params.output.experiments}")
-        experiments.as_file(params.output.experiments)
+        new_experiments.as_file(params.output.experiments)
 
 
 if __name__ == "__main__":

--- a/command_line/modify_geometry.py
+++ b/command_line/modify_geometry.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from typing import List
+
 import libtbx.phil
+from dxtbx.model import ExperimentList
 
 import dials.util
+from dials.command_line.dials_import import ManualGeometryUpdater
+from dials.util.options import ArgumentParser, flatten_experiments
 
 help_message = """
 """
@@ -19,9 +24,31 @@ output {
 )
 
 
+def update(
+    experiments: ExperimentList, new_params: libtbx.phil.scope_extract
+) -> ExperimentList:
+
+    """
+    Modify detector, beam, goniometer and scan in experiments with the values in new_params
+    """
+
+    update_geometry = ManualGeometryUpdater(new_params)
+
+    if len(experiments):
+        imagesets = experiments.imagesets()
+
+    for imageset in imagesets:
+        imageset_new = update_geometry(imageset)
+        imageset.set_detector(imageset_new.get_detector())
+        imageset.set_beam(imageset_new.get_beam())
+        imageset.set_goniometer(imageset_new.get_goniometer())
+        imageset.set_scan(imageset_new.get_scan())
+
+    return experiments
+
+
 @dials.util.show_mail_handle_errors()
-def run(args=None):
-    from dials.util.options import ArgumentParser, flatten_experiments
+def run(args: List[str] = None, phil: libtbx.phil.scope = phil_scope) -> None:
 
     usage = "dials.modify_geometry [options] models.expt"
 
@@ -53,6 +80,8 @@ def run(args=None):
         imageset.set_beam(imageset_new.get_beam())
         imageset.set_goniometer(imageset_new.get_goniometer())
         imageset.set_scan(imageset_new.get_scan())
+
+    experiments = update(experiments, params)
 
     if len(experiments):
         print(f"Saving modified experiments to {params.output.experiments}")

--- a/command_line/modify_geometry.py
+++ b/command_line/modify_geometry.py
@@ -34,8 +34,7 @@ def update(
 
     update_geometry = ManualGeometryUpdater(new_params)
 
-    if len(experiments):
-        imagesets = experiments.imagesets()
+    imagesets = experiments.imagesets()
 
     for imageset in imagesets:
         imageset_new = update_geometry(imageset)
@@ -60,7 +59,7 @@ def run(args: List[str] = None, phil: libtbx.phil.scope = phil_scope) -> None:
         epilog=help_message,
     )
 
-    params, options = parser.parse_args(args, show_diff_phil=True)
+    params, _ = parser.parse_args(args, show_diff_phil=True)
     experiments = flatten_experiments(params.input.experiments)
 
     if len(experiments) == 0:

--- a/newsfragments/2041.misc
+++ b/newsfragments/2041.misc
@@ -1,0 +1,1 @@
+`modify_geometry` now has `update` as a main function which is then called in `run()`.

--- a/tests/command_line/test_modify_geometry.py
+++ b/tests/command_line/test_modify_geometry.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
-import os
+from os import path
 
 import procrunner
 import pytest
 
 from dxtbx.serialize import load
 
+from dials.command_line.modify_geometry import update
 
-def test_modify_geometry_run(dials_regression, tmp_path):
-    orig_expt_json = os.path.join(
-        dials_regression, "experiment_test_data/kappa_experiments.json"
+
+def test_run(dials_regression, tmp_path):
+    orig_expt_json = path.join(
+        dials_regression, "experiment_test_data", "kappa_experiments.json"
     )
-    assert orig_expt_json.is_file()
+    assert path.exists(orig_expt_json)
+
     orig_expt = load.experiment_list(orig_expt_json, check_format=False)
+    orig_gonio = orig_expt.goniometers()[0]
+    assert orig_gonio.get_angles() == pytest.approx([0, 180, 0])
 
     result = procrunner.run(
         ["dials.modify_geometry", orig_expt_json, "angles=10,20,30"],
@@ -26,7 +31,32 @@ def test_modify_geometry_run(dials_regression, tmp_path):
 
     new_expt = load.experiment_list(new_expt_json, check_format=False)
 
-    orig_gonio = orig_expt.goniometers()[0]
     new_gonio = new_expt.goniometers()[0]
-    assert orig_gonio.get_angles() == pytest.approx([0, 180, 0])
     assert new_gonio.get_angles() == pytest.approx([10, 20, 30])
+
+
+def test_load(dials_data, tmp_path):
+    from dials.command_line.modify_geometry import phil_scope as modify_geom_phil
+
+    orig_expt = dials_data("aluminium_standard", pathlib=True) / "imported.expt"
+    assert orig_expt.is_file()
+
+    orig_expt = load.experiment_list(orig_expt, check_format=False)
+    orig_beam = orig_expt.beams()[0]
+    assert orig_beam.get_wavelength() == pytest.approx(0.02508235604)
+
+    new_expt = tmp_path / "modified.expt"
+
+    ## this is the idiosyncratic way to update phils
+    ## and it should work but in fact does nothing
+    working_params = modify_geom_phil.extract()
+    working_params.geometry.beam.wavelength = 0.05
+    working_params.output.experiments = str(new_expt)
+
+    update(orig_expt, working_params)
+    assert new_expt.is_file()
+
+    new_expt = load.experiment_list(new_expt, check_format=False)
+
+    new_beam = new_expt.beams()[0]
+    assert new_beam.get_wavelength() == pytest.approx(0.05)

--- a/tests/command_line/test_modify_geometry.py
+++ b/tests/command_line/test_modify_geometry.py
@@ -8,23 +8,23 @@ import pytest
 from dxtbx.serialize import load
 
 
-def test_modify_geometry(dials_regression, tmpdir):
+def test_modify_geometry_run(dials_regression, tmp_path):
     orig_expt_json = os.path.join(
         dials_regression, "experiment_test_data/kappa_experiments.json"
     )
-
-    new_expt_json = tmpdir.join("modified.expt")
+    assert orig_expt_json.is_file()
+    orig_expt = load.experiment_list(orig_expt_json, check_format=False)
 
     result = procrunner.run(
         ["dials.modify_geometry", orig_expt_json, "angles=10,20,30"],
-        working_directory=tmpdir,
+        working_directory=tmp_path,
     )
     assert not result.returncode and not result.stderr
 
-    assert os.path.exists(orig_expt_json), orig_expt_json
-    orig_expt = load.experiment_list(orig_expt_json, check_format=False)
-    assert new_expt_json.check()
-    new_expt = load.experiment_list(new_expt_json.strpath, check_format=False)
+    new_expt_json = tmp_path / "modified.expt"
+    assert new_expt_json.is_file()
+
+    new_expt = load.experiment_list(new_expt_json, check_format=False)
 
     orig_gonio = orig_expt.goniometers()[0]
     new_gonio = new_expt.goniometers()[0]

--- a/tests/command_line/test_modify_geometry.py
+++ b/tests/command_line/test_modify_geometry.py
@@ -5,7 +5,6 @@ from os import path
 import procrunner
 import pytest
 
-import libtbx.phil
 from dxtbx.serialize import load
 
 from dials.command_line.modify_geometry import phil_scope, update
@@ -36,7 +35,7 @@ def test_run(dials_regression, tmp_path):
     assert new_gonio.get_angles() == pytest.approx([10, 20, 30])
 
 
-def test_load(dials_data):
+def test_update(dials_data):
 
     orig_expt = dials_data("aluminium_standard", pathlib=True) / "imported.expt"
     assert orig_expt.is_file()
@@ -45,9 +44,8 @@ def test_load(dials_data):
     orig_beam = orig_expt.beams()[0]
     assert orig_beam.get_wavelength() == pytest.approx(0.02508235604)
 
-    working_params = phil_scope.fetch(
-        libtbx.phil.parse("geometry.beam.wavelength=0.05")
-    ).extract()
+    working_params = phil_scope.fetch().extract()
+    working_params.geometry.beam.wavelength = 0.05
 
     new_expt = update(orig_expt, working_params)
 


### PR DESCRIPTION
Separate the useful algorithm part and call it from `run()`. Trying to follow the [boilerplate](https://github.com/dials/dials/blob/main/doc/examples/boilerplate.py) but also I want to be able to call `modify_geometry` without going through `run()`.