### PR TITLE
Multi-panel `dials.rs_mapper`

### DIFF
--- a/newsfragments/xxx.feature
+++ b/newsfragments/xxx.feature
@@ -1,0 +1,1 @@
+Allow ``dials.rs_mapper`` to run for multi-panel detectors.


### PR DESCRIPTION
Allow `dials.rs_mapper` to work for multi-panel detectors by looping over panels at the highest level and accumulating the results. So far I tested only for a very simple 4 panel, small molecule MicroED dataset and the results appear sensible.

![image](https://user-images.githubusercontent.com/11502083/223477105-8ca7c52f-e87b-44a3-ba77-399480e4d142.png)

This should close #2333.