### PR TITLE
Update msgpack-c dependency to msgpack-cxx

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -20,7 +20,7 @@ conda-forge::jinja2
 conda-forge::jpeg
 conda-forge::matplotlib-base>=3.0.2
 conda-forge::mrcfile
-conda-forge::msgpack-c
+conda-forge::msgpack-cxx
 conda-forge::msgpack-python
 conda-forge::numpy>=1.19,<1.21|>=1.21.5
 conda-forge::nxmx

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -21,7 +21,7 @@ conda-forge::jpeg
 conda-forge::libcxx
 conda-forge::matplotlib-base>=3.0.2
 conda-forge::mrcfile
-conda-forge::msgpack-c
+conda-forge::msgpack-cxx
 conda-forge::msgpack-python
 conda-forge::numpy>=1.19,<1.21|>=1.21.5
 conda-forge::nxmx

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -20,7 +20,7 @@ conda-forge::jinja2
 conda-forge::jpeg
 conda-forge::matplotlib-base>=3.0.2
 conda-forge::mrcfile
-conda-forge::msgpack-c
+conda-forge::msgpack-cxx
 conda-forge::msgpack-python
 conda-forge::numpy>=1.19,<1.21|>=1.21.5
 conda-forge::nxmx

--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Update ``msgpack-c`` dependency to ``msgpack-cxx``. These are now separate packages.


### PR DESCRIPTION
These are now separate packages, and conda-forge packages them separately.

See:
https://github.com/conda-forge/msgpack-c-feedstock/pull/39#issuecomment-1378387632