### PR TITLE
DIALS 3.11.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.11.2 (2022-09-27)
+=========================
+
+Bugfixes
+--------
+
+- ``dials.scale``: Fix bug in intensity combination scoring for multi-sweep datasets, affecting midpoint test values. (`#2199 <https://github.com/dials/dials/issues/2199>`_)
+
+
 DIALS 3.11.1 (2022-09-02)
 =========================
 

--- a/newsfragments/2199.bugfix
+++ b/newsfragments/2199.bugfix
@@ -1,0 +1,1 @@
+``dials.scale``: Fix bug in intensity combination scoring for multi-sweep datasets, affecting midpoint test values.

--- a/newsfragments/2199.bugfix
+++ b/newsfragments/2199.bugfix
@@ -1,1 +1,0 @@
-``dials.scale``: Fix bug in intensity combination scoring for multi-sweep datasets, affecting midpoint test values.


### PR DESCRIPTION
Bugfixes
--------

- ``dials.scale``: Fix bug in intensity combination scoring for multi-sweep datasets, affecting midpoint test values. (#2199)