### PR TITLE
Remove % from dials.index % indexed column.

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Remove % from value in `% indexed` column in `dials.index` output.

--- a/src/dials/algorithms/indexing/indexer.py
+++ b/src/dials/algorithms/indexing/indexer.py
@@ -920,7 +920,7 @@ class Indexer:
                     str(i),
                     str(indexed_count),
                     str(unindexed_count),
-                    f"{indexed_count / (indexed_count + unindexed_count):.1%}",
+                    f"{indexed_count / (indexed_count + unindexed_count)*100:.1f}",
                 ]
             )
         logger.info(dials.util.tabulate(rows, headers="firstrow"))


### PR DESCRIPTION
Changes `dials.index` output from 

```
+------------+-------------+---------------+-------------+
|   Imageset |   # indexed |   # unindexed | % indexed   |
|------------+-------------+---------------+-------------|
|          0 |         204 |             1 | 99.5%       |
+------------+-------------+---------------+-------------+

Saving refined experiments to indexed.expt
Saving refined reflections to indexed.refl
```
to
```
+------------+-------------+---------------+-------------+
|   Imageset |   # indexed |   # unindexed |   % indexed |
|------------+-------------+---------------+-------------|
|          0 |         204 |             1 |        99.5 |
+------------+-------------+---------------+-------------+

Saving refined experiments to indexed.expt
Saving refined reflections to indexed.refl
```
