### PR TITLE
Correct angular-dependent ellipsoid mosaicity models for dials.ssx_integrate

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+dials.ssx_integrate: Address issue with ellipsoid angular models - replaced with new correct r-dependent models.

--- a/src/dials/algorithms/integration/ssx/ssx_integrate.py
+++ b/src/dials/algorithms/integration/ssx/ssx_integrate.py
@@ -282,26 +282,47 @@ class OutputAggregator:
             for k, v in sigma.items():
                 mosaicities["M_" + k][i] = v
         data = []
+        data_angular = []
         for k, v in mosaicities.items():
-            data.append(
-                {
-                    "x": n,
-                    "y": list(v),
-                    "type": "scatter",
-                    "mode": "markers",
-                    "name": k,
-                }
-            )
+            if "angular" in k:
+                data_angular.append(
+                    {
+                        "x": n,
+                        "y": list(v),
+                        "type": "scatter",
+                        "mode": "markers",
+                        "name": k,
+                        "yaxis": "y2",
+                    }
+                )
+            else:
+                data.append(
+                    {
+                        "x": n,
+                        "y": list(v),
+                        "type": "scatter",
+                        "mode": "markers",
+                        "name": k,
+                    }
+                )
         mosaic_plots = {
             "mosaicities": {
                 "data": data,
                 "layout": {
                     "title": "Profile model mosaicities per image",
                     "xaxis": {"title": "image number"},
-                    "yaxis": {"title": "Mosaicity (degrees)"},
+                    "yaxis": {"title": "Invariant crystal mosaicity (Å⁻¹)"},
                 },
             },
         }
+        if data_angular:
+            mosaic_plots["mosaicities"]["layout"]["yaxis2"] = {
+                "anchor": "x",
+                "side": "right",
+                "title": "Angular mosaicity (degrees)",
+                "overlaying": "y",
+            }
+            mosaic_plots["mosaicities"]["data"].extend(data_angular)
         plots_dict.update(mosaic_plots)
 
         return plots_dict

--- a/src/dials/algorithms/profile_model/ellipsoid/__init__.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/__init__.py
@@ -7,8 +7,4 @@ from dials_algorithms_profile_model_ellipsoid_ext import *  # noqa: F401, F403;
 
 
 def mosaicity_from_eigen_decomposition(eigen_values):
-    return (
-        sqrt(eigen_values[0]) * 180.0 / pi,
-        sqrt(eigen_values[1]) * 180.0 / pi,
-        sqrt(eigen_values[2]) * 180.0 / pi,
-    )
+    return tuple(sqrt(e) * 180.0 / pi for e in eigen_values)

--- a/src/dials/algorithms/profile_model/ellipsoid/__init__.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/__init__.py
@@ -7,4 +7,4 @@ from dials_algorithms_profile_model_ellipsoid_ext import *  # noqa: F401, F403;
 
 
 def mosaicity_from_eigen_decomposition(eigen_values):
-    return tuple(sqrt(e) * 180.0 / pi for e in eigen_values)
+    return tuple(sqrt(e) * 180.0 / pi if e > 0 else 0.0 for e in eigen_values)

