### PR TITLE
Unpin setuptools, pytest, allow Python 3.11

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -36,14 +36,14 @@ conda-forge::pyrtf
 conda-forge::pytest-forked
 conda-forge::pytest-mock
 conda-forge::pytest-xdist
-conda-forge::pytest>=4.5,<7.0
+conda-forge::pytest
 conda-forge::python-dateutil>=2.7.0
 conda-forge::reportlab
 conda-forge::requests
 conda-forge::scikit-learn
 conda-forge::scipy
 conda-forge::scons
-conda-forge::setuptools<60
+conda-forge::setuptools
 conda-forge::six
 conda-forge::sphinx>=4
 conda-forge::sqlite

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -38,7 +38,7 @@ conda-forge::pyrtf
 conda-forge::pytest-forked
 conda-forge::pytest-mock
 conda-forge::pytest-xdist
-conda-forge::pytest>=4.5,<7.0
+conda-forge::pytest
 conda-forge::python-dateutil>=2.7.0
 conda-forge::python.app
 conda-forge::reportlab
@@ -46,7 +46,7 @@ conda-forge::requests
 conda-forge::scikit-learn
 conda-forge::scipy
 conda-forge::scons
-conda-forge::setuptools<60
+conda-forge::setuptools
 conda-forge::six
 conda-forge::sphinx>=4
 conda-forge::sqlite

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -37,14 +37,14 @@ conda-forge::pytest-forked
 conda-forge::pytest-mock
 conda-forge::pytest-nunit=1.0.0
 conda-forge::pytest-xdist
-conda-forge::pytest>=4.5,<7.0
+conda-forge::pytest
 conda-forge::python-dateutil>=2.7.0
 conda-forge::reportlab
 conda-forge::requests
 conda-forge::scikit-learn
 conda-forge::scipy
 conda-forge::scons
-conda-forge::setuptools<60
+conda-forge::setuptools
 conda-forge::six
 conda-forge::sphinx>=4
 conda-forge::sqlite

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -1272,7 +1272,7 @@ be passed separately with quotes to avoid confusion (e.g
         "--python",
         help="Install this minor version of Python (default: %(default)s)",
         default="3.10",
-        choices=("3.8", "3.9", "3.10"),
+        choices=("3.8", "3.9", "3.10", "3.11"),
     )
     parser.add_argument(
         "--branch",


### PR DESCRIPTION
Python 3.10 remains the default.