### PR TITLE
dev.dials.ssx_index fixes

### DIFF
--- a/algorithms/indexing/ssx/processing.py
+++ b/algorithms/indexing/ssx/processing.py
@@ -46,7 +46,9 @@ def index_one(
     image_no: int,
 ) -> Union[Tuple[ExperimentList, flex.reflection_table], Tuple[bool, bool]]:
     if not reflection_table:
-        logger.info(f"Image {image_no+1}: Failed to index, no strong spots found.")
+        logger.info(
+            f"Image {image_no+1}: Skipped indexing, no strong spots found/remaining."
+        )
         return None, None
     # First suppress logging unless in verbose mode.
     if params.individual_log_verbosity < 2:
@@ -204,20 +206,30 @@ def preprocess(
         no_refls = set(range(len(experiments))).difference(set(observed["id"]))
         for i in no_refls:
             reflections.insert(i, None)
+        logger.info(f"Filtered {len(no_refls)} images with no spots found.")
         if len(experiments) != len(reflections):
             raise ValueError(
                 f"Unequal number of reflection tables {len(reflections)} and experiments {len(experiments)}"
             )
 
     # Calculate necessary quantities
-    for refl, experiment in zip(reflections, experiments):
+    n_filtered_out = 0
+    for i, (refl, experiment) in enumerate(zip(reflections, experiments)):
         if refl:
-            elist = ExperimentList([experiment])
-            refl["imageset_id"] = flex.int(
-                refl.size(), 0
-            )  # needed for centroid_px_to_mm
-            refl.centroid_px_to_mm(elist)
-            refl.map_centroids_to_reciprocal_space(elist)
+            if refl.size() >= params.min_spots:
+                elist = ExperimentList([experiment])
+                refl["imageset_id"] = flex.int(
+                    refl.size(), 0
+                )  # needed for centroid_px_to_mm
+                refl.centroid_px_to_mm(elist)
+                refl.map_centroids_to_reciprocal_space(elist)
+            else:
+                n_filtered_out += 1
+                reflections[i] = None
+    if n_filtered_out:
+        logger.info(
+            f"Filtered {n_filtered_out} images with fewer than {params.min_spots} spots"
+        )
 
     # Determine the max cell if applicable
     if (params.indexing.max_cell is Auto) and (

--- a/algorithms/indexing/ssx/processing.py
+++ b/algorithms/indexing/ssx/processing.py
@@ -143,7 +143,6 @@ def index_all_concurrent(
         img = experiments[idx].imageset.get_image_identifier(idx).split("/")[-1]
         n_strong = n_strong_per_image[img]
         if not (elist and table):
-
             results_summary[idx].append(
                 {
                     "Image": img,

--- a/command_line/ssx_index.py
+++ b/command_line/ssx_index.py
@@ -161,7 +161,7 @@ def run(args: List[str] = None, phil: phil.scope = phil_scope) -> None:
     summary_table = make_summary_table(summary_data)
     logger.info("\nSummary of images sucessfully indexed\n" + summary_table)
 
-    n_images = len({e.imageset.get_path(0) for e in indexed_experiments})
+    n_images = len([1 for v in summary_data.values() if v[0]["n_indexed"]])
     logger.info(f"{indexed_reflections.size()} spots indexed on {n_images} images\n")
 
     crystal_symmetries = [

--- a/command_line/ssx_index.py
+++ b/command_line/ssx_index.py
@@ -84,6 +84,10 @@ nproc = Auto
     .type = int
     .expert_level = 1
     .help = "Set the number of processors to use in indexing"
+min_spots = 10
+    .type = int
+    .expert_level = 2
+    .help = "Images with fewer than this number of strong spots will not be indexed"
 output.html = dials.ssx_index.html
     .type = str
 output.json = None
@@ -167,17 +171,18 @@ def run(args: List[str] = None, phil: phil.scope = phil_scope) -> None:
         )
         for expt in indexed_experiments
     ]
-    cluster_plots, _ = report_on_crystal_clusters(
-        crystal_symmetries,
-        make_plots=(params.output.html or params.output.json),
-    )
+    if crystal_symmetries:
+        cluster_plots, _ = report_on_crystal_clusters(
+            crystal_symmetries,
+            make_plots=(params.output.html or params.output.json),
+        )
 
     logger.info(f"Saving indexed experiments to {params.output.experiments}")
     indexed_experiments.as_file(params.output.experiments)
     logger.info(f"Saving indexed reflections to {params.output.reflections}")
     indexed_reflections.as_file(params.output.reflections)
 
-    if params.output.html or params.output.json:
+    if (params.output.html or params.output.json) and indexed_experiments:
         summary_plots = generate_plots(summary_data)
         if cluster_plots:
             summary_plots.update(cluster_plots)

--- a/command_line/ssx_index.py
+++ b/command_line/ssx_index.py
@@ -24,11 +24,11 @@ Usage:
 
 from __future__ import annotations
 
-import functools.reduce
 import json
 import logging
 import sys
 import time
+from functools import reduce
 
 from cctbx import crystal
 from libtbx import Auto, phil
@@ -162,7 +162,7 @@ def run(args: List[str] = None, phil: phil.scope = phil_scope) -> None:
     summary_table = make_summary_table(summary_data)
     logger.info("\nSummary of images sucessfully indexed\n" + summary_table)
 
-    n_images = functools.reduce(
+    n_images = reduce(
         lambda a, v: a + (v[0]["n_indexed"] > 0), summary_data.values(), 0
     )
     logger.info(f"{indexed_reflections.size()} spots indexed on {n_images} images\n")

--- a/command_line/ssx_index.py
+++ b/command_line/ssx_index.py
@@ -24,6 +24,7 @@ Usage:
 
 from __future__ import annotations
 
+import functools.reduce
 import json
 import logging
 import sys
@@ -161,7 +162,9 @@ def run(args: List[str] = None, phil: phil.scope = phil_scope) -> None:
     summary_table = make_summary_table(summary_data)
     logger.info("\nSummary of images sucessfully indexed\n" + summary_table)
 
-    n_images = len([1 for v in summary_data.values() if v[0]["n_indexed"]])
+    n_images = functools.reduce(
+        lambda a, v: a + (v[0]["n_indexed"] > 0), summary_data.values(), 0
+    )
     logger.info(f"{indexed_reflections.size()} spots indexed on {n_images} images\n")
 
     crystal_symmetries = [

--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``dev.dials.ssx_index``: Fix reporting of results for h5 files, skip indexing of an image if fewer than ``min_spots`` strong spots (default 10).

--- a/tests/command_line/test_ssx_index.py
+++ b/tests/command_line/test_ssx_index.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os.path
 
 import procrunner
-import pytest
 
 from dxtbx.serialize import load
 
@@ -52,8 +51,11 @@ def test_ssx_index_bad_input(dials_data, run_in_tmpdir):
     expts = str(ssx / "imported_no_ref_5.expt")
     refls = str(ssx / "strong_1.refl")
 
-    with pytest.raises(ValueError):
-        run([expts, refls])
+    run([expts, refls])
+    assert os.path.exists("indexed.refl")
+    assert os.path.exists("indexed.expt")
+    experiments = load.experiment_list("indexed.expt", check_format=False)
+    assert len(experiments) == 0
 
 
 def test_ssx_index_input_unit_cell(dials_data, run_in_tmpdir):


### PR DESCRIPTION
Fix issue in results reporting for h5 files (always reported that it had indexed 1 image).

Use `min_spots` parameter (default 10) to skip attempted indexing of weak/bad images.

Correctly handle function calls when a total of 0 images get indexed.