### PR TITLE
Handle case of corrupt/unreadable image files in dials.import

### DIFF
--- a/newsfragments/XXX.feature
+++ b/newsfragments/XXX.feature
@@ -1,0 +1,1 @@
+``dials.import``: Handle bad image input without crashing or useful output

--- a/src/dials/util/options.py
+++ b/src/dials/util/options.py
@@ -288,6 +288,32 @@ class Importer:
             )
         except FileNotFoundError as e:
             logger.error(f"File {e.filename} not found")
+        except Exception as e:
+            logger.error(f"Error encountered reading images:\n{e}")
+            if len(args) > 1:
+                for arg in args:
+                    try:
+                        experiments = ExperimentListFactory.from_filenames(
+                            [arg],
+                            unhandled=[],
+                            compare_beam=compare_beam,
+                            compare_detector=compare_detector,
+                            compare_goniometer=compare_goniometer,
+                            scan_tolerance=scan_tolerance,
+                            format_kwargs=format_kwargs,
+                            load_models=load_models,
+                        )
+                    except Exception as e:
+                        self._handle_converter_error(arg, e, type="Image")
+                        unhandled.append(arg)
+                    else:
+                        self.experiments.append(
+                            FilenameDataWrapper(
+                                filename="<image files>", data=experiments
+                            )
+                        )
+            else:
+                unhandled.append(args[0])
         else:
             if experiments:
                 self.experiments.append(


### PR DESCRIPTION
A problem I have encountered a few times is the case of trying to import a significant number of h5 files, but one file being corrupted or unreadable by the format class. Currently, `dials.import` will crash out without giving any indication where the problem was, as all the reading occurs in the option parser. This is rather unhelpful if you have many images and no indication of which is the bad one.

This PR changes the behaviour for image reading to be more consistent with reflection and experiment file reading in the option parser, namely that if there is an unhandled argument, there is no outright crash, rather the item is added to the list of unhandled arguments and the program can continue.

For example, rather than showing a stracktrace due to an OSError:
```
$ dials.import ../lyso.h5 ../lyso_bad.h5 
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
DIALS 3.dev.912-g094ce52c0
Traceback (most recent call last):
  File "/dials/build/../modules/dials/src/dials/command_line/dials_import.py", line 947, in <module>
    run()
  File "/dials/conda_base/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/dials/build/../modules/dials/src/dials/command_line/dials_import.py", line 943, in run
    do_import(args, phil=phil, configure_logging=True)
  File "/dials/build/../modules/dials/src/dials/command_line/dials_import.py", line 837, in do_import
    params, options, unhandled = parser.parse_args(
  File "/dials/modules/dials/src/dials/util/options.py", line 867, in parse_args
    params, args = self._phil_parser.parse_args(
  File "/dials/modules/dials/src/dials/util/options.py", line 550, in parse_args
    importer = Importer(
  File "/dials/modules/dials/src/dials/util/options.py", line 202, in __init__
    self.unhandled = self.try_read_experiments_from_images(
  File "/dials/modules/dials/src/dials/util/options.py", line 279, in try_read_experiments_from_images
    experiments = ExperimentListFactory.from_filenames(
  File "/dials/modules/dxtbx/src/dxtbx/model/experiment_list.py", line 535, in from_filenames
    format_class = find_format.find_format(filename)
  File "/dials/modules/dxtbx/src/dxtbx/datablock.py", line 266, in find_format
    self._format_class = get_format_class_for_file(
  File "/dials/modules/dxtbx/src/dxtbx/format/Registry.py", line 123, in get_format_class_for_file
    return recurse(format, image_file_str)
  File "/dials/modules/dxtbx/src/dxtbx/format/Registry.py", line 113, in recurse
    if scheme in format_class.schemes and format_class.understand(image_file):
  File "/.dxtbx/dxtbx_custom/FormatHDF5Test.py", line 21, in understand
    with h5py.File(image_file, "r") as h5_handle:
  File "/dials/conda_base/lib/python3.10/site-packages/h5py/_hl/files.py", line 533, in __init__
    fid = make_fid(name, mode, userblock_size, fapl, fcpl, swmr=swmr)
  File "/dials/conda_base/lib/python3.10/site-packages/h5py/_hl/files.py", line 226, in make_fid
    fid = h5f.open(name, flags, fapl=fapl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5f.pyx", line 106, in h5py.h5f.open
OSError: Please report this error to dials-support@lists.sourceforge.net: Unable to open file (truncated file: eof = 4794089472, sblock->base_addr = 0, stored_eof = 6310679538)
```
with this PR you get:
```
$ dials.import  ../lyso.h5 ../lyso_bad.h5 
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
DIALS 3.dev.913-gfc1da9a74
Error encountered reading images:
Unable to open file (truncated file: eof = 4794089472, sblock->base_addr = 0, stored_eof = 6310679538)
The following parameters have been modified:

input {
  experiments = <image files>
}

Unable to handle the following arguments:
  ../lyso_bad.h5

--------------------------------------------------------------------------------
  format: <class 'dxtbx_custom.FormatHDF5Test.FormatHDF5Test'>
  num images: 1000
  sequences:
    still:    0
    sweep:    0
  num stills: 1000
--------------------------------------------------------------------------------
Writing experiments to imported.expt
```

I would welcome discussion around what exactly we should be doing in this kind of case. Is it better to terminate the program, such that it doesn't 'silently fail' for the bad image? In `dials.import` we have the option `ignore_unhandled` which is `True` by default. If this is set to `False`, then the program doesn't continue after encountering the unhandled argument, thus already giving us a way to change the tolerance for faults.
