### PR TITLE
dials.export: Add option to specify composition of asymmetric unit so a complete SHELX instruction file can be written.

### DIFF
--- a/newsfragments/XXX.feature
+++ b/newsfragments/XXX.feature
@@ -1,0 +1,1 @@
+``dials.export``: Add option to specify composition of asymmetric unit for SHELX ``.ins`` file output.

--- a/src/dials/command_line/export.py
+++ b/src/dials/command_line/export.py
@@ -45,6 +45,11 @@ input is an models.expt file.
 XDS format exports a models.expt file as XDS.INP and XPARM.XDS files. If a
 reflection file is given it will be exported as a SPOT.XDS file.
 
+SHELX format exports intensity data in HKLF 4 format for use in the SHELX suite
+of programs. As this file format does not contain unit cell parameters or
+symmetry information a minimal instruction file is also written. Optionally the
+expected contents of the asymmetric unit can be added to this instruciton file.
+
 PETS format exports intensity data and diffraction data in the CIF format
 used by PETS. This is primarily intended to produce files suitable for
 dynamic diffraction refinement using Jana2020, which requires this format.
@@ -72,6 +77,11 @@ Examples::
   dials.export indexed.refl format=xds
   dials.export models.expt format=xds
   dials.export models.expt indexed.refl format=xds
+
+  # Export to shelx
+  dials.export scaled.expt scaled.refl format=shelx
+  dials.export scaled.expt scaled.refl format=shelx shelx.hklout=dials.hkl
+  dials.export scaled.expt scaled.refl format=shelx composition=C3H7NO2S
 """
 
 phil_scope = parse(
@@ -249,6 +259,9 @@ phil_scope = parse(
     ins = dials.ins
       .type = path
       .help = "The output ins file"
+    composition = None
+      .type = str
+      .help = "The chemical composition of the asymmetric unit"
     scale = True
       .type = bool
       .help = "Scale reflections to maximise output precision in SHELX 8.2f format"

--- a/src/dials/util/export_shelx.py
+++ b/src/dials/util/export_shelx.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import string
 from math import isclose
 
 from cctbx import crystal, miller
@@ -96,12 +97,13 @@ def export_shelx(scaled_data, experiment_list, params):
     _write_ins(
         experiment_list,
         best_unit_cell=params.mtz.best_unit_cell,
+        composition=params.shelx.composition,
         ins_file=params.shelx.ins,
     )
     logger.info(f"Written {params.shelx.ins}")
 
 
-def _write_ins(experiment_list, best_unit_cell, ins_file):
+def _write_ins(experiment_list, best_unit_cell, composition, ins_file):
     sg = experiment_list[0].crystal.get_space_group()
     unit_cells = []
     wavelengths = []
@@ -167,3 +169,161 @@ def _write_ins(experiment_list, best_unit_cell, ins_file):
                 )
             )
         LATT_SYMM(f, sg)
+        if composition:
+            logger.info(
+                f"Using composition {composition} to write SFAC & UNIT instructions"
+            )
+            sorted_composition = _parse_compound(composition)
+            f.write("SFAC %s\n" % " ".join(sorted_composition))
+            f.write(
+                "UNIT %s\n"
+                % " ".join(
+                    [
+                        str(sorted_composition[e] * sg.order_z())
+                        for e in sorted_composition
+                    ]
+                )
+            )
+        else:
+            f.write("SFAC C\n")
+            f.write("UNIT 0\n")
+        f.write("HKLF 4\n")  # Intensities
+        f.write("END\n")
+
+
+def _parse_compound(composition):
+    """
+    Modified from parse_compund() in xia2/src/xia2/cli/to_shelx.py
+    """
+    elements = [
+        "H",
+        "He",
+        "Li",
+        "Be",
+        "B",
+        "C",
+        "N",
+        "O",
+        "F",
+        "Ne",
+        "Na",
+        "Mg",
+        "Al",
+        "Si",
+        "P",
+        "S",
+        "Cl",
+        "Ar",
+        "K",
+        "Ca",
+        "Sc",
+        "Ti",
+        "V",
+        "Cr",
+        "Mn",
+        "Fe",
+        "Co",
+        "Ni",
+        "Cu",
+        "Zn",
+        "Ga",
+        "Ge",
+        "As",
+        "Se",
+        "Br",
+        "Kr",
+        "Rb",
+        "Sr",
+        "Y",
+        "Zr",
+        "Nb",
+        "Mo",
+        "Tc",
+        "Ru",
+        "Rh",
+        "Pd",
+        "Ag",
+        "Cd",
+        "In",
+        "Sn",
+        "Sb",
+        "Te",
+        "I",
+        "Xe",
+        "Cs",
+        "Ba",
+        "La",
+        "Ce",
+        "Pr",
+        "Nd",
+        "Pm",
+        "Sm",
+        "Eu",
+        "Gd",
+        "Tb",
+        "Dy",
+        "Ho",
+        "Er",
+        "Tm",
+        "Yb",
+        "Lu",
+        "Hf",
+        "Ta",
+        "W",
+        "Re",
+        "Os",
+        "Ir",
+        "Pt",
+        "Au",
+        "Hg",
+        "Tl",
+        "Pb",
+        "Bi",
+        "Po",
+        "At",
+        "Rn",
+        "Fr",
+        "Ra",
+        "Ac",
+        "Th",
+        "Pa",
+        "U",
+        "Np",
+        "Pu",
+    ]
+    result = {}
+    element = ""
+    number = ""
+    composition += "Q"  # Not in any element symbol
+    for c in composition:
+        if c in string.ascii_uppercase:
+            if not element:
+                element += c
+                continue
+            if number == "":
+                count = 1
+            else:
+                count = int(number)
+            if element not in result:
+                if element in elements:
+                    result[element] = 0
+                else:
+                    raise Sorry(f"Element {element} in {composition} not recognised")
+            if element in elements:
+                result[element] += count
+            element = "" + c
+            number = ""
+            if c == "Q":
+                break
+        elif c in string.ascii_lowercase:
+            element += c
+        elif c in string.digits:
+            number += c
+    if "C" in result:
+        # move C to start of list
+        elements.insert(0, elements.pop(5))
+    if all(n == 1 for n in result.values()):
+        # Assume user has just supplied list of elements so UNIT instruction cannot be caluclated
+        result = result.fromkeys(result, 0)
+    sorted_result = {e: result[e] for e in elements if e in result}
+    return sorted_result


### PR DESCRIPTION
As discussed in  #2608

This PR adds the option to specify the composition of the asymmetric unit when using `format=shelx` in `dials.export`. This will allow the `.ins` file written to be used directly for SHELXT etc. The command line option is `composition`. The string from the user is parsed using a variant of `parse_compound()` from `xia2.to_shelx`

Depending on the users input one of four things happen:

1) No input. Minimal `SFAC` and `UNIT` instructions are written:
```
SFAC C
UNIT 0
```
This is hard coded and does not call the added `_parse_compound()` function. Personally I see this as the most useful option - users can always edit the `.ins` file in Olex2/ShelXle/vi etc. 

2) A list of elements is given but each element occurs only once. The list of elements is written to the `SFAC` instruction and all zeros to the `UNIT` instruction. For SHELXT this is all that is required.

3) A formula. The list of elements is written to the `SFAC` instruction and Z*the number of times each element in the formula `UNIT` instruction. For SHELXT this is not required but I think for SHELXD it is. Obviously this requires that the space group is correct before export. 

4) A formula with unknown element - an error is raised as it seems better to correct here rather than write a potentially broken `.ins` file.
