### PR TITLE
Add check for compatible cells in cosym output

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+``dials.cosym``: raise RuntimeError if inconsistent output cells after reindexing

--- a/src/dials/command_line/cosym.py
+++ b/src/dials/command_line/cosym.py
@@ -17,6 +17,8 @@ from dials.command_line.symmetry import (
     apply_change_of_basis_ops,
     change_of_basis_ops_to_minimum_cell,
     eliminate_sys_absent,
+    median_unit_cell,
+    unit_cells_are_similar_to,
 )
 from dials.util import Sorry, log, show_mail_handle_errors
 from dials.util.exclude_images import get_selection_for_valid_image_ranges
@@ -222,6 +224,35 @@ class cosym(Subject):
         self._apply_reindexing_operators(
             reindexing_ops, subgroup=self.cosym_analysis.best_subgroup
         )
+        self._check_unit_cell_consistency()
+
+    def _check_unit_cell_consistency(self):
+        median_cell = median_unit_cell(self._experiments)
+        unit_cells_are_similar = unit_cells_are_similar_to(
+            self._experiments,
+            median_cell,
+            self.params.relative_length_tolerance,
+            self.params.absolute_angle_tolerance,
+        )
+        if not unit_cells_are_similar:
+            median_str = ", ".join(f"{i:.3f}" for i in median_cell.parameters())
+            logger.info(f"Median cell: {median_str}")
+            for i, xtal in enumerate(self._experiments.crystals()):
+                if not xtal.get_unit_cell().is_similar_to(
+                    median_cell,
+                    relative_length_tolerance=self.params.relative_length_tolerance,
+                    absolute_angle_tolerance=self.params.absolute_angle_tolerance,
+                ):
+                    cell = ", ".join(
+                        f"{i:.3f}" for i in xtal.get_unit_cell().parameters()
+                    )
+                    logger.info(f"Incompatible cell: {cell} (dataset {i})")
+                else:
+                    cell = ", ".join(
+                        f"{i:.3f}" for i in xtal.get_unit_cell().parameters()
+                    )
+                    logger.info(f"Compatible cell: {cell} (dataset {i})")
+            raise RuntimeError("Incompatible unit cells after reindexing")
 
     def export(self):
         """Output the datafiles for cosym.

--- a/tests/command_line/test_cosym.py
+++ b/tests/command_line/test_cosym.py
@@ -133,7 +133,15 @@ def test_cosym_with_reference(dials_data, run_in_tmp_path):
         "use_known_lattice_group",
     ),
     [
-        ("P2", None, None, 10, False, False),
+        pytest.param(
+            "P2",
+            None,
+            None,
+            10,
+            False,
+            False,
+            marks=pytest.mark.xfail(reason="cosym invalid reindex bug #2486"),
+        ),
         ("P3", None, None, 20, False, False),
         ("I23", None, 2, 10, False, False),
         ("P422", (79, 79, 37, 90, 90, 90), None, 10, True, False),


### PR DESCRIPTION
Fixes #2234

A suggestion that I welcome discussion on.

Should we explicity check and raise a RuntimeError when the cosym procedure has incorrectly reindexed the unit cells to be incompatible with each other?
Avoids silent continuation when there is an issue, but may make some datasets unprocessable 🤔 
Maybe this can be merged in when we think we have fixed #2486 