### PR TITLE
Kapton error handling

### DIFF
--- a/src/dials/command_line/integrate.py
+++ b/src/dials/command_line/integrate.py
@@ -609,19 +609,23 @@ def run_integration(params, experiments, reference=None):
     for abs_params in params.absorption_correction:
         if abs_params.apply:
             if abs_params.algorithm == "fuller_kapton":
-                from dials.algorithms.integration.kapton_correction \
-                    import multi_kapton_correction
+                from dials.algorithms.integration.kapton_correction import (
+                    multi_kapton_correction,
+                )
             elif abs_params.algorithm == "kapton_2019":
-                from dials.algorithms.integration.kapton_2019_correction \
-                    import multi_kapton_correction
+                from dials.algorithms.integration.kapton_2019_correction import (
+                    multi_kapton_correction,
+                )
             elif abs_params.algorithm == "other":
                 continue  # custom abs. corr. implementation should go here
             else:
-                raise ValueError("Absorption_correction.apply=True, "
-                                 "but no .algorithm has been selected!")
+                raise ValueError(
+                    "Absorption_correction.apply=True, "
+                    "but no .algorithm has been selected!"
+                )
             experiments, reflections = multi_kapton_correction(
-                experiments, reflections, abs_params.fuller_kapton,
-                logger=logger)()
+                experiments, reflections, abs_params.fuller_kapton, logger=logger
+            )()
 
     if params.significance_filter.enable:
         from dials.algorithms.integration.stills_significance_filter import (

--- a/src/dials/command_line/integrate.py
+++ b/src/dials/command_line/integrate.py
@@ -620,7 +620,7 @@ def run_integration(params, experiments, reference=None):
                 continue  # custom abs. corr. implementation should go here
             else:
                 raise ValueError(
-                    "Absorption_correction.apply=True, "
+                    "absorption_correction.apply=True, "
                     "but no .algorithm has been selected!"
                 )
             experiments, reflections = multi_kapton_correction(

--- a/src/dials/command_line/integrate.py
+++ b/src/dials/command_line/integrate.py
@@ -607,14 +607,21 @@ def run_integration(params, experiments, reference=None):
 
     # Correct integrated intensities for absorption correction, if necessary
     for abs_params in params.absorption_correction:
-        if abs_params.apply and abs_params.algorithm == "fuller_kapton":
-            from dials.algorithms.integration.kapton_correction import (
-                multi_kapton_correction,
-            )
-
+        if abs_params.apply:
+            if abs_params.algorithm == "fuller_kapton":
+                from dials.algorithms.integration.kapton_correction \
+                    import multi_kapton_correction
+            elif abs_params.algorithm == "kapton_2019":
+                from dials.algorithms.integration.kapton_2019_correction \
+                    import multi_kapton_correction
+            elif abs_params.algorithm == "other":
+                continue  # custom abs. corr. implementation should go here
+            else:
+                raise ValueError("Absorption_correction.apply=True, "
+                                 "but no .algorithm has been selected!")
             experiments, reflections = multi_kapton_correction(
-                experiments, reflections, abs_params.fuller_kapton, logger=logger
-            )()
+                experiments, reflections, abs_params.fuller_kapton,
+                logger=logger)()
 
     if params.significance_filter.enable:
         from dials.algorithms.integration.stills_significance_filter import (

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -1478,7 +1478,7 @@ The detector is reporting a gain of %f but you have also supplied a gain of %f. 
                     continue  # custom abs. corr. implementation should go here
                 else:
                     raise ValueError(
-                        "Absorption_correction.apply=True, "
+                        "absorption_correction.apply=True, "
                         "but no .algorithm has been selected!"
                     )
                 experiments, integrated = multi_kapton_correction(

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -1463,21 +1463,23 @@ The detector is reporting a gain of %f but you have also supplied a gain of %f. 
         # Integrate the reflections
         integrated = integrator.integrate()
 
-        # correct integrated intensities for absorption correction, if necessary
+        # correct integrated intensities for absorption correction,if necessary
         for abs_params in self.params.integration.absorption_correction:
             if abs_params.apply:
                 if abs_params.algorithm == "fuller_kapton":
-                    from dials.algorithms.integration.kapton_correction import (
-                        multi_kapton_correction,
-                    )
+                    from dials.algorithms.integration.kapton_correction \
+                        import multi_kapton_correction
                 elif abs_params.algorithm == "kapton_2019":
-                    from dials.algorithms.integration.kapton_2019_correction import (
-                        multi_kapton_correction,
-                    )
-
+                    from dials.algorithms.integration.kapton_2019_correction \
+                        import multi_kapton_correction
+                elif abs_params.algorithm == "other":
+                    continue  # custom abs. corr. implementation should go here
+                else:
+                    raise ValueError("Absorption_correction.apply=True, "
+                                     "but no .algorithm has been selected!")
                 experiments, integrated = multi_kapton_correction(
-                    experiments, integrated, abs_params.fuller_kapton, logger=logger
-                )()
+                    experiments, integrated, abs_params.fuller_kapton,
+                    logger=logger)()
 
         if self.params.significance_filter.enable:
             from dials.algorithms.integration.stills_significance_filter import (

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -1467,19 +1467,23 @@ The detector is reporting a gain of %f but you have also supplied a gain of %f. 
         for abs_params in self.params.integration.absorption_correction:
             if abs_params.apply:
                 if abs_params.algorithm == "fuller_kapton":
-                    from dials.algorithms.integration.kapton_correction \
-                        import multi_kapton_correction
+                    from dials.algorithms.integration.kapton_correction import (
+                        multi_kapton_correction,
+                    )
                 elif abs_params.algorithm == "kapton_2019":
-                    from dials.algorithms.integration.kapton_2019_correction \
-                        import multi_kapton_correction
+                    from dials.algorithms.integration.kapton_2019_correction import (
+                        multi_kapton_correction,
+                    )
                 elif abs_params.algorithm == "other":
                     continue  # custom abs. corr. implementation should go here
                 else:
-                    raise ValueError("Absorption_correction.apply=True, "
-                                     "but no .algorithm has been selected!")
+                    raise ValueError(
+                        "Absorption_correction.apply=True, "
+                        "but no .algorithm has been selected!"
+                    )
                 experiments, integrated = multi_kapton_correction(
-                    experiments, integrated, abs_params.fuller_kapton,
-                    logger=logger)()
+                    experiments, integrated, abs_params.fuller_kapton, logger=logger
+                )()
 
         if self.params.significance_filter.enable:
             from dials.algorithms.integration.stills_significance_filter import (


### PR DESCRIPTION
Previous implementation of `dials/command_line/stills_process.py Processor.integrate` and `dials/command_line/integrate.py run_integration` had an unexpected `UnboundLocalError` whenever `absorption_correction.apply=True`, but `absorption_correction.algorithm` was unspecified (former specifier 2/4 possible states, and later 1/4 possible state). Now, in both places whenever `absorption_correction.algorithm` is expected but unspecified, a `ValueError` is raised, unless user specifically requests `absorption_correction.algorithm=other`.'

This change should not affect any existing processes, but might save a few hours some other poor soul, who will inevitably  accidentally declare multiple absorption protocols and unexpectedly ends up with `{apply=True, algorithm=None}`, like me last week.