### PR TITLE
DIALS 3.16.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.16.1 (2023-09-05)
+=========================
+
+Bugfixes
+--------
+
+- ``dials.merge``: Fix potential for crash with ``r_free_flags.extend=True``, if there is no new flags to extend. (`#2491 <https://github.com/dials/dials/issues/2491>`_)
+
+
 DIALS 3.16.0 (2023-08-14)
 =========================
 

--- a/newsfragments/2491.bugfix
+++ b/newsfragments/2491.bugfix
@@ -1,1 +1,0 @@
-``dials.merge``: Fix potential for crash with ``r_free_flags.extend=True``, if there is no new flags to extend.

--- a/newsfragments/2491.bugfix
+++ b/newsfragments/2491.bugfix
@@ -1,1 +1,1 @@
-``dials.merge``: Fix potential for crash with r_free_flags.extend=True if there is no new flags to extend
+``dials.merge``: Fix potential for crash with ``r_free_flags.extend=True``, if there is no new flags to extend.

--- a/newsfragments/2491.bugfix
+++ b/newsfragments/2491.bugfix
@@ -1,0 +1,1 @@
+``dials.merge``: Fix potential for crash with r_free_flags.extend=True if there is no new flags to extend

--- a/src/dials/algorithms/merging/merge.py
+++ b/src/dials/algorithms/merging/merge.py
@@ -617,15 +617,16 @@ def r_free_flags_from_reference(
             flag_format = "ccp4"
         else:
             flag_format = "cns"
-        missing_flags = missing_set.generate_r_free_flags(
-            fraction=params.r_free_flags.fraction,
-            max_free=2000,
-            lattice_symmetry_max_delta=5.0,
-            use_lattice_symmetry=params.r_free_flags.use_lattice_symmetry,
-            n_shells=params.r_free_flags.n_shells,
-            format=flag_format,
-        )
-        r_free_array = r_free_array.concatenate(other=missing_flags)
+        if missing_set.size():
+            missing_flags = missing_set.generate_r_free_flags(
+                fraction=params.r_free_flags.fraction,
+                max_free=2000,
+                lattice_symmetry_max_delta=5.0,
+                use_lattice_symmetry=params.r_free_flags.use_lattice_symmetry,
+                n_shells=params.r_free_flags.n_shells,
+                format=flag_format,
+            )
+            r_free_array = r_free_array.concatenate(other=missing_flags)
 
     return r_free_array
 


### PR DESCRIPTION
Bugfixes
--------

- ``dials.merge``: Fix potential for crash with ``r_free_flags.extend=True``, if there is no new flags to extend. (#2491)