### PR TITLE
Add mesa-libGL to linux bootstrap installations

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -19,6 +19,7 @@ conda-forge::jpeg
 conda-forge::libboost-devel
 conda-forge::libboost-python-devel
 conda-forge::matplotlib-base>=3.0.2
+conda-forge::mesa-libgl-devel-cos7-x86_64
 conda-forge::mrcfile
 conda-forge::msgpack-cxx
 conda-forge::msgpack-python

--- a/newsfragments/1465.bugfix
+++ b/newsfragments/1465.bugfix
@@ -1,0 +1,1 @@
+Add mesa-libgl CDT dependency when building cctbx. This should solve build problems on RHEL8 and other distributions more modern than RHEL7.


### PR DESCRIPTION
This is to solve a longstanding issue where bootstrap builds would fail on linux systems more recent than RHEL7.

Cause:

- The conda-forge sysroot stdlib system uses `#include_next` in order to chain to a wrapped `stdlib.h`.
- gltbx adds the system `/usr/include` and `/usr/local/include` multiple times to the include search path if libgl can not be found.
- When the conda-forge sysroot stdlib tries to `#include_next`, instead of the REAL sysroot `stdlib.h`, it picks up the system `stdlib.h`.
- This worked on RHEL7- the system stdlib was old enough that it apparently didn't use this mechanism.
- Since the RHEL8 system stdlib is recent enough to use this mechanism, it thinks it is being #included twice, and so hits the usual guards.

This "System include path" was added originally to work around the fact that OpenGL is a complicated dependency and thus you need to use the library from the system. This problem can also be solved using the Conda-forge CDT system dependencies.

This should solve the issue that led to the advisory on the installation page: https://dials.github.io/documentation/installation_developer.html#modulenotfounderror-no-module-named-gltbx-gl-ext