### PR TITLE
Pass fully-resolved path to ``subprocess.run()``

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Pass a fully-qualified path for executable to ``subprocess.run()`` as resolving the path of the executable can be platform dependent.

--- a/tests/command_line/test_import.py
+++ b/tests/command_line/test_import.py
@@ -593,7 +593,7 @@ def test_convert_stills_to_sequences(dials_data, tmp_path):
     JF16M = dials_data("lysozyme_JF16M_4img", pathlib=True)
     result = subprocess.run(
         [
-            "dials.import",
+            shutil.which("dials.import"),
             "convert_stills_to_sequences=True",
             JF16M / "lyso009a_0087.JF07T32V01_master_4img.h5",
             "output.experiments=experiments_as_seq.expt",
@@ -615,7 +615,7 @@ def test_convert_stills_to_sequences(dials_data, tmp_path):
     image_path = sacla_path / "SACLA-MPCCD-run266702-0-subset.h5"
     result = subprocess.run(
         [
-            "dials.import",
+            shutil.which("dials.import"),
             "convert_stills_to_sequences=True",
             image_path,
             "output.experiments=experiments_as_seq_sacla.expt",
@@ -640,7 +640,7 @@ def test_convert_stills_to_sequences(dials_data, tmp_path):
     ]  # just three images
     result = subprocess.run(
         [
-            "dials.import",
+            shutil.which("dials.import"),
             "convert_stills_to_sequences=True",
             image_path,
             "output.experiments=joint.expt",
@@ -670,7 +670,7 @@ def test_convert_stills_to_sequences_nonh5(dials_regression, tmp_path):
     assert image_path.is_file()
     result = subprocess.run(
         [
-            "dials.import",
+            shutil.which("dials.import"),
             "convert_stills_to_sequences=True",
             image_path,
             "output.experiments=lcls.expt",

--- a/tests/command_line/test_plot_Fo_vs_Fc.py
+++ b/tests/command_line/test_plot_Fo_vs_Fc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 
 
@@ -14,7 +15,7 @@ def test(dials_data, tmp_path):
         "PYTHONDEVMODE"
     ] = ""  # disable a developermode warning from pyparsing from mathtext in matplotlib
     result = subprocess.run(
-        ["dials.plot_Fo_vs_Fc", f"hklin={mtz_file}"],
+        [shutil.which("dials.plot_Fo_vs_Fc"), f"hklin={mtz_file}"],
         cwd=tmp_path,
         env=env,
         capture_output=True,

--- a/tests/command_line/test_symmetry.py
+++ b/tests/command_line/test_symmetry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import shutil
 import subprocess
 
 import procrunner
@@ -537,7 +538,7 @@ def test_x4wide(dials_data, tmp_path):
     x4wide = dials_data("x4wide_processed", pathlib=True)
     result = subprocess.run(
         [
-            "dials.symmetry",
+            shutil.which("dials.symmetry"),
             x4wide / "AUTOMATIC_DEFAULT_scaled.expt",
             x4wide / "AUTOMATIC_DEFAULT_scaled.refl",
         ],


### PR DESCRIPTION
``subprocess.Popen()`` docs recommend passing a fully-qualified path to the executable, as resolving the path of the executable is platform dependent:
https://docs.python.org/3/library/subprocess.html#subprocess.Popen