### PR TITLE
Reindex refls_for_sym to reference setting in dials.symmetry

### DIFF
--- a/newsfragments/2183.bugfix
+++ b/newsfragments/2183.bugfix
@@ -1,0 +1,1 @@
+``dials.symmetry``: Ensure data for systematic absences check is in the correct setting for non-conventional minimum cells

--- a/src/dials/command_line/symmetry.py
+++ b/src/dials/command_line/symmetry.py
@@ -384,6 +384,9 @@ def symmetry(experiments, reflection_tables, params=None):
             )
         )
         # Reindex the input data
+        _, refls_for_sym = _reindex_experiments_reflections(
+            experiments, refls_for_sym, best_space_group, cb_op_inp_best
+        )
         experiments, reflection_tables = _reindex_experiments_reflections(
             experiments, reflection_tables, best_space_group, cb_op_inp_best
         )

--- a/tests/command_line/test_symmetry.py
+++ b/tests/command_line/test_symmetry.py
@@ -4,7 +4,6 @@ import json
 import math
 import subprocess
 
-import procrunner
 import pytest
 
 import scitbx.matrix
@@ -33,7 +32,7 @@ def test_symmetry_laue_only(dials_data, tmp_path):
     """Simple test to check that dials.symmetry completes"""
 
     lcyst_data = dials_data("l_cysteine_dials_output", pathlib=True)
