### PR TITLE
dials.show without imageset

### DIFF
--- a/command_line/show.py
+++ b/command_line/show.py
@@ -251,16 +251,14 @@ def show_experiments(experiments, show_scan_varying=False):
     text = []
     for i_expt, expt in enumerate(experiments):
         text.append("Experiment %i:" % i_expt)
+        template = None
         if expt.imageset:
             format_class = expt.imageset.get_format_class()
+            template = expt.imageset.get_template()
             if not format_class.is_abstract():
                 text.append(f"Format class: {format_class.__name__}")
-            if expt.identifier != "":
-                text.append(f"Experiment identifier: {expt.identifier}")
-        try:
-            template = expt.imageset.get_template()
-        except AttributeError:
-            template = None
+        if expt.identifier != "":
+            text.append(f"Experiment identifier: {expt.identifier}")
         if template:
             text.append(f"Image template: {template}")
         text.append(str(expt.detector))

--- a/command_line/show.py
+++ b/command_line/show.py
@@ -251,11 +251,12 @@ def show_experiments(experiments, show_scan_varying=False):
     text = []
     for i_expt, expt in enumerate(experiments):
         text.append("Experiment %i:" % i_expt)
-        format_class = expt.imageset.get_format_class()
-        if not format_class.is_abstract():
-            text.append(f"Format class: {format_class.__name__}")
-        if expt.identifier != "":
-            text.append(f"Experiment identifier: {expt.identifier}")
+        if expt.imageset:
+            format_class = expt.imageset.get_format_class()
+            if not format_class.is_abstract():
+                text.append(f"Format class: {format_class.__name__}")
+            if expt.identifier != "":
+                text.append(f"Experiment identifier: {expt.identifier}")
         try:
             template = expt.imageset.get_template()
         except AttributeError:

--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+``dials.show``: avoid crash when an experiment does not have an imageset.


### PR DESCRIPTION
`dials.show` was crashing when passed an experiment list that had an empty imageset (for example, from `dials.import_mtz`). In that case skip the display of format class and template.