### PR TITLE
Add a `small_cell` indexer to `dials.index`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ setup_kwargs = {
             "real_space_grid_search = dials.algorithms.indexing.basis_vector_search:RealSpaceGridSearch",
         ],
         "dials.index.lattice_search": [
-            "low_res_spot_match = dials.algorithms.indexing.lattice_search:LowResSpotMatch"
+            "low_res_spot_match = dials.algorithms.indexing.lattice_search:LowResSpotMatch",
+            "small_cell = dials.algorithms.indexing.lattice_search:SmallCell",
         ],
         "dials.integration.background": [
             "Auto = dials.extensions.auto_background_ext:AutoBackgroundExt",

--- a/src/dials/algorithms/indexing/lattice_search/__init__.py
+++ b/src/dials/algorithms/indexing/lattice_search/__init__.py
@@ -16,9 +16,10 @@ from dials.algorithms.indexing import indexer
 from dials.algorithms.indexing.basis_vector_search import combinations, optimise
 
 from .low_res_spot_match import LowResSpotMatch
+from .small_cell import SmallCell
 from .strategy import Strategy
 
-__all__ = ["Strategy", "LowResSpotMatch"]
+__all__ = ["Strategy", "LowResSpotMatch", "SmallCell"]
 
 
 logger = logging.getLogger(__name__)

--- a/src/dials/algorithms/indexing/lattice_search/small_cell.py
+++ b/src/dials/algorithms/indexing/lattice_search/small_cell.py
@@ -6,7 +6,7 @@ import logging
 # import math
 # import operator
 #
-import libtbx.phil
+import iotbx.phil
 
 # from dials.array_family import flex
 from xfel.small_cell.small_cell import small_cell_index_detail
@@ -39,7 +39,7 @@ class SmallCell(Strategy):
         "indices based on a known unit cell and space group."
     )
 
-    phil_scope = libtbx.phil.parse(small_cell_phil_str)
+    phil_scope = iotbx.phil.parse(small_cell_phil_str)
 
     def __init__(
         self, target_symmetry_primitive, max_lattices, params=None, *args, **kwargs

--- a/src/dials/algorithms/indexing/lattice_search/small_cell.py
+++ b/src/dials/algorithms/indexing/lattice_search/small_cell.py
@@ -12,10 +12,7 @@ from .strategy import Strategy
 
 logger = logging.getLogger(__name__)
 
-
-small_cell_phil_str = """\
-include scope xfel.small_cell.command_line.small_cell_index.small_cell_phil_str
-"""
+from xfel.small_cell.command_line.small_cell_index import small_cell_phil_str
 
 
 class SmallCell(Strategy):

--- a/src/dials/algorithms/indexing/lattice_search/small_cell.py
+++ b/src/dials/algorithms/indexing/lattice_search/small_cell.py
@@ -77,9 +77,13 @@ class SmallCell(Strategy):
                 The experimental geometry models
         """
 
-        max_clique_len, indexed_experiments, refls = small_cell_index_detail(
+        small_cell_result = small_cell_index_detail(
             experiments, reflections, self._params, write_output=False
         )
+        if not small_cell_result:
+            return []
+
+        max_clique_len, indexed_experiments, refls = zip(*small_cell_result)
 
         # FIXME small_cell_index_detail creates an indexed reflections list, but
         # we don't use that in dials.index...

--- a/src/dials/algorithms/indexing/lattice_search/small_cell.py
+++ b/src/dials/algorithms/indexing/lattice_search/small_cell.py
@@ -39,7 +39,7 @@ class SmallCell(Strategy):
 
             max_lattices (int): The maximum number of lattice models to find
         """
-        super().__init__(params=params, *args, **kwargs)
+        super().__init__(params=None, *args, **kwargs)
         self._target_symmetry_primitive = target_symmetry_primitive
         self._max_lattices = max_lattices
 
@@ -48,10 +48,12 @@ class SmallCell(Strategy):
                 "Target unit cell and space group must be provided for small_cell"
             )
 
