### PR TITLE
DIALS 3.15.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.15.1 (2023-06-29)
+=========================
+
+Bugfixes
+--------
+
+- ``dials.export_bitmaps``: Fix the ``resolution_rings.fontsize=`` feature to work on Mac, and more reliably across platforms. (`#2441 <https://github.com/dials/dials/issues/2441>`_)
+
+
 DIALS 3.15.0 (2023-06-13)
 =========================
 

--- a/newsfragments/2441.bugfix
+++ b/newsfragments/2441.bugfix
@@ -1,1 +1,0 @@
-``dials.export_bitmaps``: Fix the ``resolution_rings.fontsize=`` feature to work on Mac, and more reliably across platforms.

--- a/newsfragments/2441.bugfix
+++ b/newsfragments/2441.bugfix
@@ -1,0 +1,1 @@
+``dials.export_bitmaps``: Fix the ``resolution_rings.fontsize=`` feature to work on Mac, and more reliably across platforms.


### PR DESCRIPTION
Bugfixes
--------

- ``dials.export_bitmaps``: Fix the ``resolution_rings.fontsize=`` feature to work on Mac, and more reliably across platforms. (#2441)