### PR TITLE
Allow Unity builds, and enable for windows CI

### DIFF
--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -51,7 +51,7 @@ steps:
     call activate conda_base/
     mkdir build_dxtbx
     cd build_dxtbx
-    cmake ../modules/dxtbx
+    cmake ../modules/dxtbx -DCMAKE_UNITY_BUILD=true
     if %errorlevel% neq 0 exit /b %errorlevel%
 
     cmake --build . --config Release
@@ -72,7 +72,7 @@ steps:
     call activate conda_base/
     mkdir build_dials
     cd build_dials
-    cmake ../modules/dials
+    cmake ../modules/dials -DCMAKE_UNITY_BUILD=true
     if %errorlevel% neq 0 exit /b %errorlevel%
 
     cmake --build . --config Release

--- a/newsfragments/2361.misc
+++ b/newsfragments/2361.misc
@@ -1,0 +1,1 @@
+Fix various declaration issues preventing Unity builds.

--- a/src/dials/algorithms/image/threshold/local.h
+++ b/src/dials/algorithms/image/threshold/local.h
@@ -8,8 +8,8 @@
  *  This code is distributed under the BSD license, a copy of which is
  *  included in the root directory of this package.
  */
-#ifndef DIALS_ALGORITHMS_IMAGE_THRESHOLD_UNIMODAL_H
-#define DIALS_ALGORITHMS_IMAGE_THRESHOLD_UNIMODAL_H
+#ifndef DIALS_ALGORITHMS_IMAGE_THRESHOLD_LOCAL_H
+#define DIALS_ALGORITHMS_IMAGE_THRESHOLD_LOCAL_H
 
 #include <cmath>
 #include <vector>
@@ -1441,4 +1441,4 @@ namespace dials { namespace algorithms {
 
 }}  // namespace dials::algorithms
 
-#endif /* DIALS_ALGORITHMS_IMAGE_THRESHOLD_UNIMODAL_H */
+#endif /* DIALS_ALGORITHMS_IMAGE_THRESHOLD_LOCAL_H */

--- a/src/dials/algorithms/refinement/parameterisation/parameterisation_helpers.h
+++ b/src/dials/algorithms/refinement/parameterisation/parameterisation_helpers.h
@@ -9,7 +9,7 @@
 #include <dxtbx/model/panel.h>
 #include <dials/error.h>
 #include <dials/array_family/scitbx_shared_and_versa.h>
-//#include <dials/algorithms/refinement/rtmats.h>
+#include <dials/algorithms/refinement/rtmats.h>
 #include <scitbx/math/r3_rotation.h>
 #include <boost/python.hpp>
 #include <unordered_map>
