### PR TITLE
Warn about unused `indexing.refinement_protocol` params

### DIFF
--- a/newsfragments/2586.misc
+++ b/newsfragments/2586.misc
@@ -1,0 +1,1 @@
+``dials.stills_process``: Increase verbosity of phil string, warn when setting unused parameters

--- a/src/dials/algorithms/indexing/indexer.py
+++ b/src/dials/algorithms/indexing/indexer.py
@@ -186,7 +186,7 @@ indexing {
     d_min_start = None
       .type = float(value_min=0.0)
       .help = "For sequences/stills indexer, the lower limit of d-spacing"
-              "of reflections used in the first/the only round of refinement.
+              "of reflections used in the first/the only round of refinement."
     d_min_final = None
       .type = float(value_min=0.0)
       .help = "Do not ever include reflections below this value in refinement."

--- a/src/dials/algorithms/indexing/indexer.py
+++ b/src/dials/algorithms/indexing/indexer.py
@@ -168,7 +168,9 @@ indexing {
     mode = *refine_shells repredict_only None
       .type = choice
       .expert_level = 1
-      .help = "refine_shells: refine in increasing resolution cutoffs after indexing."
+      .help = "refine_shells: if using sequences indexer, refine in increasing"
+              "resolution cutoffs after indexing; if using stills indexer,"
+              "refine all data up to d_min_start resolution once only."
               "repredict_only: do not refine after indexing, just update spot"
               "predictions."
               "None: do not refine and do not update spot predictions."
@@ -179,16 +181,20 @@ indexing {
               "cycle. Does not apply to stills.indexer=stills."
     d_min_step = Auto
       .type = float(value_min=0.0)
-      .help = "Reduction per step in d_min for reflections to include in refinement."
+      .help = "Reduction per step in d_min for reflections to include"
+              "in refinement. Does not apply to stills.indexer=stills."
     d_min_start = None
       .type = float(value_min=0.0)
+      .help = "For sequences/stills indexer, the lower limit of d-spacing"
+              "of reflections used in the first/the only round of refinement.
     d_min_final = None
       .type = float(value_min=0.0)
       .help = "Do not ever include reflections below this value in refinement."
+              "Does not apply to stills.indexer=stills."
     disable_unit_cell_volume_sanity_check = False
       .type = bool
       .help = "Disable sanity check on unrealistic increases in unit cell volume"
-              "during refinement."
+              "during refinement. Does not apply to stills.indexer=stills."
       .expert_level = 1
   }
   multiple_lattice_search

--- a/src/dials/algorithms/indexing/indexer.py
+++ b/src/dials/algorithms/indexing/indexer.py
@@ -169,7 +169,7 @@ indexing {
       .type = choice
       .expert_level = 1
       .help = "refine_shells: if using sequences indexer, refine in increasing"
-              "resolution cutoffs after indexing; if using stills indexer,"
+              "resolution cutoffs after indexing, if using stills indexer,"
               "refine all data up to d_min_start resolution once only."
               "repredict_only: do not refine after indexing, just update spot"
               "predictions."

--- a/src/dials/algorithms/indexing/stills_indexer.py
+++ b/src/dials/algorithms/indexing/stills_indexer.py
@@ -97,7 +97,7 @@ class StillsIndexer(Indexer):
             # The stills_indexer provides its own outlier rejection
             params.refinement.reflections.outlier.algorithm = "null"
         super().__init__(reflections, experiments, params)
-        self.warn_if_setting_unused_params(params)
+        self.warn_if_setting_unused_params()
 
     def index(self):
         # most of this is the same as dials.algorithms.indexing.indexer.indexer_base.index(), with some stills
@@ -820,8 +820,7 @@ class StillsIndexer(Indexer):
 
         return ref_experiments, reflections
 
-    @staticmethod
-    def warn_if_setting_unused_params(params):
+    def warn_if_setting_unused_params(self):
         warning_message = (
             "Warning: the value of indexing.refinement_protocol.{} has been"
             " changed to {}, but this parameter is unused by stills indexer."
@@ -833,7 +832,8 @@ class StillsIndexer(Indexer):
             "disable_unit_cell_volume_sanity_check": False,
         }
         for param, default in unused_refinement_protocol_defaults.items():
-            if value := getattr(params.refinement_protocol, param) != default:
+            value = getattr(self.params.refinement_protocol, param)
+            if value != default:
                 logger.info(warning_message.format(param, str(value)))
 
 

--- a/src/dials/algorithms/indexing/stills_indexer.py
+++ b/src/dials/algorithms/indexing/stills_indexer.py
@@ -822,17 +822,19 @@ class StillsIndexer(Indexer):
 
     @staticmethod
     def warn_if_setting_unused_params(params):
-        msg = "Warning: the value of indexing.refinement_protocol.{} has been"\
-              " changed to {}, but this parameter is unused by stills indexer."
+        warning_message = (
+            "Warning: the value of indexing.refinement_protocol.{} has been"
+            " changed to {}, but this parameter is unused by stills indexer."
+        )
         unused_refinement_protocol_defaults = {
             "n_macro_cycles": 5,
             "d_min_step": libtbx.Auto,
             "d_min_final": None,
-            "disable_unit_cell_volume_sanity_check": False
+            "disable_unit_cell_volume_sanity_check": False,
         }
         for param, default in unused_refinement_protocol_defaults.items():
             if value := getattr(params.refinement_protocol, param) != default:
-                logger.info(msg.format(param, str(value)))
+                logger.info(warning_message.format(param, str(value)))
 
 
 """Mixin class definitions that override the dials indexing class methods specific to stills"""

--- a/src/dials/algorithms/indexing/stills_indexer.py
+++ b/src/dials/algorithms/indexing/stills_indexer.py
@@ -829,7 +829,6 @@ class StillsIndexer(Indexer):
             "n_macro_cycles": 5,
             "d_min_step": libtbx.Auto,
             "d_min_final": None,
-            "disable_unit_cell_volume_sanity_check": False,
         }
         for param, default in unused_refinement_protocol_defaults.items():
             value = getattr(self.params.refinement_protocol, param)

--- a/src/dials/algorithms/indexing/stills_indexer.py
+++ b/src/dials/algorithms/indexing/stills_indexer.py
@@ -9,6 +9,7 @@ from dxtbx.model.experiment_list import Experiment, ExperimentList
 
 from dials.algorithms.indexing import DialsIndexError, DialsIndexRefineError
 from dials.algorithms.indexing.indexer import Indexer
+from dials.algorithms.indexing.indexer import phil_scope as defaults_phil_scope
 from dials.algorithms.indexing.known_orientation import IndexerKnownOrientation
 from dials.algorithms.indexing.lattice_search import BasisVectorSearch, LatticeSearch
 from dials.algorithms.indexing.nave_parameters import NaveParameters
@@ -97,7 +98,7 @@ class StillsIndexer(Indexer):
             # The stills_indexer provides its own outlier rejection
             params.refinement.reflections.outlier.algorithm = "null"
         super().__init__(reflections, experiments, params)
-        self.warn_if_setting_unused_params()
+        self.warn_if_setting_unused_refinement_protocol_params()
 
     def index(self):
         # most of this is the same as dials.algorithms.indexing.indexer.indexer_base.index(), with some stills
@@ -820,20 +821,17 @@ class StillsIndexer(Indexer):
 
         return ref_experiments, reflections
 
-    def warn_if_setting_unused_params(self):
+    def warn_if_setting_unused_refinement_protocol_params(self):
         warning_message = (
-            "Warning: the value of indexing.refinement_protocol.{} has been"
-            " changed to {}, but this parameter is unused by stills indexer."
+            "Warning: the value of indexing.refinement_protocol.{} has been "
+            "changed to {}, but this parameter is unused by stills indexer."
         )
-        unused_refinement_protocol_defaults = {
-            "n_macro_cycles": 5,
-            "d_min_step": libtbx.Auto,
-            "d_min_final": None,
-        }
-        for param, default in unused_refinement_protocol_defaults.items():
-            value = getattr(self.params.refinement_protocol, param)
-            if value != default:
-                logger.info(warning_message.format(param, str(value)))
+        unused_param_keys = ["n_macro_cycles", "d_min_step", "d_min_final"]
+        defaults = defaults_phil_scope.extract().indexing.refinement_protocol
+        for key in unused_param_keys:
+            value = getattr(self.params.refinement_protocol, key)
+            if value != getattr(defaults, key):
+                logger.warning(warning_message.format(key, str(value)))
 
 
 """Mixin class definitions that override the dials indexing class methods specific to stills"""

--- a/src/dials/algorithms/indexing/stills_indexer.py
+++ b/src/dials/algorithms/indexing/stills_indexer.py
@@ -97,6 +97,7 @@ class StillsIndexer(Indexer):
             # The stills_indexer provides its own outlier rejection
             params.refinement.reflections.outlier.algorithm = "null"
         super().__init__(reflections, experiments, params)
+        self.warn_if_setting_unused_params(params)
 
     def index(self):
         # most of this is the same as dials.algorithms.indexing.indexer.indexer_base.index(), with some stills
@@ -818,6 +819,20 @@ class StillsIndexer(Indexer):
                 )
 
         return ref_experiments, reflections
+
+    @staticmethod
+    def warn_if_setting_unused_params(params):
+        msg = "Warning: the value of indexing.refinement_protocol.{} has been"\
+              " changed to {}, but this parameter is unused by stills indexer."
+        unused_refinement_protocol_defaults = {
+            "n_macro_cycles": 5,
+            "d_min_step": libtbx.Auto,
+            "d_min_final": None,
+            "disable_unit_cell_volume_sanity_check": False
+        }
+        for param, default in unused_refinement_protocol_defaults.items():
+            if value := getattr(params.refinement_protocol, param) != default:
+                logger.info(msg.format(param, str(value)))
 
 
 """Mixin class definitions that override the dials indexing class methods specific to stills"""


### PR DESCRIPTION
Some phil parameters remain unused when provided to `StillsIndexer`. Since there are no imminent plans to expand the capabilities of this indexer, this PR suggests increasing the verbosity of indexing phil string and logging subtle warnings when unused phil parameters are being set. Resolves #2584.