### PR TITLE
Use Mamba to install CI build dependencies

### DIFF
--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -55,7 +55,7 @@ steps:
 - bash: |
     set -e
     . dials
-    conda install -y dials-data pytest-azurepipelines pytest-cov pytest-timeout
+    mamba install -y dials-data pytest-azurepipelines pytest-cov pytest-timeout
     set -ux
     dials.data info -v
     echo "##vso[task.setvariable variable=DIALS_DATA_VERSION_FULL]$(dials.data info -v | grep version.full)"
@@ -111,7 +111,7 @@ steps:
     set -e
     . dials
     rm -rf tests &  # this will be overwritten with xfel tests
-    conda install -y bash distro git-lfs mpi4py openmpi pandas
+    mamba install -y bash distro git-lfs mpi4py openmpi pandas
     cd modules
     git clone https://gitlab.com/cctbx/xfel_regression.git
     cd xfel_regression


### PR DESCRIPTION
Use Mamba in place of Conda.