@@ -20,12 +20,6 @@ namespace dials { namespace refinement {
   using scitbx::mat3;
   using scitbx::vec3;
   using scitbx::math::r3_rotation::axis_and_angle_as_matrix;
-
-  // declare this here - can't #include the header as the function is defined
-  // there, leading to multiple definitions
-  mat3<double> dR_from_axis_and_angle(const vec3<double> &axis,
-                                      double angle,
-                                      bool deg = false);
 
   af::shared<mat3<double> > selected_multi_panel_compose(
     const af::const_ref<vec3<double> > &initial_state,

--- a/src/dials/algorithms/refinement/rtmats.h
+++ b/src/dials/algorithms/refinement/rtmats.h
@@ -33,9 +33,9 @@ namespace dials { namespace refinement {
    * Here the rotation is taken to be in a right-handed sense around the axis
    * whereas RTMATS uses a left-handed rotation.
    */
-  mat3<double> dR_from_axis_and_angle(const vec3<double> &axis,
-                                      double angle,
-                                      bool deg = false) {
+  inline mat3<double> dR_from_axis_and_angle(const vec3<double> &axis,
+                                             double angle,
+                                             bool deg = false) {
     if (deg) angle = DEG2RAD(angle);
     vec3<double> axis_ = axis.normalize();
     double ca = cos(angle);

--- a/src/dials/array_family/boost_python/flex_centroid.cc
+++ b/src/dials/array_family/boost_python/flex_centroid.cc
@@ -14,11 +14,12 @@
 #include <scitbx/vec3.h>
 #include <scitbx/array_family/boost_python/flex_wrapper.h>
 #include <scitbx/array_family/ref_reductions.h>
-#include <scitbx/array_family/boost_python/ref_pickle_double_buffered.h>
 #include <scitbx/array_family/boost_python/flex_pickle_double_buffered.h>
 #include <dials/array_family/scitbx_shared_and_versa.h>
 #include <dials/model/data/observation.h>
 #include <dials/error.h>
+
+#include "ref_pickle_double_buffered.h"
 
 namespace dials { namespace af { namespace boost_python {
 

--- a/src/dials/array_family/boost_python/flex_helpers.h
+++ b/src/dials/array_family/boost_python/flex_helpers.h
@@ -1,0 +1,8 @@
+#ifndef SCITBX_ARRAY_FAMILY_BOOST_PYTHON_FLEX_HELPERS_H_WRAPPER
+#define SCITBX_ARRAY_FAMILY_BOOST_PYTHON_FLEX_HELPERS_H_WRAPPER
+
+// This header does not have an include guard
+
+#include <scitbx/array_family/boost_python/flex_helpers.h>
+
+#endif

--- a/src/dials/array_family/boost_python/flex_int6.cc
+++ b/src/dials/array_family/boost_python/flex_int6.cc
@@ -8,7 +8,8 @@
 #include <boost/python/make_constructor.hpp>
 #include <boost/python/args.hpp>
 #include <boost/python/return_arg.hpp>
-#include <scitbx/array_family/boost_python/flex_helpers.h>
+
+#include "flex_helpers.h"
 
 namespace scitbx { namespace serialization { namespace single_buffered {
 

--- a/src/dials/array_family/boost_python/flex_intensity.cc
+++ b/src/dials/array_family/boost_python/flex_intensity.cc
@@ -14,11 +14,12 @@
 #include <scitbx/vec3.h>
 #include <scitbx/array_family/boost_python/flex_wrapper.h>
 #include <scitbx/array_family/ref_reductions.h>
-#include <scitbx/array_family/boost_python/ref_pickle_double_buffered.h>
 #include <scitbx/array_family/boost_python/flex_pickle_double_buffered.h>
 #include <dials/array_family/scitbx_shared_and_versa.h>
 #include <dials/model/data/observation.h>
 #include <dials/error.h>
+
+#include "ref_pickle_double_buffered.h"
 
 namespace dials { namespace af { namespace boost_python {
 

--- a/src/dials/array_family/boost_python/flex_observation.cc
+++ b/src/dials/array_family/boost_python/flex_observation.cc
@@ -14,11 +14,12 @@
 #include <scitbx/vec3.h>
 #include <scitbx/array_family/boost_python/flex_wrapper.h>
 #include <scitbx/array_family/ref_reductions.h>
-#include <scitbx/array_family/boost_python/ref_pickle_double_buffered.h>
 #include <scitbx/array_family/boost_python/flex_pickle_double_buffered.h>
 #include <dials/array_family/scitbx_shared_and_versa.h>
 #include <dials/model/data/observation.h>
 #include <dials/error.h>
+
+#include "ref_pickle_double_buffered.h"
 
 namespace dials { namespace af { namespace boost_python {
 

--- a/src/dials/array_family/boost_python/flex_shoebox.cc
+++ b/src/dials/array_family/boost_python/flex_shoebox.cc
@@ -13,7 +13,6 @@
 #include <cmath>
 #include <scitbx/array_family/boost_python/flex_wrapper.h>
 #include <scitbx/array_family/ref_reductions.h>
-#include <scitbx/array_family/boost_python/ref_pickle_double_buffered.h>
 #include <scitbx/array_family/boost_python/flex_pickle_double_buffered.h>
 #include <cctbx/miller.h>
 #include <dials/model/data/shoebox.h>
@@ -22,6 +21,8 @@
 #include <dials/algorithms/image/connected_components/connected_components.h>
 #include <dials/algorithms/spot_prediction/pixel_to_miller_index.h>
 #include <dials/config.h>
+
+#include "ref_pickle_double_buffered.h"
 
 namespace dials { namespace af { namespace boost_python {
 

--- a/src/dials/array_family/boost_python/flex_table_suite.h
+++ b/src/dials/array_family/boost_python/flex_table_suite.h
@@ -23,7 +23,6 @@
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/mpl/for_each.hpp>
 #include <scitbx/array_family/flex_types.h>
-#include <scitbx/array_family/boost_python/ref_pickle_double_buffered.h>
 #include <scitbx/boost_python/slice.h>
 #include <scitbx/boost_python/utils.h>
 #include <dials/array_family/flex_table.h>
@@ -31,6 +30,8 @@
 #include <dials/error.h>
 #include <dxtbx/model/experiment.h>
 #include <dxtbx/model/experiment_list.h>
+
+#include "ref_pickle_double_buffered.h"
 
 namespace dials { namespace af { namespace boost_python { namespace flex_table_suite {
 

--- a/src/dials/array_family/boost_python/flex_table_suite.h
+++ b/src/dials/array_family/boost_python/flex_table_suite.h
@@ -460,7 +460,7 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
    * @returns A new table with the chosen elements
    */
   template <typename T>
-  T getitem_slice(const T &self, slice s) {
+  T getitem_slice(const T &self, boost::python::slice s) {
     typedef typename T::const_iterator iterator;
     scitbx::boost_python::adapted_slice as(s, self.nrows());
     T result(as.size);
@@ -494,7 +494,7 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
    * @param s The slice
    */
   template <typename T>
-  void delitem_slice(T &self, slice s) {
+  void delitem_slice(T &self, boost::python::slice s) {
     scitbx::boost_python::adapted_slice as(s, self.nrows());
     if (as.step == 1) {
       self.erase(as.start, as.size);
@@ -516,7 +516,7 @@ namespace dials { namespace af { namespace boost_python { namespace flex_table_s
    * @param other The other table whose elements to set
    */
   template <typename T>
-  void setitem_slice(T &self, slice s, const T &other) {
+  void setitem_slice(T &self, boost::python::slice s, const T &other) {
     typedef typename T::const_iterator iterator;
     DIALS_ASSERT(self.is_consistent());
     DIALS_ASSERT(other.is_consistent());

--- a/src/dials/array_family/boost_python/flex_unit_cell.cc
+++ b/src/dials/array_family/boost_python/flex_unit_cell.cc
@@ -8,10 +8,11 @@
 #include <boost/python/make_constructor.hpp>
 #include <boost/python/args.hpp>
 #include <boost/python/return_arg.hpp>
-#include <scitbx/array_family/boost_python/flex_helpers.h>
 #include <cctbx/uctbx.h>
 #include <cctbx/miller.h>
 #include <dials/error.h>
+
+#include "flex_helpers.h"
 
 namespace dials { namespace af { namespace boost_python {
 

--- a/src/dials/array_family/boost_python/ref_pickle_double_buffered.h
+++ b/src/dials/array_family/boost_python/ref_pickle_double_buffered.h
@@ -1,0 +1,8 @@
+#ifndef SCITBX_ARRAY_FAMILY_BOOST_PYTHON_REF_PICKLE_DOUBLE_BUFFERED_H_WRAPPER
+#define SCITBX_ARRAY_FAMILY_BOOST_PYTHON_REF_PICKLE_DOUBLE_BUFFERED_H_WRAPPER
+
+// This header does not have an include guard
+
+#include <scitbx/array_family/boost_python/ref_pickle_double_buffered.h>
+
+#endif


### PR DESCRIPTION
- `local.h` had a duplicated inclusion guard
- `dR_from_axis_and_angle` included the default arguments twice, to get around an ODR violation. That has been fixed by marking it as "inline"
- Fix include of headers in scitbx that do not have duplicate inclusion guards. This makes a dials-local copy to add guards in.
- Disambiguate `slice`
- Turn on Unity builds for the Windows CI