### PR TITLE
cmake: generate coverage info for GNU and Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ include(CheckCXXSymbolExists)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # Generate compile_commands.json
 set(CMAKE_CXX_STANDARD 14)
 
+message(STATUS "CMAKE CXX COMPILER ID - ${CMAKE_CXX_COMPILER_ID}")
+
 find_package(Python REQUIRED COMPONENTS Interpreter Development)
 find_package(CCTBX COMPONENTS cctbx scitbx ccp4io annlib REQUIRED)
 find_package(DXTBX REQUIRED)

--- a/cmake/Modules/CoverageBuildConfiguration.cmake
+++ b/cmake/Modules/CoverageBuildConfiguration.cmake
@@ -10,6 +10,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
     set(CMAKE_CXX_FLAGS_COVERAGE            "${CMAKE_CXX_FLAGS_DEBUG} --coverage -fprofile-abs-path")
     set(CMAKE_EXE_LINKER_FLAGS_COVERAGE     "${CMAKE_EXE_LINKER_FLAGS_COVERAGE} --coverage")
     set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE  "${CMAKE_SHARED_LINKER_FLAGS_COVERAGE} --coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_COVERAGE}")
 else()
     # It's an error if we requested coverage, otherwise ignore
     string( TOUPPER "${CMAKE_BUILD_TYPE}" _build_type )

--- a/cmake/Modules/CoverageBuildConfiguration.cmake
+++ b/cmake/Modules/CoverageBuildConfiguration.cmake
@@ -1,6 +1,11 @@
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL Clang OR CMAKE_CXX_COMPILER_ID STREQUAL AppleClang)
     set(CMAKE_CXX_FLAGS_COVERAGE            "${CMAKE_CXX_FLAGS_DEBUG} -fprofile-instr-generate -fcoverage-mapping")
+    set(GCC_DEBUG_FLAGS "-g -Wall")
+
+    set(CMAKE_CXX_FLAGS_COVERAGE "${GCC_DEBUG_FLAGS} -fprofile-arcs -ftest-coverage")
+    set(CMAKE_C_FLAGS_COVERAGE "${GCC_DEBUG_FLAGS} -fprofile-arcs -ftest-coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_COVERAGE} ${CMAKE_C_FLAGS_COVERAGE}")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
     set(CMAKE_CXX_FLAGS_COVERAGE            "${CMAKE_CXX_FLAGS_DEBUG} --coverage -fprofile-abs-path")
     set(CMAKE_EXE_LINKER_FLAGS_COVERAGE     "${CMAKE_EXE_LINKER_FLAGS_COVERAGE} --coverage")


