### PR TITLE
Export MTZ with gemmi

### DIFF
--- a/src/dials/util/boost_python/ext.cc
+++ b/src/dials/util/boost_python/ext.cc
@@ -79,7 +79,8 @@ namespace dials { namespace util { namespace boost_python {
       .def("set_title", &GemmiMtzObject::set_title)
       .def("add_history", &GemmiMtzObject::add_history)
       .def("set_space_group_by_name", &GemmiMtzObject::set_space_group_by_name)
-      .def("add_dataset", &GemmiMtzObject::add_dataset);
+      .def("add_dataset", &GemmiMtzObject::add_dataset)
+      .def("add_column", &GemmiMtzObject::add_column);
 
     class_<ResolutionMaskGenerator>("ResolutionMaskGenerator", no_init)
       .def(init<const BeamBase &, const Panel &>())

--- a/src/dials/util/boost_python/ext.cc
+++ b/src/dials/util/boost_python/ext.cc
@@ -78,7 +78,8 @@ namespace dials { namespace util { namespace boost_python {
     class_<GemmiMtzObject, boost::noncopyable>("GemmiMtzObject")
       .def("set_title", &GemmiMtzObject::set_title)
       .def("add_history", &GemmiMtzObject::add_history)
-      .def("set_space_group_by_name", &GemmiMtzObject::set_space_group_by_name);
+      .def("set_space_group_by_name", &GemmiMtzObject::set_space_group_by_name)
+      .def("add_dataset", &GemmiMtzObject::add_dataset);
 
     class_<ResolutionMaskGenerator>("ResolutionMaskGenerator", no_init)
       .def(init<const BeamBase &, const Panel &>())

--- a/src/dials/util/boost_python/ext.cc
+++ b/src/dials/util/boost_python/ext.cc
@@ -80,12 +80,14 @@ namespace dials { namespace util { namespace boost_python {
       .def("add_history", &GemmiMtzObject::add_history)
       .def("set_space_group_by_name", &GemmiMtzObject::set_space_group_by_name)
       .def("add_dataset", &GemmiMtzObject::add_dataset)
+      .def("set_cell_for_all", &GemmiMtzObject::set_cell_for_all)
       .def("add_column", &GemmiMtzObject::add_column)
       .def("add_column_data", &GemmiMtzObject::add_column_data)
       .def("set_n_reflections", &GemmiMtzObject::set_n_reflections)
       .def("replace_original_index_miller_indices",
            &GemmiMtzObject::replace_original_index_miller_indices)
-      .def("write", &GemmiMtzObject::write);
+      .def("write", &GemmiMtzObject::write)
+      .def("summary", &GemmiMtzObject::summary);
 
     class_<ResolutionMaskGenerator>("ResolutionMaskGenerator", no_init)
       .def(init<const BeamBase &, const Panel &>())

--- a/src/dials/util/boost_python/ext.cc
+++ b/src/dials/util/boost_python/ext.cc
@@ -82,7 +82,9 @@ namespace dials { namespace util { namespace boost_python {
       .def("add_dataset", &GemmiMtzObject::add_dataset)
       .def("add_column", &GemmiMtzObject::add_column)
       .def("add_column_data", &GemmiMtzObject::add_column_data)
-      .def("set_n_reflections", &GemmiMtzObject::set_n_reflections);
+      .def("set_n_reflections", &GemmiMtzObject::set_n_reflections)
+      .def("replace_original_index_miller_indices",
+           &GemmiMtzObject::replace_original_index_miller_indices);
 
     class_<ResolutionMaskGenerator>("ResolutionMaskGenerator", no_init)
       .def(init<const BeamBase &, const Panel &>())

--- a/src/dials/util/boost_python/ext.cc
+++ b/src/dials/util/boost_python/ext.cc
@@ -80,7 +80,9 @@ namespace dials { namespace util { namespace boost_python {
       .def("add_history", &GemmiMtzObject::add_history)
       .def("set_space_group_by_name", &GemmiMtzObject::set_space_group_by_name)
       .def("add_dataset", &GemmiMtzObject::add_dataset)
-      .def("add_column", &GemmiMtzObject::add_column);
+      .def("add_column", &GemmiMtzObject::add_column)
+      .def("add_column_data", &GemmiMtzObject::add_column_data)
+      .def("set_n_reflections", &GemmiMtzObject::set_n_reflections);
 
     class_<ResolutionMaskGenerator>("ResolutionMaskGenerator", no_init)
       .def(init<const BeamBase &, const Panel &>())

--- a/src/dials/util/boost_python/ext.cc
+++ b/src/dials/util/boost_python/ext.cc
@@ -84,7 +84,8 @@ namespace dials { namespace util { namespace boost_python {
       .def("add_column_data", &GemmiMtzObject::add_column_data)
       .def("set_n_reflections", &GemmiMtzObject::set_n_reflections)
       .def("replace_original_index_miller_indices",
-           &GemmiMtzObject::replace_original_index_miller_indices);
+           &GemmiMtzObject::replace_original_index_miller_indices)
+      .def("write", &GemmiMtzObject::write);
 
     class_<ResolutionMaskGenerator>("ResolutionMaskGenerator", no_init)
       .def(init<const BeamBase &, const Panel &>())

--- a/src/dials/util/boost_python/ext.cc
+++ b/src/dials/util/boost_python/ext.cc
@@ -57,6 +57,9 @@ namespace dials { namespace util { namespace boost_python {
          arg("axis"),
          arg("s0n")));
 
+    // Have to specify noncopyable because gemmi::Mtz is noncopyable
+    class_<GemmiMtzObject, boost::noncopyable>("GemmiMtzObject");
+
     class_<ResolutionMaskGenerator>("ResolutionMaskGenerator", no_init)
       .def(init<const BeamBase &, const Panel &>())
       .def("apply", &ResolutionMaskGenerator::apply);

--- a/src/dials/util/boost_python/ext.cc
+++ b/src/dials/util/boost_python/ext.cc
@@ -58,7 +58,10 @@ namespace dials { namespace util { namespace boost_python {
          arg("s0n")));
 
     // Have to specify noncopyable because gemmi::Mtz is noncopyable
-    class_<GemmiMtzObject, boost::noncopyable>("GemmiMtzObject");
+    class_<GemmiMtzObject, boost::noncopyable>("GemmiMtzObject")
+      .def("set_title", &GemmiMtzObject::set_title)
+      .def("add_history", &GemmiMtzObject::add_history)
+      .def("set_space_group_by_name", &GemmiMtzObject::set_space_group_by_name);
 
     class_<ResolutionMaskGenerator>("ResolutionMaskGenerator", no_init)
       .def(init<const BeamBase &, const Panel &>())

--- a/src/dials/util/boost_python/ext.cc
+++ b/src/dials/util/boost_python/ext.cc
@@ -57,6 +57,23 @@ namespace dials { namespace util { namespace boost_python {
          arg("axis"),
          arg("s0n")));
 
+    def("add_dials_batches",
+        &add_dials_batches_gemmi,
+        (arg("mtz"),
+         arg("dataset_id"),
+         arg("image_range"),
+         arg("batch_offset"),
+         arg("wavelength"),
+         arg("mosaic"),
+         arg("phi_start"),
+         arg("phi_range"),
+         arg("cell_array"),
+         arg("umat_array"),
+         arg("panel_size"),
+         arg("panel_distance"),
+         arg("axis"),
+         arg("s0n")));
+
     // Have to specify noncopyable because gemmi::Mtz is noncopyable
     class_<GemmiMtzObject, boost::noncopyable>("GemmiMtzObject")
       .def("set_title", &GemmiMtzObject::set_title)

--- a/src/dials/util/export_mtz.py
+++ b/src/dials/util/export_mtz.py
@@ -36,6 +36,8 @@ from dials.util.version import dials_version
 
 logger = logging.getLogger(__name__)
 
+import os
+
 
 class MTZWriterBase:
     """Helper for adding metadata, crystals and datasets to an mtz file object."""
@@ -43,7 +45,10 @@ class MTZWriterBase:
     def __init__(self, space_group, unit_cell=None):
         """If a unit cell is provided, will be used as default unless specified
         for each crystal."""
-        mtz_file = mtz.object()
+        if "GEMMI_MTZ" in os.environ:
+            mtz_file = dials.util.ext.GemmiMtzObject()
+        else:
+            mtz_file = mtz.object()
         mtz_file.set_title(f"From {env.dispatcher_name}")
         date_str = time.strftime("%Y-%m-%d at %H:%M:%S %Z")
         if time.strftime("%Z") != "GMT":

--- a/src/dials/util/export_mtz_helpers.h
+++ b/src/dials/util/export_mtz_helpers.h
@@ -247,18 +247,21 @@ namespace dials { namespace util {
       for (std::size_t i = 0; i < unit_cell_parameters.size(); i++)
         params[i] = unit_cell_parameters[i];
       gemmi::UnitCell cell(params);
-      mtz_.datasets.push_back({next_data_set_id_,
+      mtz_.datasets.push_back({++current_data_set_id_,
                                project_name,
                                crystal_name,
                                dataset_name,
                                cell,
                                wavelength});
-      next_data_set_id_++;
+    }
+
+    void add_column(const char* column_name, const char column_type) {
+      mtz_.add_column(column_name, column_type, current_data_set_id_, -1, false);
     }
 
   private:
     gemmi::Mtz mtz_;
-    size_t next_data_set_id_ = 1;
+    int current_data_set_id_ = 0;
   };
 
   void add_dials_batches_gemmi(GemmiMtzObject& mtz,

--- a/src/dials/util/export_mtz_helpers.h
+++ b/src/dials/util/export_mtz_helpers.h
@@ -17,6 +17,8 @@
 #include <gemmi/unitcell.hpp>
 #include <gemmi/symmetry.hpp>
 
+#include <string>
+
 namespace dials { namespace util {
 
   using cctbx::uctbx::unit_cell;
@@ -225,9 +227,142 @@ namespace dials { namespace util {
       mtz_.spacegroup = gemmi::find_spacegroup_by_name(symbol);
     }
 
+    int get_max_batch_number() {
+      int max_batch_number = 0;
+      for (gemmi::Mtz::Batch b : mtz_.batches)
+        max_batch_number = std::max(max_batch_number, b.number);
+      return max_batch_number;
+    }
+
+    void add_batch(gemmi::Mtz::Batch batch) {
+      mtz_.batches.push_back(batch);
+    }
+
   private:
     gemmi::Mtz mtz_;
   };
+
+  void add_dials_batches_gemmi(GemmiMtzObject& mtz,
+                               int dataset_id,
+                               af::tiny<int, 2> image_range,
+                               int batch_offset,
+                               float wavelength,
+                               float mosaic,
+                               af::shared<float> phi_start,
+                               af::shared<float> phi_range,
+                               af::const_ref<float, af::c_grid<2> > cell_array,
+                               af::const_ref<float, af::c_grid<2> > umat_array,
+                               af::tiny<int, 2> panel_size,
+                               float panel_distance,
+                               af::shared<float> axis,
+                               af::shared<float> source) {
+    // static assertions at the start
+#if defined(__DECCXX_VER)
+    BOOST_STATIC_ASSERT(sizeof(float) == sizeof(int));
+#else
+    IOTBX_ASSERT(sizeof(float) == sizeof(int));
+#endif
+
+    int max_batch_number = mtz.get_max_batch_number();
+    int i_batch;
+    int n_batches = image_range[1] - image_range[0] + 1;
+    batch_offset += image_range[0] - 1;
+    if (max_batch_number > batch_offset) {
+      batch_offset = max_batch_number;
+    }
+
+    for (i_batch = 0; i_batch < n_batches; i_batch++) {
+      int batch_num = batch_offset + i_batch + 1;
+
+      // Prepare a batch header
+      gemmi::Mtz::Batch batch;
+      batch.set_dataset_id(dataset_id);
+      batch.title = "Batch " + std::to_string(batch_num);
+
+      // Set the batch ints first
+      // ints[0] to ints[2] are set already by the Batch struct
+      // ints[3] is batch.number
+      batch.number = batch_num;
+      // We don't set lbcell (refinement flags for unit cell),
+      // because it's probably not used by any program anyway.
+      // batch.ints[4] to [9] = left unset
+      // Skip jumpax, which is defined as:
+      // reciprocal axis closest to principle goniostat axis E1
+      // batch.ints[11] = left unset
+      // We assume one crystal, one goniostat axis, one detector.
+      batch.ints[12] = 1;  // ncryst
+      // batch.ints[13] lcrflg (mosaicity model: 0 = isotropic, 1 = anisotropic)
+      batch.ints[14] = 2;  // ldtype 3D
+      batch.ints[15] = 1;  // jsaxs - goniostat scan axis number
+      // batch.ints[16] nbscal (number of batch scales & Bfactors)
+      batch.ints[17] = 1;  // ngonax - number of goniostat axes
+      // batch.ints[18] lbmflg (flag for type of beam info: 0 for alambd, delamb; 1 also
+      // delcor, divhd, divvd)
+      batch.ints[19] = 1;  // ndet
+      // ints[20] set by set_dataset_id
+
+      // Set the floats
+      // floats[0] to floats[5] is the cell
+      for (int j = 0; j < 6; j++) {
+        batch.floats[j] = cell_array(i_batch, j);
+      }
+      // floats[6] to floats[14] is the Umat
+      for (int j = 0; j < 9; j++) {
+        batch.floats[6 + j] = umat_array(i_batch, j);
+      }
+      // floats[15] to floats[20] are missetting angles, here all zero as they are
+      // encoded in the U matrix floats[21] is crydat[0]. All other 11 crydat elements
+      // are left as zero
+      batch.floats[21] = mosaic;
+      // floats[33] to floats[35] are datum values of goniostat axes, here all zero
+      batch.floats[36] = phi_start[i_batch];  // phistt
+      batch.floats[37] = phi_start[i_batch] + phi_range[i_batch];
+      ;  // phiend
+      // floats[38] to floats[40] is scanax, the rotation axis in lab frame
+      for (int j = 0; j < 3; j++) {
+        batch.floats[38 + j] = axis[j];
+      }
+      // floats[41] and floats[42] are time1 and time2, left as 0.0
+      batch.floats[43] = 1.0;  // bscale (batch scale)
+      // floats[44] is bbfac, left as zero
+      // floats[45] is sdbscale, left as zero
+      // floats[46] is sdbfac, left as zero
+      batch.floats[47] = phi_range[i_batch];  // phirange
+      // floats[59] to floats[61] is e1
+      for (int j = 0; j < 3; j++) {
+        batch.floats[59 + j] = axis[j];
+      }
+      // floats[62] to floats[64] is e2, all left as zero
+      // floats[65] to floats[67] is e3, all left as zero
+      // floats[80] to floats[82] is source, the idealised source vector
+      // Find element closest to -1 for ideal beam direction
+      std::size_t i_min = scitbx::af::min_index(source.const_ref());
+      batch.floats[80 + i_min] = -1.f;
+
+      // floats[83] to floats[85] is so the source vector (including tilts)
+      for (int j = 0; j < 3; j++) {
+        batch.floats[83 + j] = source[j];
+      }
+      batch.floats[86] = wavelength;  // alambd
+
+      // floats[87] is delamb (dispersion (deltalambda / lambda), left as zero
+      // floats[88] is delcor (correlated component), left as zero
+      // floats[89] is divhd (horizontal beam divergence), left as zero
+      // floats[90] is divvd (vertical beam divergence), left as zero
+
+      // floats[111] and floats[112] is dx (xtal to detector distance). Only set the
+      // first
+      batch.floats[111] = panel_distance;
+
+      // floats[113] to floats[120] are detlm (detector limits)
+      batch.floats[114] = panel_size[0];  // NX
+      batch.floats[116] = panel_size[1];  // NY
+
+      batch.axes.push_back("AXIS");  // gonlab[0]
+
+      mtz.add_batch(batch);
+    }
+  }
 
 }}  // namespace dials::util
 

--- a/src/dials/util/export_mtz_helpers.h
+++ b/src/dials/util/export_mtz_helpers.h
@@ -12,6 +12,10 @@
 #include <iotbx/mtz/object.h>
 #include <scitbx/array_family/misc_functions.h>
 
+#define GEMMI_WRITE_IMPLEMENTATION
+#include <gemmi/mtz.hpp>
+#include <gemmi/unitcell.hpp>
+
 namespace dials { namespace util {
 
   using cctbx::uctbx::unit_cell;
@@ -203,6 +207,19 @@ namespace dials { namespace util {
 
     return mosflm_U;
   }
+
+  class GemmiMtzObject {
+  public:
+    GemmiMtzObject() {}
+
+    void set_title(const char* title) {
+      mtz_.title = title;
+    }
+
+  private:
+    gemmi::Mtz mtz_;
+  };
+
 }}  // namespace dials::util
 
 #endif

--- a/src/dials/util/export_mtz_helpers.h
+++ b/src/dials/util/export_mtz_helpers.h
@@ -15,6 +15,7 @@
 #define GEMMI_WRITE_IMPLEMENTATION
 #include <gemmi/mtz.hpp>
 #include <gemmi/unitcell.hpp>
+#include <gemmi/symmetry.hpp>
 
 namespace dials { namespace util {
 
@@ -214,6 +215,14 @@ namespace dials { namespace util {
 
     void set_title(const char* title) {
       mtz_.title = title;
+    }
+
+    void add_history(const char* history) {
+      mtz_.history.emplace_back(history);
+    }
+
+    void set_space_group_by_name(const char* symbol) {
+      mtz_.spacegroup = gemmi::find_spacegroup_by_name(symbol);
     }
 
   private:

--- a/src/dials/util/export_mtz_helpers.h
+++ b/src/dials/util/export_mtz_helpers.h
@@ -320,7 +320,7 @@ namespace dials { namespace util {
 
   private:
     gemmi::Mtz mtz_;
-    int current_data_set_id_ = -1;
+    int current_data_set_id_ = 0;
     std::vector<af::shared<float> > column_data_;
   };
 

--- a/src/dials/util/export_mtz_helpers.h
+++ b/src/dials/util/export_mtz_helpers.h
@@ -267,6 +267,30 @@ namespace dials { namespace util {
       mtz_.nreflections = n_reflections;
     }
 
+    void replace_original_index_miller_indices(
+      af::const_ref<cctbx::miller::index<> > const& indices) {
+      gemmi::UnmergedHklMover hkl_mover(mtz_.spacegroup);
+
+      af::shared<float> h_col;
+      af::shared<float> k_col;
+      af::shared<float> l_col;
+      af::shared<float> m_isym_col;
+
+      for (int i_refl = 0; i_refl < indices.size(); ++i_refl) {
+        cctbx::miller::index<> miller_index = indices[i_refl];
+        std::array<int, 3> hkl = {miller_index[0], miller_index[1], miller_index[2]};
+        int isym = hkl_mover.move_to_asu(hkl);
+        h_col.push_back((float)hkl[0]);
+        k_col.push_back((float)hkl[1]);
+        l_col.push_back((float)hkl[2]);
+        m_isym_col.push_back((float)isym);
+      }
+      add_column_data(h_col.const_ref());
+      add_column_data(k_col.const_ref());
+      add_column_data(l_col.const_ref());
+      add_column_data(m_isym_col.const_ref());
+    }
+
   private:
     gemmi::Mtz mtz_;
     int current_data_set_id_ = 0;

--- a/src/dials/util/export_mtz_helpers.h
+++ b/src/dials/util/export_mtz_helpers.h
@@ -238,8 +238,27 @@ namespace dials { namespace util {
       mtz_.batches.push_back(batch);
     }
 
+    void add_dataset(const char* project_name,
+                     const char* crystal_name,
+                     const char* dataset_name,
+                     af::double6 const& unit_cell_parameters,
+                     float wavelength) {
+      std::array<double, 6> params;
+      for (std::size_t i = 0; i < unit_cell_parameters.size(); i++)
+        params[i] = unit_cell_parameters[i];
+      gemmi::UnitCell cell(params);
+      mtz_.datasets.push_back({next_data_set_id_,
+                               project_name,
+                               crystal_name,
+                               dataset_name,
+                               cell,
+                               wavelength});
+      next_data_set_id_++;
+    }
+
   private:
     gemmi::Mtz mtz_;
+    size_t next_data_set_id_ = 1;
   };
 
   void add_dials_batches_gemmi(GemmiMtzObject& mtz,

--- a/src/dials/util/export_mtz_helpers.h
+++ b/src/dials/util/export_mtz_helpers.h
@@ -259,9 +259,18 @@ namespace dials { namespace util {
       mtz_.add_column(column_name, column_type, current_data_set_id_, -1, false);
     }
 
+    void add_column_data(af::const_ref<float> const& values) {
+      column_data_.push_back(values);
+    }
+
+    void set_n_reflections(int n_reflections) {
+      mtz_.nreflections = n_reflections;
+    }
+
   private:
     gemmi::Mtz mtz_;
     int current_data_set_id_ = 0;
+    std::vector<af::const_ref<float> > column_data_;
   };
 
   void add_dials_batches_gemmi(GemmiMtzObject& mtz,

--- a/src/dials/util/export_mtz_helpers.h
+++ b/src/dials/util/export_mtz_helpers.h
@@ -261,7 +261,7 @@ namespace dials { namespace util {
       mtz_.add_column(column_name, column_type, current_data_set_id_, -1, false);
     }
 
-    void add_column_data(af::const_ref<float> const& values) {
+    void add_column_data(af::shared<float> const& values) {
       column_data_.push_back(values);
     }
 
@@ -287,10 +287,10 @@ namespace dials { namespace util {
         l_col.push_back((float)hkl[2]);
         m_isym_col.push_back((float)isym);
       }
-      add_column_data(h_col.const_ref());
-      add_column_data(k_col.const_ref());
-      add_column_data(l_col.const_ref());
-      add_column_data(m_isym_col.const_ref());
+      add_column_data(h_col);
+      add_column_data(k_col);
+      add_column_data(l_col);
+      add_column_data(m_isym_col);
     }
 
     void write(const char* file_name) {
@@ -304,10 +304,7 @@ namespace dials { namespace util {
       size_t k = 0;
       for (std::size_t i = 0; i < mtz_.nreflections; i++) {
         for (std::size_t j = 0; j < column_data_.size(); j++) {
-          af::const_ref<float>& col = column_data_[j];
-          float val = col[i];
-          std::cout << val << std::endl;
-          // mtz_.data[k++] = column_data_[j][i];
+          mtz_.data[k++] = column_data_[j][i];
         }
       }
 
@@ -324,7 +321,7 @@ namespace dials { namespace util {
   private:
     gemmi::Mtz mtz_;
     int current_data_set_id_ = -1;
-    std::vector<af::const_ref<float> > column_data_;
+    std::vector<af::shared<float> > column_data_;
   };
 
   void add_dials_batches_gemmi(GemmiMtzObject& mtz,

--- a/src/dials/util/ext.py
+++ b/src/dials/util/ext.py
@@ -56,8 +56,9 @@ class ColumnView:
         self.column_type = column_type
         self.dataset_view = dataset_view
 
-    def set_values(array):
-        pass
+    def set_values(self, array):
+
+        self.dataset_view.crystal_view.mtz_object.add_column_data(array)
 
 
 @bp.inject_into(GemmiMtzObject)
@@ -93,6 +94,9 @@ class _:
         crystal = CrystalView(crystal_name, project_name, unit_cell_parameters, self)
         self.crystals.append(crystal)
         return crystal
+
+    def adjust_column_array_sizes(self, nref):
+        pass
 
 
 __all__ = (  # noqa: F405

--- a/src/dials/util/ext.py
+++ b/src/dials/util/ext.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from contextlib import redirect_stdout
+
 import boost_adaptbx.boost.python as bp
 from iotbx.mtz import extract_from_symmetry_lib
 
@@ -94,14 +97,22 @@ class _:
         # return self
 
     def add_crystal(self, crystal_name, project_name, unit_cell_parameters):
-        """Cache information about a crystal to add with the dataset later"""
+        """Cache information about a crystal to add with the dataset later.
+        Also set the general MTZ cell dimensions from this crystal"""
 
+        self.set_cell_for_all(unit_cell_parameters)
         crystal = CrystalView(crystal_name, project_name, unit_cell_parameters, self)
         self.crystals.append(crystal)
         return crystal
 
     def adjust_column_array_sizes(self, nref):
         pass
+
+    def show_summary(self, out=None, prefix=""):
+        if out is None:
+            out = sys.stdout
+        with redirect_stdout(out):
+            print(self.summary())
 
 
 __all__ = (  # noqa: F405

--- a/src/dials/util/ext.py
+++ b/src/dials/util/ext.py
@@ -1,6 +1,36 @@
 from __future__ import annotations
 
+import boost_adaptbx.boost.python as bp
+from iotbx.mtz import extract_from_symmetry_lib
+
 from dials_util_ext import *  # noqa: F403; lgtm
+from dials_util_ext import GemmiMtzObject
+
+
+@bp.inject_into(GemmiMtzObject)
+class _:
+    def set_space_group_info(self, space_group_info, symbol=None):
+        if symbol is None:
+            symbol = extract_from_symmetry_lib.ccp4_symbol(
+                space_group_info=space_group_info, lib_name="symop.lib"
+            )
+            if symbol is None:
+                symbol = "No.%d" % space_group_info.type().number()
+        self.set_space_group_by_name(symbol)
+        # FIXME is this enough? Note that the equivalent method in iotbx.mtz.object
+        # has all this extra code:
+        #
+        # group = space_group_info.group()
+        # self.set_space_group_name(name=symbol)
+        # self.set_space_group_number(number=space_group_info.type().number())
+        # self.set_point_group_name(name=group.point_group_type())
+        # self.set_lattice_centring_type(
+        #  symbol=group.conventional_centring_type_symbol())
+        # if (self.lattice_centring_type() == "\0"):
+        #  self.set_lattice_centring_type(symbol="?")
+        # self.set_space_group(space_group=space_group_info.group())
+        # return self
+
 
 __all__ = (  # noqa: F405
     "ResolutionMaskGenerator",
@@ -9,4 +39,5 @@ __all__ = (  # noqa: F405
     "ostream",
     "scale_down_array",
     "streambuf",
+    "GemmiMtzObject",
 )

--- a/src/dials/util/ext.py
+++ b/src/dials/util/ext.py
@@ -7,8 +7,47 @@ from dials_util_ext import *  # noqa: F403; lgtm
 from dials_util_ext import GemmiMtzObject
 
 
+class CrystalView:
+    def __init__(self, crystal_name, project_name, unit_cell_parameters, mtz_object):
+
+        self.datasets = []
+        self.crystal_name = crystal_name
+        self.project_name = project_name
+        self.unit_cell_parameters = unit_cell_parameters
+        self.mtz_object = mtz_object
+
+        return
+
+    def add_dataset(self, dataset_name, wavelength):
+
+        dataset = DatasetView(dataset_name, wavelength, self)
+        self.mtz_object.add_dataset(
+            self.project_name,
+            self.crystal_name,
+            dataset_name,
+            self.unit_cell_parameters,
+            wavelength,
+        )
+        self.datasets.append(dataset)
+
+        return dataset
+
+
+class DatasetView:
+    def __init__(self, dataset_name, wavelength, crystal_view):
+
+        self.dataset_name = dataset_name
+        self.wavelength = wavelength
+        self.crystal_view = crystal_view
+
+        return
+
+
 @bp.inject_into(GemmiMtzObject)
 class _:
+
+    crystals = []
+
     def set_space_group_info(self, space_group_info, symbol=None):
         if symbol is None:
             symbol = extract_from_symmetry_lib.ccp4_symbol(
@@ -30,6 +69,13 @@ class _:
         #  self.set_lattice_centring_type(symbol="?")
         # self.set_space_group(space_group=space_group_info.group())
         # return self
+
+    def add_crystal(self, crystal_name, project_name, unit_cell_parameters):
+        """Cache information about a crystal to add with the dataset later"""
+
+        crystal = CrystalView(crystal_name, project_name, unit_cell_parameters, self)
+        self.crystals.append(crystal)
+        return crystal
 
 
 __all__ = (  # noqa: F405

--- a/src/dials/util/ext.py
+++ b/src/dials/util/ext.py
@@ -44,7 +44,9 @@ class DatasetView:
 
     def add_column(self, column_name, column_type):
 
-        self.crystal_view.mtz_object.add_column(column_name, column_type)
+        # These columns are added by add_base instead
+        if column_name not in ("H", "K", "L"):
+            self.crystal_view.mtz_object.add_column(column_name, column_type)
         column = ColumnView(column_name, column_type, self)
         return column
 

--- a/src/dials/util/ext.py
+++ b/src/dials/util/ext.py
@@ -42,6 +42,23 @@ class DatasetView:
 
         return
 
+    def add_column(self, column_name, column_type):
+
+        self.crystal_view.mtz_object.add_column(column_name, column_type)
+        column = ColumnView(column_name, column_type, self)
+        return column
+
+
+class ColumnView:
+    def __init__(self, column_name, column_type, dataset_view):
+
+        self.column_name = column_name
+        self.column_type = column_type
+        self.dataset_view = dataset_view
+
+    def set_values(array):
+        pass
+
 
 @bp.inject_into(GemmiMtzObject)
 class _:

--- a/src/dials/util/ext.py
+++ b/src/dials/util/ext.py
@@ -58,7 +58,10 @@ class ColumnView:
 
     def set_values(self, array):
 
-        self.dataset_view.crystal_view.mtz_object.add_column_data(array)
+        # Do not set dummy data for these columns, as they will be set by
+        # replace_original_index_miller_indices instead.
+        if self.column_name not in ("H", "K", "L", "M_ISYM"):
+            self.dataset_view.crystal_view.mtz_object.add_column_data(array)
 
 
 @bp.inject_into(GemmiMtzObject)


### PR DESCRIPTION
This is an experimental branch to rewrite MTZ export using gemmi. To explore how to do this while keeping like-for-like comparisons possible with the existing code, the approach taken here is to create a drop-in replacement for `iotbx.mtz.object`. The minimal interface required to write unmerged MTZs is created in a `GemmiMtzObject` (not all functions required for merged MTZ output are provided here). To use this rather than `iotbx.mtz.object`, set an environment variable, like this:

```
GEMMI_MTZ=1 dials.export integrated.{expt,refl
```

The gemmi-fied version of MTZ export fixes a number of longstanding issues:
- #1099 
- #1100 
- #2057 
- #2379 

However, reproducing the `iotbx.mtz.object` interface has proven to be an uncomfortable exercise with a shoehorn. In particular, gemmi does not really use an object hierarchy like MTZ/Crystal/Dataset/Column. It uses a simpler, [flattened hierarchy instead](https://gemmi.readthedocs.io/en/latest/hkl.html#mtz-format). Here the object hierarchy is recreated, but in a way that caches data until it is ready to be written. This adds some complication that would be unnecessary if `export_mtz` was rewritten with gemmi in mind, without attempting to preserve `iotbx.mtz.object` compatibility.

Gemmi has a very nice Python interface, which is completely ignored by this branch. It would be much cleaner if most of the work was done with a Python `gemmi.Mtz` object, which is then passed to a C++ function to add the batch headers. For example, the `show_summary` function would be so much easier to write in Python rather than using string formatting options available in C++11. However, `gemmi::Mtz`'s Python bindings are made with PyBind11. I don't know how to pass a `gemmi.Mtz` from Python into a DIALS C++ function. I think this would be worth finding out though. Also, it is useful to note that data can be set in a `gemmi.Mtz` by passing in NumPy arrays, which probably means we wouldn't need to wrap flex arrays up with PyBind11 in order to write an `add_dials_batches` function. We could `flumpy` them first.

Overall, I think this branch will be useful for testing, but it should not be merged in its current state. In particular, I have yet to test whether setting the space group does what we expect in all cases, including unusual settings. I have also not tested multi-wavelength MTZ output.