### PR TITLE
DIALS 3.11.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.11.1 (2022-09-02)
+=========================
+
+Bugfixes
+--------
+
+- Revert default installation to Python 3.9, to avoid WXPython incompatibilities. (`#2216 <https://github.com/dials/dials/issues/2216>`_)
+
+
 DIALS 3.11.0 (2022-08-24)
 =========================
 

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -1268,7 +1268,7 @@ be passed separately with quotes to avoid confusion (e.g
     parser.add_argument(
         "--python",
         help="Install this minor version of Python (default: %(default)s)",
-        default="3.10",
+        default="3.9",
         choices=("3.8", "3.9", "3.10"),
     )
     parser.add_argument(

--- a/newsfragments/2216.bugfix
+++ b/newsfragments/2216.bugfix
@@ -1,0 +1,1 @@
+Revert default installation to Python 3.9, to avoid WXPython incompatibilities.

--- a/newsfragments/2216.bugfix
+++ b/newsfragments/2216.bugfix
@@ -1,1 +1,0 @@
-Revert default installation to Python 3.9, to avoid WXPython incompatibilities.


### PR DESCRIPTION
Bugfixes
--------

- Revert default installation to Python 3.9, to avoid WXPython incompatibilities. (#2216)