### PR TITLE
Fix fudged background removal in calibrant

### DIFF
--- a/newsfragments/2165.bugfix
+++ b/newsfragments/2165.bugfix
@@ -1,0 +1,1 @@
+``dials.powder_calibrate``: mask calibrant background more generally


### PR DESCRIPTION
Nick found my scotch-taped background removal for the calibrant overlay. Instead, remove the zeros as Nick found. It also helps to use log type scale to plot intensities.