### PR TITLE
Cosym: don't fill wij matrix where the overlap is less than min_pairs

### DIFF
--- a/src/dials/algorithms/symmetry/cosym/target.py
+++ b/src/dials/algorithms/symmetry/cosym/target.py
@@ -229,7 +229,14 @@ class Target:
             # For each correlation coefficient, set the weight equal to the size of
             # the sample used to calculate that coefficient
             pairwise_combos = itertools.combinations(np.isfinite(all_intensities), 2)
-            sample_size = lambda x, y: np.count_nonzero(x & y)
+
+            def sample_size(x, y):
+                pairs = np.count_nonzero(x & y)
+                if pairs < self._min_pairs:
+                    return 0
+                else:
+                    return pairs
+
             wij[right_up] = list(itertools.starmap(sample_size, pairwise_combos))
 
             if self._weights == "standard_error":


### PR DESCRIPTION
This was important when using cosym alignment for a serial dataset with a small-ish unit cell. In the current state, when a pair of experiments has 1 or 2 overlaps, that (nonzero) number goes in the weights matrix and a 0 goes in the correlations matrix. As a result the Brehm-Diederichs refinement is contaminated with bogus zero correlations. This pair of images shows the difference:
Before:
![image](https://github.com/dials/dials/assets/22478495/e8bf360c-95e2-42cc-9b39-4a3a48a3f014)
After:
![image](https://github.com/dials/dials/assets/22478495/47899925-d678-416b-a913-c460d304e031)

This was previously flagged as a possible issue, but in practice it's only detectable when there are many barely-overlapping pairs of datasets. 