### PR TITLE
Protect against mean=0 in simulation poisson distribution

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Handle simulation case where test reflections could fail to generate.

--- a/src/dials/algorithms/simulation/generate_test_reflections.py
+++ b/src/dials/algorithms/simulation/generate_test_reflections.py
@@ -99,6 +99,8 @@ def random_background_plane2(sbox, a, b, c, d):
     dz, dy, dx = sbox.focus()
 
     if b == c == d == 0.0:
+        if a == 0:
+            return
         g = variate(poisson_distribution(mean=a))
         for k in range(dz):
             for j in range(dy):
@@ -109,8 +111,9 @@ def random_background_plane2(sbox, a, b, c, d):
             for j in range(dy):
                 for i in range(dx):
                     pixel = a + b * (i + 0.5) + c * (j + 0.5) + d * (k + 0.5)
-                    g = variate(poisson_distribution(mean=pixel))
-                    sbox[k, j, i] += next(g)
+                    if pixel != 0:
+                        g = variate(poisson_distribution(mean=pixel))
+                        sbox[k, j, i] += next(g)
     return
 
 


### PR DESCRIPTION
Fix against case in testing where a poisson distribution with zero mean could be generated. This works for bootstrap builds and conda-forge prebuilt cctbx on linux, but prebuilt on mac fails. Presumably this is sensitive to how boost was compiled - if boost assertions are enabled when scitbx is compiled, it can encounter [this assert](https://github.com/boostorg/random/blob/a2740d4b30178cb187fabca163e5be7803a577b9/include/boost/random/poisson_distribution.hpp#L84), killing the process.