### PR TITLE
Enable Python 3.12

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -2,7 +2,7 @@ variables:
   CACHE_VERSION: 20201102
   isPullRequest: $[startsWith(variables['Build.SourceBranch'], 'refs/pull/')]
   PYTHON_MINIMUM_VERSION: "3.9"
-  PYTHON_TESTING_VERSION: "3.11"
+  PYTHON_TESTING_VERSION: "3.12"
 
 stages:
 - stage: prepare

--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -11,11 +11,10 @@ conda-forge::eigen
 conda-forge::future
 conda-forge::gemmi>=0.6.5
 conda-forge::h5py>=3.1.0
-conda-forge::hdf5<1.13
+conda-forge::hdf5
 conda-forge::hdf5plugin
 conda-forge::iota
 conda-forge::jinja2
-conda-forge::jpeg
 conda-forge::libboost-devel
 conda-forge::libboost-python-devel
 conda-forge::matplotlib-base>=3.0.2

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -11,11 +11,10 @@ conda-forge::eigen
 conda-forge::future
 conda-forge::gemmi>=0.6.5
 conda-forge::h5py>=3.1.0
-conda-forge::hdf5<1.13
+conda-forge::hdf5
 conda-forge::hdf5plugin
 conda-forge::iota
 conda-forge::jinja2
-conda-forge::jpeg
 conda-forge::libboost-devel
 conda-forge::libboost-python-devel
 conda-forge::libcxx

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -11,11 +11,10 @@ conda-forge::eigen
 conda-forge::future
 conda-forge::gemmi>=0.6.5
 conda-forge::h5py>=3.1.0
-conda-forge::hdf5<1.13
+conda-forge::hdf5
 conda-forge::hdf5plugin
 conda-forge::iota
 conda-forge::jinja2
-conda-forge::jpeg
 conda-forge::libboost-devel
 conda-forge::libboost-python-devel
 conda-forge::matplotlib-base>=3.0.2

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -1432,7 +1432,7 @@ be passed separately with quotes to avoid confusion (e.g
     parser.add_argument(
         "--python",
         help="Install this minor version of Python (default: %(default)s)",
-        default="3.10",
+        default="3.11",
         choices=("3.9", "3.10", "3.11", "3.12"),
     )
     parser.add_argument(

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -1433,7 +1433,7 @@ be passed separately with quotes to avoid confusion (e.g
         "--python",
         help="Install this minor version of Python (default: %(default)s)",
         default="3.10",
-        choices=("3.9", "3.10", "3.11"),
+        choices=("3.9", "3.10", "3.11", "3.12"),
     )
     parser.add_argument(
         "--branch",

--- a/newsfragments/2651.feature
+++ b/newsfragments/2651.feature
@@ -1,0 +1,1 @@
+DIALS is now compatible with Python 3.12.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 
 from build import build
 
-__version_tag__ = "3.19.dev"
+__version_tag__ = "3.20.dev"
 
 setup_kwargs = {
     "name": "dials",


### PR DESCRIPTION
- Allow usage of python 3.12 in bootstrap.
- Update default bootstrap python to 3.11.
- Update missed version tag change from release.