### PR DESCRIPTION
```console
(base) namannimmo@srf build % find . -name "*.gcno"
./dials/tests/CMakeFiles/tst_collision_detection.dir/algorithms/spatial_indexing/tst_collision_detection.cc.gcno
./dials/tests/CMakeFiles/tst_reeke_model.dir/algorithms/spot_prediction/tst_reeke_model.cc.gcno
./dials/src/dials/util/CMakeFiles/dials_util_ext.dir/boost_python/ext.cc.gcno
./dials/src/dials/util/CMakeFiles/dials_util_streambuf_test_ext.dir/boost_python/streambuf_test_ext.cpp.gcno
./dials/src/dials/pychef/CMakeFiles/dials_pychef_ext.dir/ext.cc.gcno
./dials/src/dials/algorithms/statistics/CMakeFiles/dials_algorithms_statistics_ext.dir/boost_python/statistics_ext.cc.gcno
./dials/src/dials/algorithms/background/CMakeFiles/dials_algorithms_background_gmodel_ext.dir/gmodel/boost_python/ext.cc.gcno
./dials/src/dials/algorithms/background/CMakeFiles/dials_algorithms_background_modeller_ext.dir/boost_python/modeller_ext.cc.gcno
./dials/src/dials/algorithms/background/CMakeFiles/dials_algorithms_background_simple_ext.dir/simple/boost_python/outlier_rejector.cc.gcno
./dials/src/dials/algorithms/background/CMakeFiles/dials_algorithms_background_simple_ext.dir/simple/boost_python/background_simple_ext.cc.gcno
./dials/src/dials/algorithms/background/CMakeFiles/dials_algorithms_background_simple_ext.dir/simple/boost_python/modeller.cc.gcno
./dials/src/dials/algorithms/background/CMakeFiles/dials_algorithms_background_simple_ext.dir/simple/boost_python/creator.cc.gcno
./dials/src/dials/algorithms/background/CMakeFiles/dials_algorithms_background_glm_ext.dir/glm/boost_python/ext.cc.gcno
./dials/src/dials/algorithms/background/CMakeFiles/dials_algorithms_background_ext.dir/boost_python/background_ext.cc.gcno
./dials/src/dials/algorithms/background/CMakeFiles/dials_algorithms_background_ext.dir/boost_python/helpers.cc.gcno
./dials/src/dials/algorithms/shoebox/CMakeFiles/dials_algorithms_shoebox_ext.dir/boost_python/overload_checker.cc.gcno
./dials/src/dials/algorithms/shoebox/CMakeFiles/dials_algorithms_shoebox_ext.dir/boost_python/find_overlapping.cc.gcno
./dials/src/dials/algorithms/shoebox/CMakeFiles/dials_algorithms_shoebox_ext.dir/boost_python/mask_code.cc.gcno
./dials/src/dials/algorithms/shoebox/CMakeFiles/dials_algorithms_shoebox_ext.dir/boost_python/mask_overlapping.cc.gcno
./dials/src/dials/algorithms/shoebox/CMakeFiles/dials_algorithms_shoebox_ext.dir/boost_python/shoebox_ext.cc.gcno
./dials/src/dials/algorithms/shoebox/CMakeFiles/dials_algorithms_shoebox_ext.dir/boost_python/mask_empirical.cc.gcno
./dials/src/dials/algorithms/shoebox/CMakeFiles/dials_algorithms_shoebox_ext.dir/boost_python/mask_builder.cc.gcno
./dials/src/dials/algorithms/filtering/CMakeFiles/dials_algorithms_filter_ext.dir/boost_python/filter_ext.cc.gcno
./dials/src/dials/algorithms/centroid/CMakeFiles/dials_algorithms_centroid_simple_ext.dir/simple/boost_python/simple_ext.cc.gcno
./dials/src/dials/algorithms/integration/CMakeFiles/dials_algorithms_integration_sum_ext.dir/sum/boost_python/summation.cc.gcno
./dials/src/dials/algorithms/integration/CMakeFiles/dials_algorithms_integration_sum_ext.dir/sum/boost_python/integration_sum_ext.cc.gcno
./dials/src/dials/algorithms/integration/CMakeFiles/dials_algorithms_integration_kapton_ext.dir/boost_python/kapton_ext.cc.gcno
./dials/src/dials/algorithms/integration/CMakeFiles/dials_algorithms_integration_parallel_integrator_ext.dir/boost_python/parallel_integrator_ext.cc.gcno
./dials/src/dials/algorithms/integration/CMakeFiles/dials_algorithms_integration_ext.dir/boost_python/corrections.cc.gcno
./dials/src/dials/algorithms/integration/CMakeFiles/dials_algorithms_integration_ext.dir/boost_python/integration_ext.cc.gcno
./dials/src/dials/algorithms/integration/CMakeFiles/dials_algorithms_integration_fit_ext.dir/fit/boost_python/ext.cc.gcno
./dials/src/dials/algorithms/integration/CMakeFiles/dials_algorithms_integration_integrator_ext.dir/boost_python/integration_integrator_ext.cc.gcno
./dials/src/dials/algorithms/integration/CMakeFiles/dials_algorithms_integration_bayes_ext.dir/bayes/boost_python/ext.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/reflection_predictor.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/stills_ray_predictor.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/ray_intersection.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/rotation_angles.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/spot_prediction_ext.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/pixel_labeller.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/pixel_to_miller_index.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/index_generator.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/scan_varying_helpers.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/scan_varying_ray_predictor.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/ray_predictor.cc.gcno
./dials/src/dials/algorithms/spot_prediction/CMakeFiles/dials_algorithms_spot_prediction_ext.dir/boost_python/reeke_index_generator.cc.gcno
./dials/src/dials/algorithms/simulation/CMakeFiles/dials_algorithms_simulation_ext.dir/boost_python/simulation_ext.cc.gcno
./dials/src/dials/algorithms/polygon/CMakeFiles/dials_algorithms_polygon_spatial_interpolation_ext.dir/boost_python/spatial_interpolation_ext.cc.gcno
./dials/src/dials/algorithms/polygon/CMakeFiles/dials_algorithms_polygon_ext.dir/boost_python/polygon_ext.cc.gcno
./dials/src/dials/algorithms/polygon/clip/CMakeFiles/dials_algorithms_polygon_clip_ext.dir/boost_python/clip_ext.cc.gcno
./dials/src/dials/algorithms/rs_mapper/CMakeFiles/recviewer_ext.dir/ext.cpp.gcno
./dials/src/dials/algorithms/image/centroid/CMakeFiles/dials_algorithms_image_centroid_ext.dir/boost_python/centroid_ext.cc.gcno
./dials/src/dials/algorithms/image/connected_components/CMakeFiles/dials_algorithms_image_connected_components_ext.dir/boost_python/connected_components_ext.cc.gcno
./dials/src/dials/algorithms/image/threshold/CMakeFiles/dials_algorithms_image_threshold_ext.dir/boost_python/local.cc.gcno
./dials/src/dials/algorithms/image/threshold/CMakeFiles/dials_algorithms_image_threshold_ext.dir/boost_python/threshold_ext.cc.gcno
./dials/src/dials/algorithms/image/threshold/CMakeFiles/dials_algorithms_image_threshold_ext.dir/boost_python/unimodal.cc.gcno
./dials/src/dials/algorithms/image/fill_holes/CMakeFiles/dials_algorithms_image_fill_holes_ext.dir/boost_python/fill_holes_ext.cc.gcno
./dials/src/dials/algorithms/image/filter/CMakeFiles/dials_algorithms_image_filter_ext.dir/boost_python/mean_and_variance.cc.gcno
./dials/src/dials/algorithms/image/filter/CMakeFiles/dials_algorithms_image_filter_ext.dir/boost_python/median.cc.gcno
./dials/src/dials/algorithms/image/filter/CMakeFiles/dials_algorithms_image_filter_ext.dir/boost_python/index_of_dispersion_filter.cc.gcno
./dials/src/dials/algorithms/image/filter/CMakeFiles/dials_algorithms_image_filter_ext.dir/boost_python/anisotropic_diffusion.cc.gcno
./dials/src/dials/algorithms/image/filter/CMakeFiles/dials_algorithms_image_filter_ext.dir/boost_python/convolve.cc.gcno
./dials/src/dials/algorithms/image/filter/CMakeFiles/dials_algorithms_image_filter_ext.dir/boost_python/filter_ext.cc.gcno
./dials/src/dials/algorithms/image/filter/CMakeFiles/dials_algorithms_image_filter_ext.dir/boost_python/summed_area.cc.gcno
./dials/src/dials/algorithms/image/filter/CMakeFiles/dials_algorithms_image_filter_ext.dir/boost_python/distance.cc.gcno
./dials/src/dials/algorithms/spot_finding/CMakeFiles/dials_algorithms_spot_finding_ext.dir/boost_python/spot_finding_ext.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/mahalanobis.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/parameterisation_helpers.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/restraints_helpers.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/gaussian_smoother.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/refinement_ext.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/gallego_yezzi.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/rtmats.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/outlier_helpers.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/gaussian_smoother_2D.cc.gcno
./dials/src/dials/algorithms/refinement/CMakeFiles/dials_refinement_helpers_ext.dir/boost_python/gaussian_smoother_3D.cc.gcno
./dials/src/dials/algorithms/scaling/CMakeFiles/dials_scaling_ext.dir/boost_python/scaling_helper.cc.gcno
./dials/src/dials/algorithms/scaling/CMakeFiles/dials_scaling_ext.dir/boost_python/scaling_ext.cc.gcno
./dials/src/dials/algorithms/indexing/CMakeFiles/dials_algorithms_indexing_ext.dir/boost_python/fft3d.cc.gcno
./dials/src/dials/algorithms/indexing/CMakeFiles/dials_algorithms_indexing_ext.dir/boost_python/indexing_ext.cc.gcno
./dials/src/dials/algorithms/profile_model/CMakeFiles/dials_algorithms_profile_model_ellipsoid_ext.dir/ellipsoid/boost_python/ext.cc.gcno
./dials/src/dials/algorithms/profile_model/CMakeFiles/dials_algorithms_profile_model_modeller_ext.dir/modeller/boost_python/sampler.cc.gcno
./dials/src/dials/algorithms/profile_model/CMakeFiles/dials_algorithms_profile_model_modeller_ext.dir/modeller/boost_python/modeller.cc.gcno
./dials/src/dials/algorithms/profile_model/CMakeFiles/dials_algorithms_profile_model_modeller_ext.dir/modeller/boost_python/ext.cc.gcno
./dials/src/dials/algorithms/profile_model/CMakeFiles/dials_algorithms_profile_model_gaussian_rs_ext.dir/gaussian_rs/boost_python/gaussian_rs_ext.cc.gcno
./dials/src/dials/algorithms/profile_model/CMakeFiles/dials_algorithms_profile_model_gaussian_rs_transform_ext.dir/gaussian_rs/transform/boost_python/transform_ext.cc.gcno
./dials/src/dials/viewer/CMakeFiles/dials_viewer_ext.dir/boost_python/RGB_2d.cc.gcno
./dials/src/dials/viewer/CMakeFiles/dials_viewer_ext.dir/boost_python/RGB_2d_ext.cc.gcno
./dials/src/dials/model/data/CMakeFiles/dials_model_data_ext.dir/boost_python/adjacency_list.cc.gcno
./dials/src/dials/model/data/CMakeFiles/dials_model_data_ext.dir/boost_python/pixel_list.cc.gcno
./dials/src/dials/model/data/CMakeFiles/dials_model_data_ext.dir/boost_python/data_ext.cc.gcno
./dials/src/dials/model/data/CMakeFiles/dials_model_data_ext.dir/boost_python/image_volume.cc.gcno
./dials/src/dials/model/data/CMakeFiles/dials_model_data_ext.dir/boost_python/shoebox.cc.gcno
./dials/src/dials/model/data/CMakeFiles/dials_model_data_ext.dir/boost_python/observation.cc.gcno
./dials/src/dials/model/data/CMakeFiles/dials_model_data_ext.dir/boost_python/image.cc.gcno
./dials/src/dials/model/data/CMakeFiles/dials_model_data_ext.dir/boost_python/prediction.cc.gcno
./dials/src/dials/model/data/CMakeFiles/dials_model_data_ext.dir/boost_python/ray.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_shoebox_extractor.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_unit_cell.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_centroid.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_ext.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_int6.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_intensity.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_observation.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_shoebox.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_binner.cc.gcno
./dials/src/dials/array_family/CMakeFiles/dials_array_family_flex_ext.dir/boost_python/flex_reflection_table.cc.gcno
(base) namannimmo@srf build %
```