### PR TITLE
Scipy/numpy implementation of the French & Wilson algorithm

### DIFF
--- a/src/dials/algorithms/merging/french_wilson.py
+++ b/src/dials/algorithms/merging/french_wilson.py
@@ -38,6 +38,9 @@ def french_wilson(
     is_acentric = ~is_centric
 
     rejected = (sigmas <= 0) & ((intensities <= 0) | (sigmas < 0))
+    logger.debug(
+        f"Rejecting {np.count_nonzero(rejected)} reflections with non-positive sigmas"
+    )
 
     # Compute expected intensities
     d_star_cubed = flumpy.to_numpy(merged_intensities.d_star_cubed().data())
@@ -47,7 +50,12 @@ def french_wilson(
         n_bins=n_bins,
         m_estimator=standardized_median,
     )
-    rejected |= expected_intensities == 0
+    expected_intensity_is_zero = expected_intensities == 0
+    logger.debug(
+        f"Rejecting {np.count_nonzero(expected_intensity_is_zero)} "
+        "reflections with expected intensity equal to zero"
+    )
+    rejected |= expected_intensity_is_zero
     valid = ~rejected
 
     J = np.zeros_like(intensities)
@@ -133,7 +141,7 @@ def compute_posterior_moments_acentric(
 ) -> PosteriorMoments:
 
     h = (intensities / sigmas) - np.abs(sigmas / expected_intensities)
-    logger.debug(f"h range: {h.min()} - {h.max}")
+    logger.debug(f"h range: {h.min():.4f} - {h.max():.4f}")
     i_sig_min = h_min + 0.3
     valid = (intensities / sigmas >= i_sig_min) & (h >= h_min)
 
@@ -181,7 +189,7 @@ def compute_posterior_moments_centric(
 ) -> PosteriorMoments:
 
     h = (intensities / sigmas) - np.abs(sigmas / (2 * expected_intensities))
-    logger.debug(f"h range: {h.min()} - {h.max}")
+    logger.debug(f"h range: {h.min():.4f} - {h.max():.4f}")
     i_sig_min = h_min + 0.3
     valid = (intensities / sigmas >= i_sig_min) & (h >= h_min)
 

--- a/src/dials/algorithms/merging/french_wilson.py
+++ b/src/dials/algorithms/merging/french_wilson.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+from scipy import interpolate, stats
+
+from cctbx import miller
+from cctbx.french_wilson import (
+    ac_zf,
+    ac_zf_sd,
+    ac_zj,
+    ac_zj_sd,
+    c_zf,
+    c_zf_sd,
+    c_zj,
+    c_zj_sd,
+)
+from dxtbx import flumpy
+
+logger = logging.getLogger(__name__)
+
+
+def french_wilson(
+    merged_intensities: miller.array,
+    n_bins: int = 50,
+    sigma_iobs_rejection_criterion: float = -4.0,
+) -> miller.array:
+    assert merged_intensities.is_xray_intensity_array()
+    assert merged_intensities.sigmas() is not None
+    assert merged_intensities.is_unique_set_under_symmetry()
+
+    intensities = flumpy.to_numpy(merged_intensities.data())
+    sigmas = flumpy.to_numpy(merged_intensities.sigmas())
+    is_centric = flumpy.to_numpy(merged_intensities.centric_flags().data())
+    is_acentric = ~is_centric
+
+    rejected = (sigmas <= 0) & ((intensities <= 0) | (sigmas < 0))
+
+    # Compute expected intensities
+    four_stol_sq = 4 * flumpy.to_numpy(
+        merged_intensities.sin_theta_over_lambda_sq().data()
+    )
+    expected_intensities = compute_expected_intensities(
+        four_stol_sq,
+        intensities,
+        n_bins=n_bins,
+    )
+    rejected |= expected_intensities == 0
+    valid = ~rejected
+
+    J = np.zeros_like(intensities)
+    sigJ = np.zeros_like(intensities)
+    F = np.zeros_like(intensities)
+    sigF = np.zeros_like(intensities)
+
+    # Compute acentric moments
+    posterior_moments_acentric = compute_posterior_moments_acentric(
+        intensities[is_acentric], sigmas[is_acentric], expected_intensities[is_acentric]
+    )
+    J[is_acentric] = posterior_moments_acentric.J
+    sigJ[is_acentric] = posterior_moments_acentric.sigJ
+    F[is_acentric] = posterior_moments_acentric.F
+    sigF[is_acentric] = posterior_moments_acentric.sigF
+    valid[is_acentric] &= posterior_moments_acentric.valid
+
+    # Compute centric moments
+    posterior_moments_centric = compute_posterior_moments_centric(
+        intensities[is_centric], sigmas[is_centric], expected_intensities[is_centric]
+    )
+    J[is_centric] = posterior_moments_centric.J
+    sigJ[is_centric] = posterior_moments_centric.sigJ
+    F[is_centric] = posterior_moments_centric.F
+    sigF[is_centric] = posterior_moments_centric.sigF
+    valid[is_centric] &= posterior_moments_centric.valid
+
+    logger.debug(f"Rejected {np.count_nonzero(~valid)} reflections")
+    return (
+        merged_intensities.customized_copy(
+            data=flumpy.from_numpy(F),
+            sigmas=flumpy.from_numpy(sigF),
+            anomalous_flag=merged_intensities.anomalous_flag(),
+        )
+        .set_observation_type_xray_amplitude()
+        .select(flumpy.from_numpy(valid))
+    )
+
+
+def compute_expected_intensities(
+    x: np.ndarray,
+    intensities: np.ndarray,
+    n_bins: int,
+) -> np.ndarray:
+    # Compute the mean intensities binned according to x
+    bin_means, bin_edges, binnumber = stats.binned_statistic(
+        x, intensities, statistic="mean", bins=n_bins
+    )
+    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+
+    # Interpolate expected intensities
+    # f = interpolate.interp1d(bin_centers, bin_means, fill_value="extrapolate")
+    f = interpolate.interp1d(
+        bin_centers,
+        bin_means,
+        bounds_error=False,
+        fill_value=(bin_means[0], bin_means[-1]),
+    )
+    # f = interpolate.CubicSpline(bin_centers, bin_means, bc_type="clamped")
+    expected_intensities = f(x)
+    return expected_intensities
+
+
+@dataclass
+class PosteriorMoments:
+    J: np.ndarray
+    sigJ: np.ndarray
+    F: np.ndarray
+    sigF: np.ndarray
+    valid: np.ndarray
+
+
+def compute_posterior_moments_acentric(
+    intensities: np.ndarray,
+    sigmas: np.ndarray,
+    expected_intensities: np.ndarray,
+    h_min: int = -4,
+) -> PosteriorMoments:
+
+    h = (intensities / sigmas) - np.abs(sigmas / expected_intensities)
+    logger.debug(f"h range: {h.min()} - {h.max}")
+    i_sig_min = h_min + 0.3
+    valid = (intensities / sigmas >= i_sig_min) & (h >= h_min)
+
+    J = np.empty_like(h)
+    sigJ = np.empty_like(h)
+    F = np.empty_like(h)
+    sigF = np.empty_like(h)
+
+    # Set up interpolation functions as a function of h
+    n_interp = len(ac_zj)
+    x = (np.array(range(n_interp))) / 10 - 4
+    J_h = interpolate.interp1d(x, ac_zj)
+    sigJ_h = interpolate.interp1d(x, ac_zj_sd)
+    F_h = interpolate.interp1d(x, ac_zf)
+    sigF_h = interpolate.interp1d(x, ac_zf_sd)
+
+    # Interpolation only valid for -4 < h < 3
+    sel = valid & (h < 3)
+    J[sel] = J_h(h[sel]) * sigmas[sel]
+    sigJ[sel] = sigJ_h(h[sel]) * sigmas[sel]
+    F[sel] = F_h(h[sel]) * np.sqrt(sigmas)[sel]
+    sigF[sel] = sigF_h(h[sel]) * np.sqrt(sigmas)[sel]
+
+    # For h >= 3 approximate as a normal distribution
+    sel = valid & (h >= 3)
+    J[sel] = h[sel] * sigmas[sel]
+    sigJ[sel] = sigmas[sel]
+    F[sel] = np.sqrt(J[sel])
+    sigF[sel] = 0.5 * sigmas[sel] / F[sel]
+
+    return PosteriorMoments(
+        J=J,
+        sigJ=sigJ,
+        F=F,
+        sigF=sigF,
+        valid=valid,
+    )
+
+
+def compute_posterior_moments_centric(
+    intensities: np.ndarray,
+    sigmas: np.ndarray,
+    expected_intensities: np.ndarray,
+    h_min: int = -4,
+) -> PosteriorMoments:
+
+    h = (intensities / sigmas) - np.abs(sigmas / (2 * expected_intensities))
+    logger.debug(f"h range: {h.min()} - {h.max}")
+    i_sig_min = h_min + 0.3
+    valid = (intensities / sigmas >= i_sig_min) & (h >= h_min)
+
+    J = np.empty_like(h)
+    sigJ = np.empty_like(h)
+    F = np.empty_like(h)
+    sigF = np.empty_like(h)
+
+    # Set up interpolation functions as a function of h
+    n_interp = len(c_zj)
+    xh = (np.array(range(n_interp))) / 10 - 4
+    J_h = interpolate.interp1d(xh, c_zj)
+    sigJ_h = interpolate.interp1d(xh, c_zj_sd)
+    F_h = interpolate.interp1d(xh, c_zf)
+    sigF_h = interpolate.interp1d(xh, c_zf_sd)
+
+    # Obtain posterior moments via interpolation for -4 < h < 4
+    sel = valid & (h < 4)
+    J[sel] = J_h(h[sel]) * sigmas[sel]
+    sigJ[sel] = sigJ_h(h[sel]) * sigmas[sel]
+    F[sel] = F_h(h[sel]) * np.sqrt(sigmas)[sel]
+    sigF[sel] = sigF_h(h[sel]) * np.sqrt(sigmas)[sel]
+
+    # adapted from French-Wilson w/ added x^6 term in the expansion
+    sel = valid & (h >= 4)
+    h_2 = 1 / np.square(h[sel])
+    h_4 = np.square(h_2)
+    h_6 = h_2 * h_4
+    posterior_F = np.sqrt(h[sel]) * (
+        1 - (3 / 8) * h_2 - (87 / 128) * h_4 - (2889 / 1024) * h_6
+    )
+    posterior_sigF = np.sqrt(
+        h[sel] * ((1 / 4) * h_2 + (15 / 32) * h_4 + (273 / 128) * h_6)
+    )
+    J[sel] = h[sel] * sigmas[sel] * (1 - (1 / 2) * h_2 - (3 / 4) * h_4 - 3 * h_6)
+    sigJ[sel] = 2 * sigmas[sel] * posterior_F * posterior_sigF
+    F[sel] = posterior_F * np.sqrt(sigmas[sel])
+    sigF[sel] = posterior_sigF * np.sqrt(sigmas[sel])
+
+    return PosteriorMoments(
+        J=J,
+        sigJ=sigJ,
+        F=F,
+        sigF=sigF,
+        valid=valid,
+    )

--- a/src/dials/algorithms/merging/french_wilson.py
+++ b/src/dials/algorithms/merging/french_wilson.py
@@ -40,11 +40,9 @@ def french_wilson(
     rejected = (sigmas <= 0) & ((intensities <= 0) | (sigmas < 0))
 
     # Compute expected intensities
-    four_stol_sq = 4 * flumpy.to_numpy(
-        merged_intensities.sin_theta_over_lambda_sq().data()
-    )
+    d_star_cubed = flumpy.to_numpy(merged_intensities.d_star_cubed().data())
     expected_intensities = compute_expected_intensities(
-        four_stol_sq,
+        d_star_cubed,
         intensities,
         n_bins=n_bins,
         m_estimator=standardized_median,

--- a/src/dials/algorithms/merging/french_wilson.py
+++ b/src/dials/algorithms/merging/french_wilson.py
@@ -151,8 +151,8 @@ def compute_posterior_moments_acentric(
     sigF = np.empty_like(h)
 
     # Set up interpolation functions as a function of h
-    n_interp = len(ac_zj)
-    x = (np.array(range(n_interp))) / 10 - 4
+    # Tables give values from h = -4.0 to h = 10.0 in steps of 0.1
+    x = (np.array(range(len(ac_zj)))) / 10 - 4
     J_h = interpolate.interp1d(x, ac_zj)
     sigJ_h = interpolate.interp1d(x, ac_zj_sd)
     F_h = interpolate.interp1d(x, ac_zf)
@@ -199,12 +199,12 @@ def compute_posterior_moments_centric(
     sigF = np.empty_like(h)
 
     # Set up interpolation functions as a function of h
-    n_interp = len(c_zj)
-    xh = (np.array(range(n_interp))) / 10 - 4
-    J_h = interpolate.interp1d(xh, c_zj)
-    sigJ_h = interpolate.interp1d(xh, c_zj_sd)
-    F_h = interpolate.interp1d(xh, c_zf)
-    sigF_h = interpolate.interp1d(xh, c_zf_sd)
+    # Tables give values from h = -4.0 to h = 10.0 in steps of 0.1
+    x = (np.array(range(len(c_zj)))) / 10 - 4
+    J_h = interpolate.interp1d(x, c_zj)
+    sigJ_h = interpolate.interp1d(x, c_zj_sd)
+    F_h = interpolate.interp1d(x, c_zf)
+    sigF_h = interpolate.interp1d(x, c_zf_sd)
 
     # Obtain posterior moments via interpolation for -4 < h < 4
     sel = valid & (h < 4)

--- a/src/dials/algorithms/merging/french_wilson.py
+++ b/src/dials/algorithms/merging/french_wilson.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 
 import numpy as np
@@ -46,6 +47,7 @@ def french_wilson(
         four_stol_sq,
         intensities,
         n_bins=n_bins,
+        m_estimator=standardized_median,
     )
     rejected |= expected_intensities == 0
     valid = ~rejected
@@ -87,14 +89,19 @@ def french_wilson(
     )
 
 
+def standardized_median(a: np.ndarray) -> float:
+    return np.median(a) / math.log(2)
+
+
 def compute_expected_intensities(
     x: np.ndarray,
     intensities: np.ndarray,
     n_bins: int,
+    m_estimator="mean",
 ) -> np.ndarray:
     # Compute the mean intensities binned according to x
     bin_means, bin_edges, binnumber = stats.binned_statistic(
-        x, intensities, statistic="mean", bins=n_bins
+        x, intensities, statistic=m_estimator, bins=n_bins
     )
     bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
 

--- a/src/dials/algorithms/merging/french_wilson.py
+++ b/src/dials/algorithms/merging/french_wilson.py
@@ -74,14 +74,17 @@ def french_wilson(
     valid[is_acentric] &= posterior_moments_acentric.valid
 
     # Compute centric moments
-    posterior_moments_centric = compute_posterior_moments_centric(
-        intensities[is_centric], sigmas[is_centric], expected_intensities[is_centric]
-    )
-    J[is_centric] = posterior_moments_centric.J
-    sigJ[is_centric] = posterior_moments_centric.sigJ
-    F[is_centric] = posterior_moments_centric.F
-    sigF[is_centric] = posterior_moments_centric.sigF
-    valid[is_centric] &= posterior_moments_centric.valid
+    if np.count_nonzero(is_centric):
+        posterior_moments_centric = compute_posterior_moments_centric(
+            intensities[is_centric],
+            sigmas[is_centric],
+            expected_intensities[is_centric],
+        )
+        J[is_centric] = posterior_moments_centric.J
+        sigJ[is_centric] = posterior_moments_centric.sigJ
+        F[is_centric] = posterior_moments_centric.F
+        sigF[is_centric] = posterior_moments_centric.sigF
+        valid[is_centric] &= posterior_moments_centric.valid
 
     logger.debug(f"Rejected {np.count_nonzero(~valid)} reflections")
     return (

--- a/src/dials/algorithms/merging/merge.py
+++ b/src/dials/algorithms/merging/merge.py
@@ -29,6 +29,8 @@ from dials.util import tabulate
 from dials.util.export_mtz import MADMergedMTZWriter, MergedMTZWriter
 from dials.util.filter_reflections import filter_reflection_table
 
+from .french_wilson import french_wilson
+
 logger = logging.getLogger("dials")
 
 
@@ -277,7 +279,7 @@ def truncate(merged_intensities):
     logger.info("\nPerforming French-Wilson treatment of scaled intensities")
     out = StringIO()
     if merged_intensities.anomalous_flag():
-        anom_amplitudes = merged_intensities.french_wilson(log=out)
+        anom_amplitudes = french_wilson(merged_intensities)
         n_removed = merged_intensities.size() - anom_amplitudes.size()
         assert anom_amplitudes.is_xray_amplitude_array()
         amplitudes = anom_amplitudes.as_non_anomalous_array()
@@ -286,7 +288,7 @@ def truncate(merged_intensities):
     else:
         anom_amplitudes = None
         dano = None
-        amplitudes = merged_intensities.french_wilson(log=out)
+        amplitudes = french_wilson(merged_intensities)
         n_removed = merged_intensities.size() - amplitudes.size()
     logger.info("Total number of rejected intensities %s", n_removed)
     logger.debug(out.getvalue())

--- a/src/dials/algorithms/merging/merge.py
+++ b/src/dials/algorithms/merging/merge.py
@@ -261,7 +261,7 @@ def show_wilson_scaling_analysis(merged_intensities, n_residues=200):
             logger.info(out.getvalue())
 
 
-def truncate(merged_intensities):
+def truncate(merged_intensities, implementation: str = "dials"):
     """
     Perform French-Wilson truncation procedure on merged intensities.
 
@@ -278,8 +278,13 @@ def truncate(merged_intensities):
     """
     logger.info("\nPerforming French-Wilson treatment of scaled intensities")
     out = StringIO()
+    if implementation == "cctbx":
+        do_french_wilson = lambda ma: ma.french_wilson(log=out)
+    else:
+        do_french_wilson = french_wilson
+
     if merged_intensities.anomalous_flag():
-        anom_amplitudes = french_wilson(merged_intensities)
+        anom_amplitudes = do_french_wilson(merged_intensities)
         n_removed = merged_intensities.size() - anom_amplitudes.size()
         assert anom_amplitudes.is_xray_amplitude_array()
         amplitudes = anom_amplitudes.as_non_anomalous_array()
@@ -288,7 +293,7 @@ def truncate(merged_intensities):
     else:
         anom_amplitudes = None
         dano = None
-        amplitudes = french_wilson(merged_intensities)
+        amplitudes = do_french_wilson(merged_intensities)
         n_removed = merged_intensities.size() - amplitudes.size()
     logger.info("Total number of rejected intensities %s", n_removed)
     logger.debug(out.getvalue())

--- a/src/dials/command_line/merge.py
+++ b/src/dials/command_line/merge.py
@@ -47,7 +47,13 @@ anomalous = True
     .help = "Output anomalous as well as mean intensities."
 truncate = True
     .type = bool
-    .help = "Option to perform truncation on merged data."
+    .help = "Use the French & Wilson (1978) algorithm to correct for negative "
+            "intensities when estimating amplitudes."
+french_wilson {
+    implementation = *dials cctbx
+        .type = choice
+        .help = "Choice of implementation of the French & Wilson algorithm"
+}
 d_min = None
     .type = float
     .help = "High resolution limit to apply to the data."
@@ -209,7 +215,9 @@ def merge_data_to_mtz(params, experiments, reflections):
 
         anom_amplitudes = None
         if params.truncate:
-            amplitudes, anom_amplitudes, dano = truncate(merged_intensities)
+            amplitudes, anom_amplitudes, dano = truncate(
+                merged_intensities, implementation=params.french_wilson.implementation
+            )
             # This will add the data for F, SIGF
             mtz_dataset.amplitudes = amplitudes
             # This will add the data for F(+), F(-), SIGF(+), SIGF(-)

--- a/tests/algorithms/merging/test_french_wilson.py
+++ b/tests/algorithms/merging/test_french_wilson.py
@@ -13,6 +13,16 @@ MAX_SIGF_OVER_F_CENTRIC = max(
 )
 
 
+def check_french_wilson_amplitudes(amplitudes):
+    assert amplitudes.is_xray_amplitude_array()
+    assert flex.min(amplitudes.data()) >= 0
+    assert flex.min(amplitudes.sigmas()) >= 0
+    sigF_over_F = amplitudes.sigmas() / amplitudes.data()
+    is_centric = amplitudes.centric_flags().data()
+    assert flex.max(sigF_over_F.select(~is_centric)) <= MAX_SIGF_OVER_F_ACENTRIC
+    assert flex.max(sigF_over_F.select(is_centric)) <= MAX_SIGF_OVER_F_CENTRIC
+
+
 def test_french_wilson_insulin(dials_data):
     insulin = dials_data("insulin_processed", pathlib=True)
     expts = load.experiment_list(insulin / "scaled.expt", check_format=False)
@@ -21,10 +31,15 @@ def test_french_wilson_insulin(dials_data):
     merged_intensities = merged.array()
 
     amplitudes = french_wilson.french_wilson(merged_intensities)
-    assert amplitudes.is_xray_amplitude_array()
-    assert flex.min(amplitudes.data()) >= 0
-    assert flex.min(amplitudes.sigmas()) >= 0
-    sigF_over_F = amplitudes.sigmas() / amplitudes.data()
-    is_centric = amplitudes.centric_flags().data()
-    assert flex.max(sigF_over_F.select(~is_centric)) <= MAX_SIGF_OVER_F_ACENTRIC
-    assert flex.max(sigF_over_F.select(is_centric)) <= MAX_SIGF_OVER_F_CENTRIC
+    check_french_wilson_amplitudes(amplitudes)
+
+
+def test_french_wilson_l_cysteine(dials_data):
+    l_cysteine = dials_data("l_cysteine_4_sweeps_scaled")
+    expts = load.experiment_list(l_cysteine / "scaled_30.expt", check_format=False)
+    refls = flex.reflection_table.from_file(l_cysteine / "scaled_30.refl")
+    merged, _, _ = merge.merge(expts, refls)
+    merged_intensities = merged.array()
+
+    amplitudes = french_wilson.french_wilson(merged_intensities)
+    check_french_wilson_amplitudes(amplitudes)

--- a/tests/algorithms/merging/test_french_wilson.py
+++ b/tests/algorithms/merging/test_french_wilson.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dxtbx.serialize import load
+
+from dials.algorithms.merging import french_wilson, merge
+from dials.array_family import flex
+
+MAX_SIGF_OVER_F_ACENTRIC = max(
+    sigf / f for f, sigf in zip(french_wilson.ac_zf, french_wilson.ac_zf_sd)
+)
+MAX_SIGF_OVER_F_CENTRIC = max(
+    sigf / f for f, sigf in zip(french_wilson.c_zf, french_wilson.c_zf_sd)
+)
+
+
+def test_french_wilson_insulin(dials_data):
+    insulin = dials_data("insulin_processed", pathlib=True)
+    expts = load.experiment_list(insulin / "scaled.expt", check_format=False)
+    refls = flex.reflection_table.from_file(insulin / "scaled.refl")
+    merged, _, _ = merge.merge(expts, refls)
+    merged_intensities = merged.array()
+
+    amplitudes = french_wilson.french_wilson(merged_intensities)
+    assert amplitudes.is_xray_amplitude_array()
+    assert flex.min(amplitudes.data()) >= 0
+    assert flex.min(amplitudes.sigmas()) >= 0
+    sigF_over_F = amplitudes.sigmas() / amplitudes.data()
+    is_centric = amplitudes.centric_flags().data()
+    assert flex.max(sigF_over_F.select(~is_centric)) <= MAX_SIGF_OVER_F_ACENTRIC
+    assert flex.max(sigF_over_F.select(is_centric)) <= MAX_SIGF_OVER_F_CENTRIC

--- a/tests/command_line/test_merge.py
+++ b/tests/command_line/test_merge.py
@@ -29,10 +29,13 @@ def validate_mtz(mtz_file, expected_labels, unexpected_labels=None):
 
 
 @pytest.mark.parametrize("anomalous", [True, False])
-@pytest.mark.parametrize("truncate", [True, False])
-def test_merge(dials_data, tmp_path, anomalous, truncate):
+@pytest.mark.parametrize(
+    "truncate,french_wilson_impl", [(True, "dials"), (True, "cctbx"), (False, None)]
+)
+def test_merge(dials_data, tmp_path, anomalous, truncate, french_wilson_impl):
     """Test the command line script with LCY data"""
     # Main options: truncate on/off, anomalous on/off
+    # french_wilson.implementation dials/cctbx
 
     mean_labels = ["IMEAN", "SIGIMEAN"]
     anom_labels = ["I(+)", "I(-)", "SIGI(+)", "SIGI(-)"]
@@ -50,6 +53,7 @@ def test_merge(dials_data, tmp_path, anomalous, truncate):
         refls,
         expts,
         f"truncate={truncate}",
+        f"french_wilson.implementation={french_wilson_impl}",
         f"anomalous={anomalous}",
         f"output.mtz={str(mtz_file)}",
         "project_name=ham",


### PR DESCRIPTION
This implementation uses the standardized median as an M-estimator for the average intensity of resolution bins, as mentioned in https://github.com/dials/dials/issues/2067#issuecomment-1090481460 which makes the procedure robust against the presence of very negative intensities as highlighted in that issue.

The choice between the new `dials` and existing `cctbx` implementations can be made using the parameter `french_wilson.implementation=dials|cctbx`.