-    result = procrunner.run(
+    result = subprocess.run(
         [
             "dials.symmetry",
             lcyst_data / "20_integrated_experiments.json",
@@ -42,7 +41,7 @@ def test_symmetry_laue_only(dials_data, tmp_path):
             lcyst_data / "25_integrated.pickle",
             "systematic_absences.check=False",
         ],
-        working_directory=tmp_path,
+        cwd=tmp_path,
     )
     assert not result.returncode and not result.stderr
     assert tmp_path.joinpath("symmetrized.refl").is_file()
@@ -78,14 +77,14 @@ def test_symmetry_basis_changes_for_C2(tmp_path):
         joint_table.extend(r)
     joint_table.as_file(tmp_path / "tmp.refl")
 
-    result = procrunner.run(
+    result = subprocess.run(
         [
             "dials.symmetry",
             tmp_path / "tmp.expt",
             tmp_path / "tmp.refl",
             "json=symmetry.json",
         ],
-        working_directory=tmp_path,
+        cwd=tmp_path,
     )
     assert not result.returncode and not result.stderr
     assert tmp_path.joinpath("symmetrized.refl").is_file()
@@ -123,7 +122,7 @@ def test_symmetry_with_absences(dials_data, tmpdir, option):
     if option:
         cmd.append(option)
 
-    result = procrunner.run(cmd, working_directory=tmpdir)
+    result = subprocess.run(cmd, cwd=tmpdir)
     assert not result.returncode and not result.stderr
     assert tmpdir.join("symmetrized.refl").check()
     assert tmpdir.join("symmetrized.expt").check()
@@ -137,7 +136,7 @@ def test_symmetry_with_laue_group_override(dials_data, tmp_path):
     """Simple test to check that dials.symmetry, with overridden laue group, completes"""
 
     lcyst_data = dials_data("l_cysteine_dials_output", pathlib=True)
-    result = procrunner.run(
+    result = subprocess.run(
         [
             "dials.symmetry",
             "laue_group=P121",
@@ -147,7 +146,7 @@ def test_symmetry_with_laue_group_override(dials_data, tmp_path):
             lcyst_data / "25_integrated_experiments.json",
             lcyst_data / "25_integrated.pickle",
         ],
-        working_directory=tmp_path,
+        cwd=tmp_path,
     )
     assert not result.returncode and not result.stderr
     assert tmp_path.joinpath("symmetrized.refl").is_file()
@@ -170,7 +169,7 @@ def test_symmetry_absences_only(dials_data, tmp_path):
         location / "experiments_0.json",
         location / "reflections_0.pickle",
     ]
-    result = procrunner.run(command, working_directory=tmp_path)
+    result = subprocess.run(command, cwd=tmp_path)
     assert not result.returncode and not result.stderr
     assert tmp_path.joinpath("dials.symmetry.html").is_file()
     assert tmp_path.joinpath("symmetrized.expt").is_file()
@@ -179,7 +178,7 @@ def test_symmetry_absences_only(dials_data, tmp_path):
 
     # Now try with a d_min
     command += ["d_min=4.0"]
-    result = procrunner.run(command, working_directory=tmp_path)
+    result = subprocess.run(command, cwd=tmp_path)
     assert not result.returncode and not result.stderr
     exps = load.experiment_list(tmp_path / "symmetrized.expt", check_format=False)
     assert str(exps[0].crystal.get_space_group().info()) == "P 41"

--- a/tests/command_line/test_symmetry.py
+++ b/tests/command_line/test_symmetry.py
@@ -4,6 +4,7 @@ import json
 import math
 import subprocess
 
+import procrunner
 import pytest
 
 import scitbx.matrix
@@ -32,7 +33,7 @@ def test_symmetry_laue_only(dials_data, tmp_path):
     """Simple test to check that dials.symmetry completes"""
 
     lcyst_data = dials_data("l_cysteine_dials_output", pathlib=True)
-    result = subprocess.run(
+    result = procrunner.run(
         [
             "dials.symmetry",
             lcyst_data / "20_integrated_experiments.json",
@@ -41,7 +42,7 @@ def test_symmetry_laue_only(dials_data, tmp_path):
             lcyst_data / "25_integrated.pickle",
             "systematic_absences.check=False",
         ],
-        cwd=tmp_path,
+        working_directory=tmp_path,
     )
     assert not result.returncode and not result.stderr
     assert tmp_path.joinpath("symmetrized.refl").is_file()
@@ -77,14 +78,14 @@ def test_symmetry_basis_changes_for_C2(tmp_path):
         joint_table.extend(r)
     joint_table.as_file(tmp_path / "tmp.refl")
 
-    result = subprocess.run(
+    result = procrunner.run(
         [
             "dials.symmetry",
             tmp_path / "tmp.expt",
             tmp_path / "tmp.refl",
             "json=symmetry.json",
         ],
-        cwd=tmp_path,
+        working_directory=tmp_path,
     )
     assert not result.returncode and not result.stderr
     assert tmp_path.joinpath("symmetrized.refl").is_file()
@@ -122,7 +123,7 @@ def test_symmetry_with_absences(dials_data, tmpdir, option):
     if option:
         cmd.append(option)
 
-    result = subprocess.run(cmd, cwd=tmpdir)
+    result = procrunner.run(cmd, working_directory=tmpdir)
     assert not result.returncode and not result.stderr
     assert tmpdir.join("symmetrized.refl").check()
     assert tmpdir.join("symmetrized.expt").check()
@@ -136,7 +137,7 @@ def test_symmetry_with_laue_group_override(dials_data, tmp_path):
     """Simple test to check that dials.symmetry, with overridden laue group, completes"""
 
     lcyst_data = dials_data("l_cysteine_dials_output", pathlib=True)
-    result = subprocess.run(
+    result = procrunner.run(
         [
             "dials.symmetry",
             "laue_group=P121",
@@ -146,7 +147,7 @@ def test_symmetry_with_laue_group_override(dials_data, tmp_path):
             lcyst_data / "25_integrated_experiments.json",
             lcyst_data / "25_integrated.pickle",
         ],
-        cwd=tmp_path,
+        working_directory=tmp_path,
     )
     assert not result.returncode and not result.stderr
     assert tmp_path.joinpath("symmetrized.refl").is_file()
@@ -169,7 +170,7 @@ def test_symmetry_absences_only(dials_data, tmp_path):
         location / "experiments_0.json",
         location / "reflections_0.pickle",
     ]
-    result = subprocess.run(command, cwd=tmp_path)
+    result = procrunner.run(command, working_directory=tmp_path)
     assert not result.returncode and not result.stderr
     assert tmp_path.joinpath("dials.symmetry.html").is_file()
     assert tmp_path.joinpath("symmetrized.expt").is_file()
@@ -178,7 +179,7 @@ def test_symmetry_absences_only(dials_data, tmp_path):
 
     # Now try with a d_min
     command += ["d_min=4.0"]
-    result = subprocess.run(command, cwd=tmp_path)
+    result = procrunner.run(command, working_directory=tmp_path)
     assert not result.returncode and not result.stderr
     exps = load.experiment_list(tmp_path / "symmetrized.expt", check_format=False)
     assert str(exps[0].crystal.get_space_group().info()) == "P 41"


### PR DESCRIPTION
In #2042, @dagewa [shared a data set](https://github.com/dials/dials/issues/2042#issuecomment-1112213738) which should index as `P 1 21 1`. However, `dials.symmetry` reports `P 1 2 1`. Looking into this, I realized that the underlying cause is that the reflection table passed into the systematic absence search has not been reindexed to the canonical setting of this Laue group. This leads to `dials.symmetry` searching the wrong crystallographic basis for absent reflections. I believe this PR fixes the bug, but I need some more familiar eyes on the problem. 

I don't think I have the ability to assign reviewers. Can @jbeilstenedmands and perhaps @rjgildea have a look? 