### PR TITLE
DIALS 3.8.8

### DIFF
--- a/algorithms/merging/merge.py
+++ b/algorithms/merging/merge.py
@@ -422,6 +422,11 @@ def generate_html_report(mtz_file, filename):
         ):
             anom_data[array.info().wavelength] = array
     data = {"dF": {}}
+    for wave in list(anom_data.keys()):
+        if (
+            anom_data[wave].anomalous_flag() is False
+        ):  # i.e. if not anomalous data e.g. P-1 s.g
+            del anom_data[wave]
     if not anom_data:
         return
     data = make_dano_plots(anom_data)

--- a/algorithms/scaling/combine_intensities.py
+++ b/algorithms/scaling/combine_intensities.py
@@ -342,9 +342,8 @@ class MultiDatasetIntensityCombiner:
             combined_indices = flex.miller_index([])
             for dataset in self.datasets:
                 Int, Var = _get_Is_from_Imidval(dataset, Imid)
-                Int *= dataset["prescaling_correction"]
                 sigma = flex.sqrt(Var) * dataset["prescaling_correction"]
-                combined_intensities.extend(Int)
+                combined_intensities.extend(Int * dataset["prescaling_correction"])
                 combined_sigmas.extend(sigma)
                 combined_scales.extend(dataset["inverse_scale_factor"])
                 combined_indices.extend(dataset["miller_index"])

--- a/command_line/symmetry.py
+++ b/command_line/symmetry.py
@@ -382,6 +382,9 @@ def symmetry(experiments, reflection_tables, params=None):
             )
         )
         # Reindex the input data
+        _, refls_for_sym = _reindex_experiments_reflections(
+            experiments, refls_for_sym, best_space_group, cb_op_inp_best
+        )
         experiments, reflection_tables = _reindex_experiments_reflections(
             experiments, reflection_tables, best_space_group, cb_op_inp_best
         )

--- a/newsfragments/2168.bugfix
+++ b/newsfragments/2168.bugfix
@@ -1,0 +1,1 @@
+``dials.image_viewer``: Fix error after loading images with the "Load" button.

--- a/newsfragments/2175.bugfix
+++ b/newsfragments/2175.bugfix
@@ -1,0 +1,1 @@
+``dials.merge``: Fix crash for P-1 datasets

--- a/newsfragments/2182.bugfix
+++ b/newsfragments/2182.bugfix
@@ -1,0 +1,1 @@
+``dials.export format=mtz``: Handle shared experiment models when converting to cambridge frame

--- a/newsfragments/2183.bugfix
+++ b/newsfragments/2183.bugfix
@@ -1,0 +1,1 @@
+``dials.symmetry``: Ensure data for systematic absences check is in the correct setting for non-conventional minimum cells

--- a/newsfragments/2199.bugfix
+++ b/newsfragments/2199.bugfix
@@ -1,0 +1,1 @@
+``dials.scale``: Fix bug in intensity combination scoring for multi-sweep datasets, affecting midpoint test values.

--- a/tests/command_line/test_symmetry.py
+++ b/tests/command_line/test_symmetry.py
@@ -1,5 +1,6 @@
 import json
 import math
+import subprocess
 
 import procrunner
 import pytest
@@ -524,3 +525,27 @@ def test_few_reflections(dials_data, run_in_tmpdir):
 
     # Run dials.symmetry on the above data files.
     symmetry.symmetry(experiments, reflections, params)
+
+
+def test_x4wide(dials_data, tmp_path):
+    """Verify reflections are reindexed before systematic absence analysis.
+
+    Exercise a bug fix in https://github.com/dials/dials/pull/2183
+
+    Expected space group is P 43 21 2 (or its enantiomorphic equivalent, P 41 21 2)
+    See also https://www.rcsb.org/structure/3QF8
+    """
+    x4wide = dials_data("x4wide_processed", pathlib=True)
+    result = subprocess.run(
+        [
+            "dials.symmetry",
+            x4wide / "AUTOMATIC_DEFAULT_scaled.expt",
+            x4wide / "AUTOMATIC_DEFAULT_scaled.refl",
+        ],
+        cwd=tmp_path,
+    )
+    assert not result.returncode and not result.stderr
+    assert tmp_path.joinpath("symmetrized.refl").is_file()
+    assert tmp_path.joinpath("symmetrized.expt").is_file()
+    exps = load.experiment_list(tmp_path / "symmetrized.expt", check_format=False)
+    assert str(exps[0].crystal.get_space_group().info()) == "P 41 21 2"

--- a/util/export_mtz.py
+++ b/util/export_mtz.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from collections import Counter
+from copy import deepcopy
 from math import isclose
 
 import numpy as np
@@ -650,6 +651,23 @@ def convert_to_cambridge(experiments):
     """Rotate the geometry of an experiment list to match the Cambridge frame,
     in which X is along the idealized X-ray beam and Z is along the primary
     rotation axis"""
+
+    # First handle the potential for shared experiment models - we don't
+    # want to apply multiple transformations to shared models, simplest way is
+    # to make a copy for each experiment.
+    n_expt = len(experiments)
+    if len(experiments.crystals()) < n_expt:
+        for expt in experiments:
+            expt.crystal = deepcopy(expt.crystal)
+    if len(experiments.beams()) < n_expt:
+        for expt in experiments:
+            expt.beam = deepcopy(expt.beam)
+    if len(experiments.detectors()) < n_expt:
+        for expt in experiments:
+            expt.detector = deepcopy(expt.detector)
+    if any(experiments.goniometers()) and len(experiments.goniometers()) < n_expt:
+        for expt in experiments:
+            expt.goniometer = deepcopy(expt.goniometer)
 
     for expt in experiments:
         if expt.goniometer:

--- a/util/image_viewer/slip_viewer/tile_generation.py
+++ b/util/image_viewer/slip_viewer/tile_generation.py
@@ -4,7 +4,10 @@ import sys
 import wx
 
 import scitbx.matrix
-from dxtbx.model.detector_helpers import get_panel_projection_2d_from_axes
+from dxtbx.model.detector_helpers import (
+    get_detector_projection_2d_axes,
+    get_panel_projection_2d_from_axes,
+)
 from scitbx.array_family import flex
 
 ######
@@ -132,6 +135,13 @@ def get_flex_image_multipanel(
             panel_r, panel_t = panel.get_projection_2d()
         else:
             if getattr(detector, "projection", "lab") == "image":
+                if not hasattr(detector, "projection_2d_axes"):
+                    # This can happen if the image wasn't preloaded as part
+                    # of an experiment list. Since it's used here, catch here.
+                    detector.projection_2d_axes = get_detector_projection_2d_axes(
+                        detector
+                    )
+
                 # Get axes from precalculated 2D projection.
                 origin_2d, fast_2d, slow_2d = detector.projection_2d_axes
                 fast = scitbx.matrix.col(fast_2d[i] + (0,))


### PR DESCRIPTION
Bugfixes
--------

- ``dials.image_viewer``: Fix error after loading images with the "Load" button. (#2168)
- ``dials.merge``: Fix crash for P-1 datasets (#2175)
- ``dials.export format=mtz``: Handle shared experiment models when converting to cambridge frame (#2182)
- ``dials.symmetry``: Ensure data for systematic absences check is in the correct setting for non-conventional minimum cells (#2183)
- ``dials.scale``: Fix bug in intensity combination scoring for multi-sweep datasets, affecting midpoint test values. (#2199)