### PR TITLE
`dials.export_bitmaps`: optionally overlay ice rings

### DIFF
--- a/newsfragments/XXX.feature
+++ b/newsfragments/XXX.feature
@@ -1,0 +1,1 @@
+``dials.export_bitmaps``: Optionally overlay ice rings.

--- a/tests/command_line/test_export_bitmaps.py
+++ b/tests/command_line/test_export_bitmaps.py
@@ -7,18 +7,23 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "show_resolution_rings",
+    "show_resolution_rings,show_ice_rings",
     [
-        False,
-        True,
+        (False, False),
+        (True, False),
+        (False, True),
+        (True, True),
     ],
 )
-def test_export_single_bitmap(dials_data, tmp_path, show_resolution_rings):
+def test_export_single_bitmap(
+    dials_data, tmp_path, show_resolution_rings, show_ice_rings
+):
     result = procrunner.run(
         [
             "dials.export_bitmaps",
             dials_data("centroid_test_data", pathlib=True) / "centroid_0001.cbf",
             f"resolution_rings.show={show_resolution_rings}",
+            f"ice_rings.show={show_ice_rings}",
         ],
         working_directory=tmp_path,
     )


### PR DESCRIPTION
E.g. generate the following fetching image with:
```
$ dials.export_bitmaps $(dials.data get -q x4wide)/*0001.cbf binning=2 brightness=10 ice_rings.show=True ice_rings.fill="#33FFAC" resolution_rings.show=True resolution_rings.fill="#FF33F0"
```
![image](https://user-images.githubusercontent.com/2810624/233098370-747cb83b-89ef-4945-8348-a27a5343f58c.png)
