### PR TITLE
Rigorous definition of `trusted_range`

### DIFF
--- a/src/dials/algorithms/integration/kapton_2019_correction.py
+++ b/src/dials/algorithms/integration/kapton_2019_correction.py
@@ -50,7 +50,7 @@ class KaptonTape_2019:
             p.set_local_frame(fast.elems, slow.elems, ori.elems)
             p.set_pixel_size((pixel_size, pixel_size))
             p.set_image_size(image_size)
-            p.set_trusted_range((-1, 2e6))
+            p.set_trusted_range((0, 2e6))
             p.set_name(f"KAPTON_{name}")
             return d
 

--- a/src/dials/algorithms/integration/parallel_integrator.h
+++ b/src/dials/algorithms/integration/parallel_integrator.h
@@ -1096,12 +1096,12 @@ namespace dials { namespace algorithms {
 
       // Get the starting frame and the underload/overload values
       int zstart = scan.get_array_range()[0];
-      double underload = detector[0].get_trusted_range()[0];
-      double overload = detector[0].get_trusted_range()[1];
-      DIALS_ASSERT(underload < overload);
+      double min_trusted = detector[0].get_trusted_range()[0];
+      double max_trusted = detector[0].get_trusted_range()[1];
+      DIALS_ASSERT(min_trusted < max_trusted);
       for (std::size_t i = 1; i < detector.size(); ++i) {
-        DIALS_ASSERT(underload == detector[i].get_trusted_range()[0]);
-        DIALS_ASSERT(overload == detector[i].get_trusted_range()[1]);
+        DIALS_ASSERT(min_trusted == detector[i].get_trusted_range()[0]);
+        DIALS_ASSERT(max_trusted == detector[i].get_trusted_range()[1]);
       }
 
       // Get the reflection flags and bbox

--- a/src/dials/algorithms/integration/parallel_integrator.h
+++ b/src/dials/algorithms/integration/parallel_integrator.h
@@ -410,24 +410,24 @@ namespace dials { namespace algorithms {
      * @param compute_intensity The intensity calculation function
      * @param buffer The image buffer array
      * @param zstart The first image index
-     * @param underload The underload value
-     * @param overload The overload value
+     * @param min_trusted The minimum trusted value
+     * @param max_trusted The maximum trusted value
      */
     ReflectionIntegrator(const MaskCalculatorIface &compute_mask,
                          const BackgroundCalculatorIface &compute_background,
                          const IntensityCalculatorIface &compute_intensity,
                          const Buffer &buffer,
                          int zstart,
-                         double underload,
-                         double overload,
+                         double min_trusted,
+                         double max_trusted,
                          bool debug)
         : compute_mask_(compute_mask),
           compute_background_(compute_background),
           compute_intensity_(compute_intensity),
           buffer_(buffer),
           zstart_(zstart),
-          underload_(underload),
-          overload_(overload),
+          min_trusted_(min_trusted),
+          max_trusted_(max_trusted),
           debug_(debug) {}
 
     /**
@@ -457,7 +457,7 @@ namespace dials { namespace algorithms {
         index, reflection_list, adjacency_list, reflection, adjacent_reflections);
 
       // Extract the shoebox data
-      extract_shoebox(buffer_, reflection, zstart_, underload_, overload_);
+      extract_shoebox(buffer_, reflection, zstart_, min_trusted_, max_trusted_);
 
       // Compute the mask
       compute_mask_(reflection);
@@ -474,7 +474,7 @@ namespace dials { namespace algorithms {
       try {
         compute_background_(reflection);
       } catch (dials::error const &) {
-        finalize_shoebox(reflection, adjacent_reflections, underload_, overload_);
+        finalize_shoebox(reflection, adjacent_reflections, min_trusted_, max_trusted_);
         return;
       }
 
@@ -494,7 +494,7 @@ namespace dials { namespace algorithms {
       }
 
       // Erase the shoebox
-      finalize_shoebox(reflection, adjacent_reflections, underload_, overload_);
+      finalize_shoebox(reflection, adjacent_reflections, min_trusted_, max_trusted_);
 
       // Set the reflection data
       set_reflection(index, reflection_list, reflection);
@@ -553,10 +553,10 @@ namespace dials { namespace algorithms {
      */
     void finalize_shoebox(af::Reflection &reflection,
                           std::vector<af::Reflection> &adjacent_reflections,
-                          double underload,
-                          double overload) const {
+                          double min_trusted,
+                          double max_trusted) const {
       // Inspect the pixels
-      inspect_pixels(reflection, underload, overload);
+      inspect_pixels(reflection, min_trusted, max_trusted);
 
       // Delete the shoebox
       delete_shoebox(reflection, adjacent_reflections);
@@ -567,8 +567,8 @@ namespace dials { namespace algorithms {
      * @param reflection The reflection
      */
     void inspect_pixels(af::Reflection &reflection,
-                        double underload,
-                        double overload) const {
+                        double min_trusted,
+                        double max_trusted) const {
       typedef Shoebox<>::float_type float_type;
 
       // Get the shoebox
@@ -593,7 +593,7 @@ namespace dials { namespace algorithms {
         double d = data[i];
         int m = mask[i];
 
-        if (d >= overload) {
+        if (d > max_trusted) {
           flags |= af::Overloaded;
         }
 
@@ -660,8 +660,8 @@ namespace dials { namespace algorithms {
     void extract_shoebox(const Buffer &buffer,
                          af::Reflection &reflection,
                          int zstart,
-                         double underload,
-                         double overload) const {
+                         double min_trusted,
+                         double max_trusted) const {
       typedef af::const_ref<Buffer::float_type, af::c_grid<2> > data_buffer_type;
       std::size_t panel = reflection.get<std::size_t>("panel");
       int6 bbox = reflection.get<int6>("bbox");
@@ -698,7 +698,7 @@ namespace dials { namespace algorithms {
             if (jj >= 0 && ii >= 0 && jj < data_buffer.accessor()[0]
                 && ii < data_buffer.accessor()[1]) {
               double d = data_buffer(jj, ii);
-              int m = (d > underload && d < overload) ? Valid : 0;
+              int m = (d >= min_trusted && d <= max_trusted) ? Valid : 0;
               data(k, j, i) = d;
               mask(k, j, i) = m;
             } else {
@@ -761,8 +761,8 @@ namespace dials { namespace algorithms {
     const IntensityCalculatorIface &compute_intensity_;
     const Buffer &buffer_;
     int zstart_;
-    double underload_;
-    double overload_;
+    double min_trusted_;
+    double max_trusted_;
     bool debug_;
     mutable boost::mutex mutex_;
   };
@@ -1094,7 +1094,7 @@ namespace dials { namespace algorithms {
         buffer_size = zsize;
       }
 
-      // Get the starting frame and the underload/overload values
+      // Get the starting frame and the trusted range values
       int zstart = scan.get_array_range()[0];
       double min_trusted = detector[0].get_trusted_range()[0];
       double max_trusted = detector[0].get_trusted_range()[1];
@@ -1117,8 +1117,9 @@ namespace dials { namespace algorithms {
       AdjacencyList overlaps = find_overlapping_multi_panel(bbox, panel);
 
       // Allocate the array for the image data
+      double mask_value = min_trusted - 1.0;
       Buffer buffer(
-        detector, zsize, buffer_size, underload, imageset.get_static_mask());
+        detector, zsize, buffer_size, mask_value, imageset.get_static_mask());
 
       // If we have shoeboxes then delete
       if (reflections.contains("shoebox")) {
@@ -1146,8 +1147,8 @@ namespace dials { namespace algorithms {
                                       compute_intensity,
                                       buffer,
                                       zstart,
-                                      underload,
-                                      overload,
+                                      min_trusted,
+                                      max_trusted,
                                       debug);
 
       // Do the integration

--- a/src/dials/algorithms/integration/parallel_reference_profiler.h
+++ b/src/dials/algorithms/integration/parallel_reference_profiler.h
@@ -459,12 +459,12 @@ namespace dials { namespace algorithms {
 
       // Get the starting frame and the underload/overload values
       int zstart = scan.get_array_range()[0];
-      double underload = detector[0].get_trusted_range()[0];
-      double overload = detector[0].get_trusted_range()[1];
-      DIALS_ASSERT(underload < overload);
+      double min_trusted = detector[0].get_trusted_range()[0];
+      double max_trusted = detector[0].get_trusted_range()[1];
+      DIALS_ASSERT(min_trusted < max_trusted);
       for (std::size_t i = 1; i < detector.size(); ++i) {
-        DIALS_ASSERT(underload == detector[i].get_trusted_range()[0]);
-        DIALS_ASSERT(overload == detector[i].get_trusted_range()[1]);
+        DIALS_ASSERT(min_trusted == detector[i].get_trusted_range()[0]);
+        DIALS_ASSERT(max_trusted == detector[i].get_trusted_range()[1]);
       }
 
       // Get the reflection flags and bbox

--- a/src/dials/algorithms/shoebox/overload_checker.h
+++ b/src/dials/algorithms/shoebox/overload_checker.h
@@ -32,10 +32,10 @@ namespace dials { namespace algorithms { namespace shoebox {
       typedef Shoebox<>::float_type float_type;
 
       /**
-       * @param overload - The overload values for each pixel
+       * @param saturation - The saturation values for each pixel
        */
-      Checker(const af::const_ref<double> &overload)
-          : overload_(overload.begin(), overload.end()) {}
+      Checker(const af::const_ref<double> &saturation)
+          : saturation_(saturation.begin(), saturation.end()) {}
 
       /**
        * Mark all pixels that are overloaded as invalid
@@ -46,13 +46,13 @@ namespace dials { namespace algorithms { namespace shoebox {
       bool operator()(std::size_t panel,
                       const af::const_ref<float_type, af::c_grid<3> > &data,
                       af::ref<int, af::c_grid<3> > mask) const {
-        DIALS_ASSERT(panel < overload_.size());
+        DIALS_ASSERT(panel < saturation_.size());
         DIALS_ASSERT(data.accessor().all_eq(mask.accessor()));
         DIALS_ASSERT(data.size() == mask.size());
         bool result = false;
-        double overload_value = overload_[panel];
+        double saturation_value = saturation_[panel];
         for (std::size_t i = 0; i < data.size(); ++i) {
-          if (data[i] >= overload_value) {
+          if (data[i] > saturation_value) {
             mask[i] &= ~Valid;
             result = true;
           }
@@ -61,16 +61,16 @@ namespace dials { namespace algorithms { namespace shoebox {
       }
 
     private:
-      af::shared<double> overload_;
+      af::shared<double> saturation_;
     };
 
   public:
     /**
-     * Add the overload values for this detector
-     * @param overload The overloads for each panel
+     * Add the saturation values for this detector
+     * @param saturation The saturation value for each panel
      */
-    void add(const af::const_ref<double> &overload) {
-      checker_.push_back(Checker(overload));
+    void add(const af::const_ref<double> &saturation) {
+      checker_.push_back(Checker(saturation));
     }
 
     /**

--- a/src/dials/algorithms/spot_finding/factory.py
+++ b/src/dials/algorithms/spot_finding/factory.py
@@ -313,7 +313,7 @@ class BackgroundGradientFilter:
                         and x < (ex2 - buffer_size)
                     ):
                         mask[0, i_y, i_x] = False  # foreground
-                    elif value > trusted_range[0] and value < trusted_range[1]:
+                    elif value >= trusted_range[0] and value <= trusted_range[1]:
                         mask[0, i_y, i_x] = True  # background
 
             model = modeller.create(data.as_double(), mask)

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -243,7 +243,7 @@ def _dials_phil_str():
     integration_only_overrides {
       trusted_range = None
         .type = floats(size=2)
-        .help = "Override the panel trusted range (underload and saturation) during integration."
+        .help = "Override the panel trusted range [min_trusted_value, max_trusted_value] during integration."
         .short_caption = "Panel trusted range"
     }
   }

--- a/tests/algorithms/indexing/test_assign_indices.py
+++ b/tests/algorithms/indexing/test_assign_indices.py
@@ -82,7 +82,7 @@ def experiment():
         slow_direction="-y",
         pixel_size=(0.172, 0.172),
         image_size=(2463, 2527),
-        trusted_range=(-1, 1e8),
+        trusted_range=(0, 1e8),
     )
 
     goniometer = GoniometerFactory.single_axis()

--- a/tests/algorithms/profile_model/ellipsoid/conftest.py
+++ b/tests/algorithms/profile_model/ellipsoid/conftest.py
@@ -100,7 +100,7 @@ def test_experiment():
                 "thickness": 0.32,
                 "mu": 3.9220322752480934,
                 "gain": 1.0,
-                "trusted_range": [-1.0, 161977.0],
+                "trusted_range": [0.0, 161977.0],
                 "image_size": [2463, 2527],
                 "px_mm_strategy": {"type": "ParallaxCorrectedPxMmStrategy"},
                 "identifier": "",

--- a/tests/array_family/test_reflection_table.py
+++ b/tests/array_family/test_reflection_table.py
@@ -795,7 +795,7 @@ def test_extract_shoeboxes():
                 def __getitem__(self, index):
                     class FakePanel:
                         def get_trusted_range(self):
-                            return (-1, 1000000)
+                            return (0, 1000000)
 
                     return FakePanel()
 

--- a/tests/command_line/test_generate_mask.py
+++ b/tests/command_line/test_generate_mask.py
@@ -177,7 +177,7 @@ def test_generate_mask_trusted_range(dials_data, tmpdir):
 
         # Import with narrow trusted range to produce overloads
         do_import(
-            ["trusted_range=-1,100", "output.experiments=overloads.expt"] + image_files,
+            ["trusted_range=0,100", "output.experiments=overloads.expt"] + image_files,
             phil=import_phil_scope,
         )
 

--- a/tests/command_line/test_show.py
+++ b/tests/command_line/test_show.py
@@ -159,7 +159,7 @@ Panel:
   identifier:
   pixel_size:{0.172,0.172}
   image_size: {2463,2527}
-  trusted_range: {-1,495976}
+  trusted_range: {0,495976}
   thickness: 0.32
   material: Si
   mu: 3.96039
@@ -219,7 +219,7 @@ Panel:
   identifier:
   pixel_size:{0.172,0.172}
   image_size: {2463,195}
-  trusted_range: {-1,1e+06}
+  trusted_range: {0,1e+06}
   thickness: 0.32
   material: Si
   mu: 3.663
@@ -244,7 +244,7 @@ Panel:
   identifier:
   pixel_size:{0.172,0.172}
   image_size: {2463,195}
-  trusted_range: {-1,1e+06}
+  trusted_range: {0,1e+06}
   thickness: 0.32
   material: Si
   mu: 3.663


### PR DESCRIPTION
Work in progress to define the `trusted_range` as the inclusive range [min-valid-value, max-valid-value] and use this consistently throughout the codebase.

Requires https://github.com/cctbx/dxtbx/pull/536

Currently 11 test failures. Some of these are due to loading old experiment lists with trusted range starting from -1.

```
         - tests/algorithms/background/test_gmodel.py:26 test_simple
         - tests/algorithms/background/test_gmodel.py:87 test_robust
         - tests/command_line/test_background.py:6 test
         - tests/command_line/test_integrate.py:365 test_multi_sweep
         - tests/command_line/test_integrate.py:18 test_basic_integrate
         - tests/command_line/test_integrate.py:145 test_basic_threaded_integrate
         - tests/command_line/test_integrate.py:174 test_basic_integrate_output_integrated_only
         - tests/command_line/test_integrate.py:210 test_integration_with_sampling
         - tests/command_line/test_integrate.py:242 test_integration_with_sample_size
         - tests/command_line/test_integrate.py:337 test_basic_integration_with_profile_fitting
         - tests/command_line/test_model_background.py:11 test_model_background
```