### PR TITLE
With clustering tables

### DIFF
--- a/newsfragments/xxxx.feature
+++ b/newsfragments/xxxx.feature
@@ -1,0 +1,1 @@
+``dials.correlation_matrix``: Add tables with cluster information to html output

--- a/src/dials/algorithms/correlation/analysis.py
+++ b/src/dials/algorithms/correlation/analysis.py
@@ -125,9 +125,6 @@ class CorrelationMatrix:
 
         self.cosym_analysis = CosymAnalysis(self.datasets, self.params)
 
-        # QUERY THIS BIT WITH JAMES
-        # self.cosym_analysis.run()
-
     def _merge_intensities(self, datasets: list) -> list:
         """
         Merge intensities and elimate systematically absent reflections.
@@ -324,7 +321,7 @@ class CorrelationMatrix:
                 if merged is None:
                     merged = copy.deepcopy(d)
                 else:
-                    merged = merged.concatenate(d)
+                    merged = merged.concatenate(d, assert_is_similar_symmetry=False)
             merging = merged.merge_equivalents()
             merged_intensities = merging.array()
             multiplicities = merging.redundancies()

--- a/src/dials/algorithms/correlation/cluster.py
+++ b/src/dials/algorithms/correlation/cluster.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from libtbx.str_utils import wordwrap
+
+
+class ClusterInfo:
+    def __init__(
+        self, cluster_id, labels, multiplicity, completeness, unit_cell, height=None
+    ):
+        self.cluster_id = cluster_id
+        self.labels = labels
+        self.multiplicity = multiplicity
+        self.completeness = completeness
+        self.unit_cell = unit_cell
+        self.height = height
+
+    def __str__(self):
+        lines = [
+            "Cluster %i" % self.cluster_id,
+            "  Number of datasets: %i" % len(self.labels),
+            "  Completeness: %.1f %%" % (self.completeness * 100),
+            "  Multiplicity: %.2f" % self.multiplicity,
+            "  Datasets:" + ",".join("%s" % s for s in self.labels),
+        ]
+        if self.height is not None:
+            lines.append("  height: %f" % self.height)
+        return "\n".join(lines)
+
+    @staticmethod
+    def as_table(cluster_info):
+        headers = [
+            "Cluster",
+            "No. datasets",
+            "Datasets",
+            "Height",
+            "Multiplicity",
+            "Completeness",
+        ]
+        rows = []
+        for info in cluster_info:
+            rows.append(
+                [
+                    "%i" % info.cluster_id,
+                    "%i" % len(info.labels),
+                    wordwrap(" ".join("%s" % l for l in info.labels)),
+                    "%.2g" % info.height,
+                    "%.1f" % info.multiplicity,
+                    "%.2f" % info.completeness,
+                ]
+            )
+
+        rows.insert(0, headers)
+        return rows

--- a/src/dials/command_line/correlation_matrix.py
+++ b/src/dials/command_line/correlation_matrix.py
@@ -132,7 +132,9 @@ def run(args=None):
         html = template.stream(
             page_title="DIALS Correlation Matrix",
             cc_cluster_json=matrices.cc_json,
+            cc_cluster_table=matrices.cc_table,
             cos_angle_cluster_json=matrices.cos_json,
+            cos_angle_cluster_table=matrices.cos_table,
             image_range_tables=[matrices.table_list],
             cosym_graphs=matrices.rij_graphs,
         )

--- a/src/dials/templates/clusters.html
+++ b/src/dials/templates/clusters.html
@@ -41,6 +41,9 @@
                                     <div class="panel-body">
 
                                         <div class="container-fluid">
+                                            {{ macros.table(cc_cluster_table,
+                                                has_column_header=true,
+                                                has_row_header=true) }}
                                             {{ macros.plotly_graph("cc_cluster", cc_cluster_json, style="dendrogram-plot") }}
                                         </div>
                                     </div>
@@ -57,6 +60,9 @@
                                     <div class="panel-body">
 
                                         <div class="container-fluid">
+                                            {{ macros.table(cos_angle_cluster_table,
+                                                has_column_header=true,
+                                                has_row_header=true) }}
                                             {{ macros.plotly_graph("cos_angle_cluster", cos_angle_cluster_json, style="dendrogram-plot") }}
                                         </div>
 


### PR DESCRIPTION
Added clustering tables into the html output and migrated over the rest of the clustering code in xia2.multiplex. 

Also fixes a bug found in xia2.multiplex where the tables in the html listing all clusters were found to have incorrect multiplicity and completeness statistics (indices were shifted by 1, so while the listed cluster ids were correct, the statistics were calculated based on different dataset ids).