### PR TITLE
Constraints mapping bug

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+``dials.refine``: correct an error in mapping constraint definitions to models

--- a/src/dials/algorithms/refinement/constraints.py
+++ b/src/dials/algorithms/refinement/constraints.py
@@ -215,8 +215,12 @@ class ConstraintManagerFactory:
                     )
             for j in p.get_experiment_ids():
                 if j in constraint_scope.id:
-                    prefixes.append(model_type + f"{j + 1}")
+                    prefixes.append(model_type + f"{i + 1}")
                     break
+        logger.debug(
+            "Selection of experiments by id has identified the following "
+            "models to constrain: " + ",".join(prefixes)
+        )
 
         # ignore model name prefixes
         patt1 = re.compile("^" + model_type + "[0-9]+")


### PR DESCRIPTION
Fixes an issue in which models which are shared by many experiments (such as detector models in serial crystallography) were being identified by `id` being set to the index in the list of those models, not the index of the experiment list.

For a concrete example using data shared by @nksauter this had the effect that that this `.phil` snippet:
```
      constraints {
        id = 1, 5000
        parameter=Dist
      }
```
attempted to apply constraints to the 2nd and 5001st detector, not the first and second detectors, picked out by experiments with `id == 1` and `id == 5000`.