### PR TITLE
dials.cosym: don't apply cb_op to crystal twice

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``dials.cosym``: Fix bug whereby the change of basis op was applied twice to the crystal model

--- a/src/dials/command_line/cosym.py
+++ b/src/dials/command_line/cosym.py
@@ -218,7 +218,6 @@ class cosym(Subject):
             )
             expt = self._experiments[dataset_id]
             refl = self._reflections[dataset_id]
-            expt.crystal = expt.crystal.change_basis(cb_op)
             if subgroup is not None:
                 cb_op = subgroup["cb_op_inp_best"] * cb_op
                 expt.crystal = expt.crystal.change_basis(cb_op)


### PR DESCRIPTION
This bug appears to have been introduced in #1647. Since it was only the crystal model, and not the miller indices, that were affected, I don't think it should cause any problems in most cases, although it may affect the resulting unit cells in cases of pseudo-symmetry.

Co-authored-by: James Beilsten-Edmands <30625594+jbeilstenedmands@users.noreply.github.com>