--- a/src/dials/algorithms/profile_model/ellipsoid/algorithm.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/algorithm.py
@@ -403,7 +403,7 @@ def run_ellipsoid_refinement(
     experiments,
     reflection_table,
     sigma_d,
-    profile_model="angular2",
+    profile_model="simple6",
     wavelength_model="delta",
     fix_unit_cell=False,
     fix_orientation=False,

--- a/src/dials/algorithms/profile_model/ellipsoid/algorithm.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/algorithm.py
@@ -283,7 +283,7 @@ def refine_profile(
     refiner_data,
     wavelength_spread_model="delta",
     max_iter=1000,
-    LL_tolerance=1e-36,
+    LL_tolerance=1e-6,
 ):
     """Do the profile refinement"""
     logger.info("\n" + "=" * 80 + "\nRefining profile parmameters")

--- a/src/dials/algorithms/profile_model/ellipsoid/boost_python/ext.cc
+++ b/src/dials/algorithms/profile_model/ellipsoid/boost_python/ext.cc
@@ -388,8 +388,11 @@ namespace dials { namespace algorithms { namespace boost_python {
      * @param experiment The experiment
      * @param sigma The covariance matrix
      */
-    PredictorAngular(Experiment experiment, mat3<double> sigma, double probability)
-        : PredictorBase(experiment, probability), sigma_(sigma) {}
+    PredictorAngular(Experiment experiment,
+                     mat3<double> sigma,
+                     double probability,
+                     mat3<double> sigma_A)
+        : PredictorBase(experiment, probability), sigma_(sigma), sigma_A_(sigma_A) {}
 
   protected:
     /**
@@ -400,10 +403,13 @@ namespace dials { namespace algorithms { namespace boost_python {
       mat3<double> Q = compute_change_of_basis_operation2(s0, r);
       vec3<double> zaxis(0, 0, 1);
       DIALS_ASSERT(std::abs(((Q * r.normalize()) * zaxis) - 1) < TINY);
-      return (Q.transpose() * sigma_ * Q);
+      double r_scale = std::pow(r.length(), 2);
+      mat3<double> A(r_scale, 0, 0, 0, r_scale, 0, 0, 0, 0.0);
+      return (Q.transpose() * A * sigma_A_ * Q) + sigma_;
     }
 
     mat3<double> sigma_;
+    mat3<double> sigma_A_;
   };
 
   /**
@@ -600,8 +606,11 @@ namespace dials { namespace algorithms { namespace boost_python {
     BBoxCalculatorAngular(Experiment experiment,
                           mat3<double> sigma,
                           double probability,
-                          int border)
-        : BBoxCalculatorBase(experiment, probability, border), sigma_(sigma) {}
+                          int border,
+                          mat3<double> sigma_A)
+        : BBoxCalculatorBase(experiment, probability, border),
+          sigma_(sigma),
+          sigma_A_(sigma_A) {}
 
   protected:
     /**
@@ -612,10 +621,13 @@ namespace dials { namespace algorithms { namespace boost_python {
       mat3<double> Q = compute_change_of_basis_operation2(s0, r);
       vec3<double> zaxis(0, 0, 1);
       DIALS_ASSERT(std::abs(((Q * r.normalize()) * zaxis) - 1) < TINY);
-      return (Q.transpose() * sigma_ * Q);
+      double r_scale = std::pow(r.length(), 2);
+      mat3<double> A(r_scale, 0, 0, 0, r_scale, 0, 0, 0, 0.0);
+      return (Q.transpose() * A * sigma_A_ * Q) + sigma_;
     }
 
     mat3<double> sigma_;
+    mat3<double> sigma_A_;
   };
 
   /**
@@ -823,8 +835,13 @@ namespace dials { namespace algorithms { namespace boost_python {
      * @param experiment The experiment
      * @param sigma The covariance matrix
      */
-    MaskCalculatorAngular(Experiment experiment, mat3<double> sigma, double probability)
-        : MaskCalculatorBase(experiment, probability), sigma_(sigma) {}
+    MaskCalculatorAngular(Experiment experiment,
+                          mat3<double> sigma,
+                          double probability,
+                          mat3<double> sigma_A)
+        : MaskCalculatorBase(experiment, probability),
+          sigma_(sigma),
+          sigma_A_(sigma_A) {}
 
   protected:
     /**
@@ -835,10 +852,13 @@ namespace dials { namespace algorithms { namespace boost_python {
       mat3<double> Q = compute_change_of_basis_operation2(s0, r);
       vec3<double> zaxis(0, 0, 1);
       DIALS_ASSERT(std::abs(((Q * r.normalize()) * zaxis) - 1) < TINY);
-      return (Q.transpose() * sigma_ * Q);
+      double r_scale = std::pow(r.length(), 2);
+      mat3<double> A(r_scale, 0, 0, 0, r_scale, 0, 0, 0, 0.0);
+      return (Q.transpose() * A * sigma_A_ * Q) + sigma_;
     }
 
     mat3<double> sigma_;
+    mat3<double> sigma_A_;
   };
 
   vec2<double> rse(const mat3<double> &R,
@@ -877,7 +897,7 @@ namespace dials { namespace algorithms { namespace boost_python {
       .def(init<Experiment, mat3<double>, double>());
 
     class_<PredictorAngular, bases<PredictorBase>>("PredictorAngular", no_init)
-      .def(init<Experiment, mat3<double>, double>());
+      .def(init<Experiment, mat3<double>, double, mat3<double>>());
 
     class_<BBoxCalculatorBase>("BBoxCalculatorBase", no_init)
       .def("compute", &BBoxCalculatorBase::compute);
@@ -888,7 +908,7 @@ namespace dials { namespace algorithms { namespace boost_python {
 
     class_<BBoxCalculatorAngular, bases<BBoxCalculatorBase>>("BBoxCalculatorAngular",
                                                              no_init)
-      .def(init<Experiment, mat3<double>, double, int>());
+      .def(init<Experiment, mat3<double>, double, int, mat3<double>>());
 
     class_<MaskCalculatorBase>("MaskCalculatorBase", no_init)
       .def("compute", &MaskCalculatorBase::compute);
@@ -899,7 +919,7 @@ namespace dials { namespace algorithms { namespace boost_python {
 
     class_<MaskCalculatorAngular, bases<MaskCalculatorBase>>("MaskCalculatorAngular",
                                                              no_init)
-      .def(init<Experiment, mat3<double>, double>());
+      .def(init<Experiment, mat3<double>, double, mat3<double>>());
   }
 
 }}}  // namespace dials::algorithms::boost_python

--- a/src/dials/algorithms/profile_model/ellipsoid/model.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/model.py
@@ -254,7 +254,7 @@ class ProfileModelBase(object):
         if L[0] > 1e-5:
             raise RuntimeError("Mosaicity matrix is unphysically large")
         if min(L) < 1e-12:
-            val = min(L) ** 0.5 if min(L) > 0 else 0
+            val = min(L) ** 0.5 if min(L) > 0 else 0.0
             raise RuntimeError(
                 f"Mosaicity matrix minimum sigma {val:.5} is unphysically small"
             )

--- a/src/dials/algorithms/profile_model/ellipsoid/model.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/model.py
@@ -20,6 +20,8 @@ from dials.algorithms.profile_model.ellipsoid import (
     PredictorSimple,
 )
 from dials.algorithms.profile_model.ellipsoid.parameterisation import (
+    Angular2MosaicityParameterisation,
+    Angular4MosaicityParameterisation,
     Simple1Angular1MosaicityParameterisation,
     Simple1Angular3MosaicityParameterisation,
     Simple1MosaicityParameterisation,
@@ -178,6 +180,11 @@ class EllipsoidProfileModel(ProfileModelExt):
             return cls(Simple6Angular1ProfileModel.from_dict(d))
         if d["parameterisation"] == "simple6angular3":
             return cls(Simple6Angular3ProfileModel.from_dict(d))
+        # next two retained for backwards compatilibty of reading expt files
+        if d["parameterisation"] == "angular2":
+            return cls(Angular2ProfileModel.from_dict(d))
+        if d["parameterisation"] == "angular4":
+            return cls(Angular4ProfileModel.from_dict(d))
         raise RuntimeError(
             f"Unknown profile model parameterisation: {d['parameterisation']}"
         )
@@ -751,3 +758,35 @@ def compute_change_of_basis_operation(s0, s2):
     e3 = s2 / norm(s2)
     R = np.array([e1, e2, e3], dtype=np.float64)
     return R
+
+
+class Angular2ProfileModel(AngularProfileModelBase):
+    """
+    Class to store profile model
+
+    """
+
+    name = "angular2"
+
+    def parameterisation(self):
+        """
+        Get the parameterisation
+
+        """
+        return Angular2MosaicityParameterisation(self.params)
+
+
+class Angular4ProfileModel(AngularProfileModelBase):
+    """
+    Class to store profile model
+
+    """
+
+    name = "angular4"
+
+    def parameterisation(self):
+        """
+        Get the parameterisation
+
+        """
+        return Angular4MosaicityParameterisation(self.params)

--- a/src/dials/algorithms/profile_model/ellipsoid/model.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/model.py
@@ -36,7 +36,7 @@ phil_scope = parse(
     """
 rlp_mosaicity {
 
-    model = simple1 simple6 *simple1angular1 simple1angular3 simple6angular1 simple6angular3
+    model = simple1 *simple6 simple1angular1 simple1angular3 simple6angular1 simple6angular3
     .type = choice
 
 }

--- a/src/dials/algorithms/profile_model/ellipsoid/model.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/model.py
@@ -685,7 +685,16 @@ class Simple6Angular1ProfileModel(AngularProfileModelBase):
         """
         return Class.from_params(
             np.array(
-                [sigma_d, 0, sigma_d, 0, 0, sigma_d, sigma_d / 10.0], dtype=np.float64
+                [
+                    sigma_d,
+                    sigma_d / 100.0,
+                    sigma_d,
+                    sigma_d / 100.0,
+                    sigma_d / 100.0,
+                    sigma_d,
+                    sigma_d / 100.0,
+                ],
+                dtype=np.float64,
             )
         )
 
@@ -732,14 +741,14 @@ class Simple6Angular3ProfileModel(AngularProfileModelBase):
             np.array(
                 [
                     sigma_d,
-                    0,
+                    sigma_d / 100.0,
                     sigma_d,
-                    0,
-                    0,
+                    sigma_d / 100.0,
+                    sigma_d / 100.0,
                     sigma_d,
-                    sigma_d / 10.0,
-                    0.0,
-                    sigma_d / 10.0,
+                    sigma_d / 100.0,
+                    sigma_d / 100.0,
+                    sigma_d / 100.0,
                 ],
                 dtype=np.float64,
             )
@@ -763,7 +772,7 @@ class Simple6Angular3ProfileModel(AngularProfileModelBase):
 
         # Setup the parameters
         return Class.from_params(
-            flex.double((LL[0], LL[1], LL[2], LL[3], LL[4], LL[5], LL[5], 0, LL[5]))
+            flex.double((LL[0], LL[1], LL[2], LL[3], LL[4], LL[5], LL[5], LL[5], LL[5]))
         )
 
 

--- a/src/dials/algorithms/profile_model/ellipsoid/model.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/model.py
@@ -88,11 +88,11 @@ refinement {
     min_n_reflections=10
         .type = int
 
-    max_iter=1000
+    max_iter=100
         .type = int
         .help = "Max number of iterations per refinement cycle"
 
-    LL_tolerance=1e-6
+    LL_tolerance=1e-2
         .type = float
         .help = "Convergence tolerance for log likelihood during refinement"
 

--- a/src/dials/algorithms/profile_model/ellipsoid/model.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/model.py
@@ -92,7 +92,7 @@ refinement {
         .type = int
         .help = "Max number of iterations per refinement cycle"
 
-    LL_tolerance=1e-2
+    LL_tolerance=1e-3
         .type = float
         .help = "Convergence tolerance for log likelihood during refinement"
 

--- a/src/dials/algorithms/profile_model/ellipsoid/model.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/model.py
@@ -642,7 +642,7 @@ class Simple1Angular3ProfileModel(AngularProfileModelBase):
         """
         return Class.from_params(
             np.array(
-                [sigma_d, sigma_d / 10.0, sigma_d / 100.0, sigma_d / 10.0],
+                [sigma_d, sigma_d, 0.0, sigma_d],
                 dtype=np.float64,
             )
         )
@@ -669,12 +669,12 @@ class Simple6Angular1ProfileModel(AngularProfileModelBase):
             np.array(
                 [
                     sigma_d,
-                    sigma_d / 100.0,
+                    0.0,
                     sigma_d,
-                    sigma_d / 100.0,
-                    sigma_d / 100.0,
+                    0.0,
+                    0.0,
                     sigma_d,
-                    sigma_d / 100.0,
+                    sigma_d,
                 ],
                 dtype=np.float64,
             )
@@ -702,14 +702,14 @@ class Simple6Angular3ProfileModel(AngularProfileModelBase):
             np.array(
                 [
                     sigma_d,
-                    sigma_d / 100.0,
+                    0.0,
                     sigma_d,
-                    sigma_d / 100.0,
-                    sigma_d / 100.0,
+                    0.0,
+                    0.0,
                     sigma_d,
-                    sigma_d / 100.0,
-                    sigma_d / 100.0,
-                    sigma_d / 100.0,
+                    sigma_d,
+                    0.0,
+                    sigma_d,
                 ],
                 dtype=np.float64,
             )

--- a/src/dials/algorithms/profile_model/ellipsoid/parameterisation.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/parameterisation.py
@@ -1000,15 +1000,16 @@ class ReflectionModelState(object):
             n_M_params = dM_dp.shape[0]  # state.M_params.size
             if state.is_mosaic_spread_angular:
                 # first add the derivative of the static component
-                QTMQ = np.einsum("ij,mjk,kl->ilm", self._Q.T, dM_dp, self._Q)
-                self._ds_dp[:, :, n_tot : n_tot + n_M_params] = QTMQ
+                self._ds_dp[:, :, n_tot : n_tot + n_M_params] = np.transpose(
+                    dM_dp, axes=(1, 2, 0)
+                )
                 n_tot += n_M_params
                 # now add the derivative of the angular component
                 dM_dp_A = self.state.dM_dp_A
                 n_M_A_params = dM_dp_A.shape[0]
                 normr = norm(self._r)
                 A = np.array(
-                    [[normr**2, 0, 0], [0, normr**2, 0], [0, 0, 1]],
+                    [[normr**2, 0, 0], [0, normr**2, 0], [0, 0, 0]],
                     dtype=np.float64,
                 ).reshape(3, 3)
                 AdM = np.einsum("ij,mjk->mik", A, dM_dp_A)

--- a/src/dials/algorithms/profile_model/ellipsoid/parameterisation.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/parameterisation.py
@@ -334,7 +334,7 @@ class Simple1Angular3MosaicityParameterisation(BaseParameterisation):
             matrix.sqr(flumpy.from_numpy(self.sigma())).as_flex_double_matrix()
         )
         v = decomp.values()[0] ** 0.5
-        mosaicities = {"spherical": v[0]}
+        mosaicities = {"spherical": v}
         decomp = linalg.eigensystem.real_symmetric(
             matrix.sqr(list(self.sigma_A()[0:2, 0:2].flatten())).as_flex_double_matrix()
         )

--- a/src/dials/algorithms/profile_model/ellipsoid/refiner.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/refiner.py
@@ -821,7 +821,9 @@ class FisherScoringMaximumLikelihood(FisherScoringMaximumLikelihoodBase):
 
         # Get some matrices
         U = self.model.U_matrix.flatten()
-        M = self.model.mosaicity_covariance_matrix.flatten()
+        M = (
+            self.model._M_parameterisation.sigma().flatten()
+        )  # mosaicity_covariance_matrix.flatten()
 
         # Print some information
         format_string1 = "  Unit cell: (%.3f, %.3f, %.3f, %.3f, %.3f, %.3f)"
@@ -855,6 +857,19 @@ class FisherScoringMaximumLikelihood(FisherScoringMaximumLikelihoodBase):
                     ]
                 )
             )
+            if self.model.is_mosaic_spread_angular:
+                MA = self.model._M_parameterisation.sigma_A().flatten()
+                logger.info(
+                    "\n".join(
+                        [
+                            "",
+                            "  Sigma M",
+                            format_string3 % tuple(MA[0:3]),
+                            format_string3 % tuple(MA[3:6]),
+                            format_string3 % tuple(MA[6:9]),
+                        ]
+                    )
+                )
 
         logger.info(
             "\n".join(
@@ -965,8 +980,15 @@ class Refiner(object):
         if not self.state.is_mosaic_spread_fixed:
             logger.info("\nDecomposition of Sigma_M:")
             print_eigen_values_and_vectors(
-                matrix.sqr(flumpy.from_numpy(self.state.mosaicity_covariance_matrix))
+                matrix.sqr(
+                    flumpy.from_numpy(self.state._M_parameterisation.sigma().flatten())
+                )
             )
+            if self.state.is_mosaic_spread_angular:
+                logger.info(self.state._M_parameterisation.sigma_A())
+                # print_eigen_values_and_vectors(
+                #    matrix.sqr(flumpy.from_numpy(self.state._M_parameterisation.sigma_A().flatten()))
+                # )
 
         # Save the history
         self.history = self.ml.history

--- a/src/dials/algorithms/profile_model/ellipsoid/refiner.py
+++ b/src/dials/algorithms/profile_model/ellipsoid/refiner.py
@@ -863,7 +863,7 @@ class FisherScoringMaximumLikelihood(FisherScoringMaximumLikelihoodBase):
                     "\n".join(
                         [
                             "",
-                            "  Sigma M",
+                            "  Sigma M angular",
                             format_string3 % tuple(MA[0:3]),
                             format_string3 % tuple(MA[3:6]),
                             format_string3 % tuple(MA[6:9]),
@@ -985,14 +985,10 @@ class Refiner(object):
                 )
             )
             if self.state.is_mosaic_spread_angular:
-                logger.info(
-                    print_eigen_values_and_vectors_angular(
-                        matrix.sqr(
-                            flumpy.from_numpy(
-                                self.state._M_parameterisation.sigma_A()[
-                                    :2, :2
-                                ].flatten()
-                            )
+                print_eigen_values_and_vectors_angular(
+                    matrix.sqr(
+                        flumpy.from_numpy(
+                            self.state._M_parameterisation.sigma_A()[:2, :2].flatten()
                         )
                     )
                 )
@@ -1215,7 +1211,7 @@ def print_eigen_values_and_vectors_angular(A):
     mosaicity = mosaicity_from_eigen_decomposition(eigen_values)
     logger.info(
         """
- Angular Mosaicity in degrees equivalent units:\n"""
+ Angular mosaicity in degrees equivalent units:\n"""
         + "\n".join(f" M{i+1} : {m:.5f} degrees" for i, m in enumerate(mosaicity))
     )
 

--- a/src/dials/command_line/ssx_integrate.py
+++ b/src/dials/command_line/ssx_integrate.py
@@ -302,7 +302,7 @@ def process_batch(sub_tables, sub_expts, configuration, batch_offset=0):
                 i + 1 + batch_offset,
             )
         )
-
+    input_iterable = sorted(input_iterable, key=lambda i: i.table.size(), reverse=True)
     with manage_loggers(
         configuration["params"].individual_log_verbosity,
         configuration["loggers_to_disable"],

--- a/tests/algorithms/integration/ssx/test_ellipsoid_integrate.py
+++ b/tests/algorithms/integration/ssx/test_ellipsoid_integrate.py
@@ -22,15 +22,13 @@ def test_run_ellipsoid_refinement(dials_data):
     refls = refls.select_on_experiment_identifiers([expts[0].identifier])
     refls = reindex(refls, expts[0])
 
-    e_angular2 = {"radial": 0.0179, "angular": 0.0148}
-    e_angular4 = {"radial": 0.0179, "angular_0": 0.0207, "angular_1": 0.0029}
-    e_simple1 = {"spherical": 0.0159}
-    e_simple6 = {"min": 0.0034, "mid": 0.0113, "max": 0.02520}
+    e_simple1 = {"spherical": 0.00027709}
+    e_simple6 = {"min": 5.93276e-5, "mid": 0.00019659, "max": 0.00043976}
 
     initial_crystal = copy.deepcopy(expts[0].crystal)
     for model, expected in zip(
-        ["angular2", "angular4", "simple1", "simple6"],
-        [e_angular2, e_angular4, e_simple1, e_simple6],
+        ["simple1", "simple6"],
+        [e_simple1, e_simple6],
     ):
         elist = copy.deepcopy(expts[0:1])
         out_expt, _, __ = run_ellipsoid_refinement(
@@ -51,13 +49,12 @@ def test_run_ellipsoid_refinement(dials_data):
         elist,
         refls,
         0.00062,
-        profile_model="angular4",
+        profile_model="simple6",
         fix_orientation=True,
         fix_unit_cell=True,
     )
-    e_angular4 = {"radial": 0.0182, "angular_0": 0.0207, "angular_1": 0.0052}
     for k, v in out_expt.profiles()[0].mosaicity().items():
-        assert e_angular4[k] == pytest.approx(v, abs=1e-4)
+        assert e_simple6[k] == pytest.approx(v, abs=1e-4)
     assert out_expt[0].crystal.get_unit_cell().parameters() == pytest.approx(
         initial_crystal.get_unit_cell().parameters(), abs=1e-12
     )

--- a/tests/command_line/test_ssx_integrate.py
+++ b/tests/command_line/test_ssx_integrate.py
@@ -50,19 +50,42 @@ import json
 
 expected_simple1 = {
     "likelihood": 171374.17464891364,
-    "mosaicity": [0.020799705597009843],
+    "mosaicity": [0.00036302334611331463],
+}
+expected_s1a1 = {
+    "likelihood": 171374.1740045413,
+    "mosaicity": [0.0003630828987324925, 4.791495711931804e-06],
+}
+expected_s1a3 = {
+    "likelihood": 172378.47458692876,
+    "mosaicity": [0.0003189999519843126, 0.07559499810366903, 2.2915562056795664e-08],
 }
 expected_simple6 = {
     "likelihood": 176234.85494941485,
-    "mosaicity": [0.007835942631996863, 0.02266467599439014, 0.026879730729450498],
+    "mosaicity": [
+        0.00013676299892573563,
+        0.00039557321999982774,
+        0.00046913980327840824,
+    ],
 }
-expected_angular2 = {
-    "likelihood": 171782.58653554777,
-    "mosaicity": [0.024549034458866092, 0.01864434938489629],
+expected_s6a1 = {
+    "likelihood": 177094.36892815138,
+    "mosaicity": [
+        1.9031463306553676e-05,
+        0.0003987602229705104,
+        0.00046360902730780773,
+        0.032456740908481226,
+    ],
 }
-expected_angular4 = {
-    "likelihood": 179074.32947807646,
-    "mosaicity": [0.024550628270576778, 0.025846182907222837, 0.005215268399212766],
+expected_s6a3 = {
+    "likelihood": 175696.41329749255,
+    "mosaicity": [
+        0.00011870174298666728,
+        0.0004429552218934676,
+        0.0005125703788199112,
+        0.0364844215478352,
+        3.5892742428290925e-05,
+    ],
 }
 
 
@@ -71,8 +94,10 @@ expected_angular4 = {
     [
         ("simple1", expected_simple1),
         ("simple6", expected_simple6),
-        ("angular2", expected_angular2),
-        ("angular4", expected_angular4),
+        ("simple1angular1", expected_s1a1),
+        ("simple1angular3", expected_s1a3),
+        ("simple6angular1", expected_s6a1),
+        ("simple6angular3", expected_s6a3),
     ],
 )
 @pytest.mark.xdist_group(name="group1")
@@ -97,6 +122,8 @@ def test_ssx_integrate_fullprocess_ellipsoid(dials_data, tmp_path, model, expect
             f"ellipsoid.rlp_mosaicity={model}",
             "n_macro_cycles=2",
             f"output.history={tmp_path /'history.json'}",
+            "max_iter=100",
+            "LL_tolerance=1e-6",
         ],
         working_directory=tmp_path,
     )

--- a/tests/command_line/test_ssx_integrate.py
+++ b/tests/command_line/test_ssx_integrate.py
@@ -49,42 +49,33 @@ def test_ssx_integrate_fullprocess(dials_data, tmp_path):
 import json
 
 expected_simple1 = {
-    "likelihood": 171374.17464891364,
-    "mosaicity": [0.00036302334611331463],
+    "likelihood": 171374.174649,
+    "mosaicity": [0.0003630],
 }
 expected_s1a1 = {
-    "likelihood": 171374.1740045413,
-    "mosaicity": [0.0003630828987324925, 4.791495711931804e-06],
+    "likelihood": 171217.954551,
+    "mosaicity": [0.0003951, 6.6198e-06],
 }
 expected_s1a3 = {
-    "likelihood": 172378.47458692876,
-    "mosaicity": [0.0003189999519843126, 0.07559499810366903, 2.2915562056795664e-08],
+    "likelihood": 171209.435802,
+    "mosaicity": [0.0004138, 0.0450596, 1.39279e-05],
 }
 expected_simple6 = {
-    "likelihood": 176234.85494941485,
-    "mosaicity": [
-        0.00013676299892573563,
-        0.00039557321999982774,
-        0.00046913980327840824,
-    ],
+    "likelihood": 176234.854949,
+    "mosaicity": [0.0001368, 0.0003956, 0.0004691],
 }
 expected_s6a1 = {
-    "likelihood": 177094.36892815138,
-    "mosaicity": [
-        1.9031463306553676e-05,
-        0.0003987602229705104,
-        0.00046360902730780773,
-        0.032456740908481226,
-    ],
+    "likelihood": 177094.368288,
+    "mosaicity": [1.9031e-05, 0.0003987, 0.0004636, 0.0324567],
 }
 expected_s6a3 = {
-    "likelihood": 175696.41329749255,
+    "likelihood": 175269.990971,
     "mosaicity": [
-        0.00011870174298666728,
-        0.0004429552218934676,
-        0.0005125703788199112,
-        0.0364844215478352,
-        3.5892742428290925e-05,
+        0.0001031,
+        0.0004483,
+        0.0005149,
+        0.0461091,
+        0.0013212,
     ],
 }
 
@@ -123,7 +114,7 @@ def test_ssx_integrate_fullprocess_ellipsoid(dials_data, tmp_path, model, expect
             "n_macro_cycles=2",
             f"output.history={tmp_path /'history.json'}",
             "max_iter=100",
-            "LL_tolerance=1e-6",
+            "LL_tolerance=1e-3",
         ],
         working_directory=tmp_path,
     )
@@ -133,7 +124,7 @@ def test_ssx_integrate_fullprocess_ellipsoid(dials_data, tmp_path, model, expect
     assert tmp_path.joinpath("dials.ssx_integrate.html").is_file()
     expts = load.experiment_list(tmp_path / "integrated_1.expt", check_format=False)
     mosaicity = expts[0].profile.mosaicity()
-    assert list(mosaicity.values()) == pytest.approx(expected["mosaicity"], abs=1e-6)
+    assert list(mosaicity.values()) == pytest.approx(expected["mosaicity"], abs=1e-5)
     with (tmp_path / "history.json").open("r") as fh:
         data = json.load(fh)
         assert data["0"]["likelihood_per_iteration"][-1][-1] == pytest.approx(


### PR DESCRIPTION
The angular2 and angular4 mosaicity models did not have an r-dependent angular term, which is necessary to model angular mosaic spreads. This PR replaces them with new models with angular components in addition to the simple1 and simple6 reflection-independent mosaicity models.

Also some plotting has been improved to put the mosaicities in the correct units.