### PR TITLE
DIALS 3.8.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.8.4 (2022-04-01)
+========================
+
+Bugfixes
+--------
+
+- ``dials.scale``: Fix crash when a dataset is filtered out during the scaling process (issue #2045). (`#2045 <https://github.com/dials/dials/issues/2045>`_)
+
+
 DIALS 3.8.3 (2022-02-22)
 ========================
 

--- a/algorithms/scaling/scaler.py
+++ b/algorithms/scaling/scaler.py
@@ -1103,6 +1103,10 @@ class MultiScalerBase(ScalerBase):
                 datasets_to_remove.append(i)
         if datasets_to_remove:
             self.remove_datasets(self.active_scalers, datasets_to_remove)
+            (
+                self._global_Ih_table,
+                self._free_Ih_table,
+            ) = self._create_global_Ih_table(self.params.anomalous)
         self._create_Ih_table()
         self._update_model_data()
 
@@ -1225,7 +1229,6 @@ class MultiScalerBase(ScalerBase):
                 self.global_Ih_table.Ih_table_blocks[0],
                 random_phil.multi_dataset.Isigma_cutoff,
             )
-
             for i, scaler in enumerate(self.active_scalers):
                 # first set cross dataset connected reflections identified.
                 # scaler.scaling_selection = flex.bool(scaler.n_suitable_refl, False)

--- a/algorithms/scaling/scaler_factory.py
+++ b/algorithms/scaling/scaler_factory.py
@@ -239,17 +239,14 @@ class MultiScalerFactory:
                 idx_to_remove.append(i)
             else:
                 single_scalers.append(scaler)
+        ms = MultiScaler(single_scalers)
         if idx_to_remove:
-            for j in idx_to_remove[::-1]:
-                del experiments[j]
-                del reflections[j]
+            for i in idx_to_remove:
+                ms.removed_datasets.append(experiments[i].identifier)
             logger.info(
                 "Removed experiments %s", " ".join(str(i) for i in idx_to_remove)
             )
-        n_exp, n_refl, n_ss = (len(experiments), len(reflections), len(single_scalers))
-        assert n_exp == n_ss, (n_exp, n_ss)
-        assert n_exp == n_refl, (n_exp, n_refl)
-        return MultiScaler(single_scalers)
+        return ms
 
     @staticmethod
     def create_from_targetscaler(targetscaler):
@@ -282,22 +279,17 @@ class TargetScalerFactory:
                 idx_to_remove.append(i)
             else:
                 unscaled_scalers.append(scaler)
-        if idx_to_remove:
-            for j in idx_to_remove[::-1]:
-                del experiments[j]
-                del reflections[j]
-            logger.info(
-                "Removed experiments %s", " ".join(str(i) for i in idx_to_remove)
-            )
         scaled_scalers = [
             NullScalerFactory.create(params, experiments[-1], reflections[-1])
         ]
-
-        n_exp, n_refl = (len(experiments), len(reflections))
-        n_ss, n_us = (len(scaled_scalers), len(unscaled_scalers))
-        assert n_exp == n_ss + n_us, (n_exp, str(n_ss) + " + " + str(n_us))
-        assert n_exp == n_refl, (n_exp, n_refl)
-        return TargetScaler(scaled_scalers, unscaled_scalers)
+        ts = TargetScaler(scaled_scalers, unscaled_scalers)
+        if idx_to_remove:
+            for i in idx_to_remove:
+                ts.removed_datasets.append(experiments[i].identifier)
+            logger.info(
+                "Removed experiments %s", " ".join(str(i) for i in idx_to_remove)
+            )
+        return ts
 
     @staticmethod
     def create(params, experiments, reflections):

--- a/newsfragments/2045.bugfix
+++ b/newsfragments/2045.bugfix
@@ -1,1 +1,0 @@
-``dials.scale``: Fix crash when a dataset is filtered out during the scaling process (issue #2045).

--- a/newsfragments/2045.bugfix
+++ b/newsfragments/2045.bugfix
@@ -1,0 +1,1 @@
+``dials.scale``: Fix crash when a dataset is filtered out during the scaling process (issue #2045).

--- a/tests/algorithms/scaling/test_scale.py
+++ b/tests/algorithms/scaling/test_scale.py
@@ -644,6 +644,26 @@ def test_scale_and_filter_image_group_single_dataset(dials_data, tmp_path):
     assert analysis_results["termination_reason"] == "no_more_removed"
 
 
+def test_scale_when_a_dataset_is_filtered_out(dials_data, tmp_path):
+    location = dials_data("multi_crystal_proteinase_k", pathlib=True)
+    # Modify one of the input tables so that it gets filtered out
+    # during scaler initialisation. Triggers the bug referenced in
+    # https://github.com/dials/dials/issues/2045
+    refls = flex.reflection_table.from_file(location / "reflections_3.pickle")
+    refls["partiality"] = flex.double(refls.size(), 0.3)
+    refls.as_file(tmp_path / "modified_3.refl")
+    command = ["dials.scale", "d_min=2.0", tmp_path / "modified_3.refl"]
+    for i in [1, 2, 3, 4]:
+        command.append(location / f"experiments_{i}.json")
+    for i in [1, 2, 4]:
+        command.append(location / f"reflections_{i}.pickle")
+    result = procrunner.run(command, working_directory=tmp_path)
+    assert not result.returncode and not result.stderr
+    assert (tmp_path / "scaled.refl").is_file()
+    expts = load.experiment_list(tmp_path / "scaled.expt", check_format=False)
+    assert len(expts) == 3
+
+
 def test_scale_dose_decay_model(dials_data, tmp_path):
     """Test the scale and filter command line program."""
     location = dials_data("multi_crystal_proteinase_k", pathlib=True)


### PR DESCRIPTION
Bugfixes
--------

- ``dials.scale``: Fix crash when a dataset is filtered out during the scaling process (issue #2045). (#2045)