-        params.small_cell.powdercell = (
+        self._params.small_cell.powdercell = (
             target_symmetry_primitive.unit_cell().parameters()
         )
-        params.small_cell.spacegroup = str(target_symmetry_primitive.space_group_info())
+        self._params.small_cell.spacegroup = str(
+            target_symmetry_primitive.space_group_info()
+        )
 
     def find_crystal_models(self, reflections, experiments):
         """Find a list of candidate crystal models.

--- a/src/dials/algorithms/indexing/lattice_search/small_cell.py
+++ b/src/dials/algorithms/indexing/lattice_search/small_cell.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+# import copy
+import logging
+
+# import math
+# import operator
+#
+import libtbx.phil
+
+# from dials.array_family import flex
+from xfel.small_cell.small_cell import small_cell_index_detail
+
+# from cctbx import miller
+# from dxtbx.model import Crystal
+# from scitbx import matrix
+# from scitbx.math import least_squares_plane, superpose
+#
+from dials.algorithms.indexing import DialsIndexError
+
+from .strategy import Strategy
+
+logger = logging.getLogger(__name__)
+
+
+small_cell_phil_str = """\
+include scope xfel.small_cell.command_line.small_cell_index.small_cell_phil_str
+"""
+
+
+class SmallCell(Strategy):
+    """
+    A lattice search strategy using the small_cell algorithm.
+
+    """
+
+    phil_help = (
+        "A lattice search strategy that matches low resolution spots to candidate "
+        "indices based on a known unit cell and space group."
+    )
+
+    phil_scope = libtbx.phil.parse(small_cell_phil_str)
+
+    def __init__(
+        self, target_symmetry_primitive, max_lattices, params=None, *args, **kwargs
+    ):
+        """Construct a LowResSpotMatch object.
+
+        Args:
+            target_symmetry_primitive (cctbx.crystal.symmetry): The target
+                crystal symmetry and unit cell
+
+            max_lattices (int): The maximum number of lattice models to find
+        """
+        super().__init__(params=params, *args, **kwargs)
+        self._target_symmetry_primitive = target_symmetry_primitive
+        self._max_lattices = max_lattices
+
+        if target_symmetry_primitive is None:
+            raise DialsIndexError(
+                "Target unit cell and space group must be provided for small_cell"
+            )
+
+        params.small_cell.powdercell = (
+            target_symmetry_primitive.unit_cell().parameters()
+        )
+        params.small_cell.spacegroup = str(target_symmetry_primitive.space_group_info())
+
+    def find_crystal_models(self, reflections, experiments):
+        """Find a list of candidate crystal models.
+
+        Args:
+            reflections (dials.array_family.flex.reflection_table):
+                The found spots centroids and associated data
+
+            experiments (dxtbx.model.experiment_list.ExperimentList):
+                The experimental geometry models
+        """
+
+        max_clique_len, indexed_experiments, refls = small_cell_index_detail(
+            experiments, reflections, self._params, write_output=False
+        )
+
+        # FIXME small_cell_index_detail creates an indexed reflections list, but
+        # we don't use that in dials.index...
+
+        candidate_crystal_models = []
+
+        self.candidate_crystal_models = candidate_crystal_models
+        return self.candidate_crystal_models

--- a/src/dials/algorithms/indexing/lattice_search/small_cell.py
+++ b/src/dials/algorithms/indexing/lattice_search/small_cell.py
@@ -8,11 +8,12 @@ import logging
 #
 import iotbx.phil
 
-# from dials.array_family import flex
-from xfel.small_cell.small_cell import small_cell_index_detail
-
 # from cctbx import miller
-# from dxtbx.model import Crystal
+from dxtbx.model import Crystal
+
+# from dials.array_family import flex
+from xfel.small_cell.small_cell import small_cell_index_lattice_detail
+
 # from scitbx import matrix
 # from scitbx.math import least_squares_plane, superpose
 #
@@ -77,18 +78,21 @@ class SmallCell(Strategy):
                 The experimental geometry models
         """
 
-        small_cell_result = small_cell_index_detail(
-            experiments, reflections, self._params, write_output=False
+        small_cell_result = small_cell_index_lattice_detail(
+            experiments, reflections, self._params
         )
         if not small_cell_result:
             return []
 
-        max_clique_len, indexed_experiments, refls = zip(*small_cell_result)
-
-        # FIXME small_cell_index_detail creates an indexed reflections list, but
-        # we don't use that in dials.index...
-
-        candidate_crystal_models = []
+        ori = small_cell_result[2]
+        direct_matrix = ori.direct_matrix()
+        real_a = direct_matrix[0:3]
+        real_b = direct_matrix[3:6]
+        real_c = direct_matrix[6:9]
+        crystal = Crystal(real_a, real_b, real_c, self._params.small_cell.spacegroup)
+        candidate_crystal_models = [
+            crystal,
+        ]
 
         self.candidate_crystal_models = candidate_crystal_models
         return self.candidate_crystal_models

--- a/src/dials/algorithms/indexing/lattice_search/small_cell.py
+++ b/src/dials/algorithms/indexing/lattice_search/small_cell.py
@@ -1,22 +1,11 @@
 from __future__ import annotations
 
-# import copy
 import logging
 
-# import math
-# import operator
-#
 import iotbx.phil
-
-# from cctbx import miller
 from dxtbx.model import Crystal
-
-# from dials.array_family import flex
 from xfel.small_cell.small_cell import small_cell_index_lattice_detail
 
-# from scitbx import matrix
-# from scitbx.math import least_squares_plane, superpose
-#
 from dials.algorithms.indexing import DialsIndexError
 
 from .strategy import Strategy


### PR DESCRIPTION
WIP.

Requires https://github.com/cctbx/cctbx_project/pull/912.

Currently, it runs, but indexing fails to assign indices for the `cctbx.xfel.small_cell_process` test cases. I'm not sure what the problem is.

### Test procedure
First run the `cctbx.xfel.small_cell_process` test

```
cd $(dials.data get -q 4fluoro_cxi)/lcls_2022_smSFX_workshop_data/indexing/
cctbx.xfel.small_cell_process params_1.phil ../ten_cbfs/*.cbf
```
Now split the output to get reference geometry for each of the individual images
```
dials.split_experiments idx-0000_integrated.expt
```
Then import the first image like this, ensuring the detector geometry and wavelength come from the reference
```
dials.import ../ten_cbfs/cxily6520_r0164_02081.cbf reference_geometry=split_0.expt
```
Find spots using the same parameters as in `params_1.phil`
```
dials.find_spots imported.expt\
  lookup.mask=../calibration/psana_border_hot_shift4.mask\
  filter.min_spot_size=2\
  kernel_size=2,2\
  global_threshold=10
```
Now try to index
```
dials.index imported.expt strong.refl\
  method=small_cell\
  unit_cell=6.0226,7.2623,29.5203,90,90,90\
  space_group=C222
```
We get some output from `small_cell`, showing that a cell model has been found, but unfortunately indices can't be assigned :-(
```
$$$ stills_indexer::choose_best_orientation_matrix, candidate 0 initial outlier identification
$$$ stills_indexer::identify_outliers
Couldn't refine candidate 0, ValueError: Empty reflections table provided to ReflectionManager
No suitable indexing solution found
```
I'm wondering if @phyy-nx or @dwpaley might know what is wrong here?