### PR TITLE
Don't print template for every image of a grid scan

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``dials.import``: Don't print filename template for every image of an ``ImageSequence``


### PR DESCRIPTION
Fixes #2413

With `main`:
```
$ dials.import $DIALS_DATA/thaumatin_grid_scan/thau_3_2_00*
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
DIALS 3.dev.968-g8ff14c84f-release
The following parameters have been modified:

input {
  experiments = <image files>
}

--------------------------------------------------------------------------------
  format: <class 'dxtbx.format.FormatCBFMiniPilatusDLS6MSN119.FormatCBFMiniPilatusDLS6MSN119'>
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:6:6
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:11:11
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:13:13
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:9:9
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:17:17
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:10:10
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:14:14
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:18:18
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:15:15
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:7:7
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:1:1
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:8:8
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:19:19
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:4:4
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:3:3
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:12:12
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:16:16
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:5:5
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:2:2
  num images: 19
  sequences:
    still:    1
    sweep:    0
  num stills: 0
--------------------------------------------------------------------------------
Writing experiments to imported.expt
```

With this PR:
```
$ dials.import $DIALS_DATA/thaumatin_grid_scan/thau_3_2_00*
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
DIALS 3.dev.987-g53d2cf7f2
The following parameters have been modified:

input {
  experiments = <image files>
}

--------------------------------------------------------------------------------
  format: <class 'dxtbx.format.FormatCBFMiniPilatusDLS6MSN119.FormatCBFMiniPilatusDLS6MSN119'>
  template: /dls/science/groups/scisoft/DIALS/dials_data/thaumatin_grid_scan/thau_3_2_####.cbf.bz2:1:19
  num images: 19
  sequences:
    still:    1
    sweep:    0
  num stills: 0
--------------------------------------------------------------------------------
Writing experiments to imported.expt
```