### PR TITLE
Add MCD outlier rejection to stills

### DIFF
--- a/src/dials/algorithms/indexing/indexer.py
+++ b/src/dials/algorithms/indexing/indexer.py
@@ -330,7 +330,11 @@ class Indexer:
             "auto",
             libtbx.Auto,
         ):
-            if self.experiments[0].goniometer is None:
+            if (
+                self.experiments[0].goniometer is None
+                or self.experiments[0].scan is None
+                or self.experiments[0].scan.is_still()
+            ):
                 self.all_params.refinement.reflections.outlier.algorithm = "sauter_poon"
             else:
                 # different default to dials.refine

--- a/src/dials/algorithms/indexing/stills_indexer.py
+++ b/src/dials/algorithms/indexing/stills_indexer.py
@@ -64,13 +64,11 @@ def plot_displacements(reflections, predictions, experiments):
 
 
 def e_refine(params, experiments, reflections, graph_verbose=False):
-    # Stills-specific parameters we always want
-    assert params.refinement.reflections.outlier.algorithm in (
-        None,
-        "null",
-    ), "Cannot index, set refinement.reflections.outlier.algorithm=null"  # we do our own outlier rejection
-
     from dials.algorithms.refinement.refiner import RefinerFactory
+
+    outlier_algorithm = params.refinement.reflections.outlier.algorithm
+    if outlier_algorithm == "sauter_poon":
+        params.refinement.reflections.outlier.algorithm = "null"
 
     refiner = RefinerFactory.from_parameters_data_experiments(
         params, reflections, experiments
@@ -78,8 +76,7 @@ def e_refine(params, experiments, reflections, graph_verbose=False):
 
     refiner.run()
 
-    ref_sel = refiner.selection_used_for_refinement()
-    assert ref_sel.count(True) == len(reflections)
+    params.refinement.reflections.outlier.algorithm = outlier_algorithm
 
     if not graph_verbose:
         return refiner
@@ -95,8 +92,7 @@ class StillsIndexer(Indexer):
 
     def __init__(self, reflections, experiments, params=None):
         if params.refinement.reflections.outlier.algorithm in ("auto", libtbx.Auto):
-            # The stills_indexer provides its own outlier rejection
-            params.refinement.reflections.outlier.algorithm = "null"
+            params.refinement.reflections.outlier.algorithm = "sauter_poon"
         super().__init__(reflections, experiments, params)
         self.warn_if_setting_unused_refinement_protocol_params()
 
@@ -200,7 +196,6 @@ class StillsIndexer(Indexer):
                 isoform_experiments = ExperimentList()
                 isoform_reflections = flex.reflection_table()
                 # Note, changes to params after initial indexing. Cannot use tie to target when fixing the unit cell.
-                self.all_params.refinement.reflections.outlier.algorithm = "null"
                 self.all_params.refinement.parameterisation.crystal.fix = "cell"
                 self.all_params.refinement.parameterisation.crystal.unit_cell.restraints.tie_to_target = (
                     []
@@ -702,6 +697,9 @@ class StillsIndexer(Indexer):
         refiner = e_refine(params, experiments, indexed, graph_verbose=False)
 
         RR = refiner.predict_for_reflection_table(indexed)
+
+        if params.refinement.reflections.outlier.algorithm != "sauter_poon":
+            return refiner.selection_used_for_refinement()
 
         px_sz = experiments[0].detector[0].get_pixel_size()
 

--- a/src/dials/algorithms/refinement/outlier_detection/mcd.py
+++ b/src/dials/algorithms/refinement/outlier_detection/mcd.py
@@ -27,6 +27,7 @@ class MCD(CentroidOutlier):
         k2=2,
         k3=100,
         threshold_probability=0.975,
+        coordinates="xy",
     ):
 
         if cols is None:

--- a/src/dials/algorithms/refinement/outlier_detection/outlier_base.py
+++ b/src/dials/algorithms/refinement/outlier_detection/outlier_base.py
@@ -402,9 +402,10 @@ outlier
             "doi.org/10.1080/00401706.1999.10485670."
     .expert_level = 1
   {
-     coordinates = *xy radial_transverse
-       .help = "Whether to use xy spot coordinates or radial/transverse spot"
-               "coordinates, relative to the beam vector"
+     coordinates = *xy radial_transverse deltatt_transverse
+       .help = "Whether to use xy spot coordinates in image space,"
+               "radial/transverse spot coordinates relative to the beam"
+               "vector, or a mix of delta two theta and transverse coordinates"
        .type = choice
      alpha = 0.5
        .help = "Decimal fraction controlling the size of subsets over which the"

--- a/src/dials/algorithms/refinement/outlier_detection/outlier_base.py
+++ b/src/dials/algorithms/refinement/outlier_detection/outlier_base.py
@@ -402,6 +402,10 @@ outlier
             "doi.org/10.1080/00401706.1999.10485670."
     .expert_level = 1
   {
+     coordinates = *xy radial_transverse
+       .help = "Whether to use xy spot coordinates or radial/transverse spot"
+               "coordinates, relative to the beam vector"
+       .type = choice
      alpha = 0.5
        .help = "Decimal fraction controlling the size of subsets over which the"
                "covariance matrix determinant is minimised."

--- a/src/dials/algorithms/refinement/refinement_helpers.py
+++ b/src/dials/algorithms/refinement/refinement_helpers.py
@@ -313,3 +313,40 @@ def set_obs_s1(reflections, experiments):
             s1 = s1 / s1.norms() * (1 / beam.get_wavelength())
             reflections["s1"].set_selected(isel, s1)
     return nrefs_wo_s1
+
+
+def compute_radial_and_transverse_residuals(experiments, reflections):
+    """Compute radial and transverse residuals, relative to the beam center"""
+    beam_centre_lab = flex.vec3_double(len(reflections))
+    obs_lab_coords = flex.vec3_double(len(reflections))
+    delta_lab_coords = flex.vec3_double(len(reflections))
+    for expt_id, expt in enumerate(experiments):
+        s0 = expt.beam.get_s0()
+        for panel_id, panel in enumerate(expt.detector):
+            sel = (reflections["id"] == expt_id) & (reflections["panel"] == panel_id)
+            refls = reflections.select(sel)
+
+            # Compute the beam center in lab space (a vector pointing from the origin to where the beam would intersect
+            # the panel, if it did intersect the panel)
+            beam_centre = panel.get_beam_centre_lab(s0)
+            beam_centre_lab.set_selected(sel, flex.vec3_double(len(refls), beam_centre))
+
+            # Compute obs in lab space
+            x, y, _ = refls["xyzobs.mm.value"].parts()
+            c = flex.vec2_double(x, y)
+            obs_lab_coords.set_selected(sel, panel.get_lab_coord(c))
+
+            # Compute deltaXY in panel space. This vector is relative to the panel origin
+            x, y, _ = (refls["xyzcal.mm"] - refls["xyzobs.mm.value"]).parts()
+            # Convert deltaXY to lab space, subtracting off the panel origin
+            delta_lab_coords.set_selected(
+                sel, panel.get_lab_coord(flex.vec2_double(x, y)) - panel.get_origin()
+            )
+
+    # The radial vector points from the center of the reflection to the beam center
+    radial_vectors = (obs_lab_coords - beam_centre_lab).each_normalize()
+    # The transverse vector is orthogonal to the radial vector and the beam vector
+    transverse_vectors = radial_vectors.cross(beam_centre_lab).each_normalize()
+    # Compute the raidal and transverse components of each deltaXY
+    reflections["r_resid"] = delta_lab_coords.dot(radial_vectors)
+    reflections["t_resid"] = delta_lab_coords.dot(transverse_vectors)

--- a/src/dials/algorithms/refinement/refiner.py
+++ b/src/dials/algorithms/refinement/refiner.py
@@ -391,9 +391,14 @@ class RefinerFactory:
         if (
             params.refinement.reflections.outlier.algorithm == "mcd"
             and params.refinement.reflections.outlier.mcd.coordinates
-            == "radial_transverse"
+            in ("radial_transverse", "deltatt_transverse")
         ):
-            compute_radial_and_transverse_residuals(experiments, obs)
+            compute_radial_and_transverse_residuals(
+                experiments,
+                obs,
+                two_theta=params.refinement.reflections.outlier.mcd.coordinates
+                == "deltatt_transverse",
+            )
 
         # determine whether to do basic centroid analysis to automatically
         # determine outlier rejection block

--- a/src/dials/algorithms/refinement/refiner.py
+++ b/src/dials/algorithms/refinement/refiner.py
@@ -29,7 +29,11 @@ from dials.algorithms.refinement.parameterisation.parameter_report import (
 from dials.algorithms.refinement.prediction.managed_predictors import (
     ExperimentsPredictorFactory,
 )
-from dials.algorithms.refinement.refinement_helpers import ordinal_number, string_sel
+from dials.algorithms.refinement.refinement_helpers import (
+    ordinal_number,
+    string_sel,
+    compute_radial_and_transverse_residuals,
+)
 from dials.algorithms.refinement.reflection_manager import ReflectionManagerFactory
 from dials.algorithms.refinement.reflection_manager import (
     phil_str as reflections_phil_str,
@@ -383,6 +387,13 @@ class RefinerFactory:
         obs["x_resid"] = x_calc - x_obs
         obs["y_resid"] = y_calc - y_obs
         obs["phi_resid"] = phi_calc - phi_obs
+
+        if (
+            params.refinement.reflections.outlier.algorithm == "mcd"
+            and params.refinement.reflections.outlier.mcd.coordinates
+            == "radial_transverse"
+        ):
+            compute_radial_and_transverse_residuals(experiments, obs)
 
         # determine whether to do basic centroid analysis to automatically
         # determine outlier rejection block

--- a/src/dials/algorithms/refinement/reflection_manager.py
+++ b/src/dials/algorithms/refinement/reflection_manager.py
@@ -265,11 +265,18 @@ class ReflectionManagerFactory:
         if params.outlier.algorithm in ("null", None):
             outlier_detector = None
         else:
-            if do_stills:
+            if (
+                params.outlier.algorithm == "mcd"
+                and params.outlier.mcd.coordinates == "radial_transverse"
+            ):
+                colnames = ["r_resid", "t_resid"]
+            else:
                 colnames = ["x_resid", "y_resid"]
+            if do_stills:
+                colnames.append("delpsical.rad")
                 params.outlier.block_width = None
             else:
-                colnames = ["x_resid", "y_resid", "phi_resid"]
+                colnames.append("phi_resid")
             from dials.algorithms.refinement.outlier_detection import (
                 CentroidOutlierFactory,
             )

--- a/src/dials/algorithms/refinement/reflection_manager.py
+++ b/src/dials/algorithms/refinement/reflection_manager.py
@@ -270,6 +270,11 @@ class ReflectionManagerFactory:
                 and params.outlier.mcd.coordinates == "radial_transverse"
             ):
                 colnames = ["r_resid", "t_resid"]
+            elif (
+                params.outlier.algorithm == "mcd"
+                and params.outlier.mcd.coordinates == "deltatt_transverse"
+            ):
+                colnames = ["twotheta_resid", "t_resid"]
             else:
                 colnames = ["x_resid", "y_resid"]
             if do_stills:

--- a/src/dials/command_line/ssx_index.py
+++ b/src/dials/command_line/ssx_index.py
@@ -72,7 +72,6 @@ refinement {
   }
   reflections {
     weighting_strategy.override = stills
-    outlier.algorithm = null
   }
 }
 """

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -318,7 +318,6 @@ refinement {
   }
   reflections {
     weighting_strategy.override = stills
-    outlier.algorithm = null
   }
 }
 integration {


### PR DESCRIPTION
This is a reworking of outlier rejection for indexing and refinement for stills, including in dials.stills_process and the stills indexer.  The stills indexer has used sauter_poon since its inception, but was never really the right answer for the problem at it assumes it is removing non-systematic error.  However, still images from e.g. XFEL data come from a wider bandpass and therefore have a systematic radial displacement compared to transverse.  This is visible in detector residuals in the deltaXY/deltaPsi plot:

![image](https://github.com/dials/dials/assets/13471434/772f2ee5-440d-4d06-8fe8-3ea8eec9782c)

```
export TEST_DATA=`dials.data get -q iterative_cspad_refinement`
cctbx.xfel.detector_residuals $TEST_DATA/cspad_ref* colormap=RdYlBu_r tag=cspad_refined delta_scalar=25 
```

In this plot the displacement of the prediction from the observation of every spot is shown relative to the center of the panel, exaggerated by a factor of 25, with the color being the deltaPsi value.  This is typical of XFEL data.

sauter_poon works great for monochromatic systems, but here it truncates out the caps of the data, because those spots are too widely displaced from their predictions:

```
dials.refine $TEST_DATA/refine.phil $TEST_DATA/cspad_ref*
cctbx.xfel.detector_residuals refined.* colormap=RdYlBu_r tag=cspad_refined2 delta_scalar=25 
```

Output:
```
Detecting centroid outliers using the SauterPoon algorithm
16036 reflections have been flagged as outliers
90465 reflections remain in the manager

```

![image](https://github.com/dials/dials/assets/13471434/3dc69ad9-581b-4066-8d0a-86ee54c9f849)

The new code allows refining using MCD, adding new coordinates for fitting an ellipsoid that better fits serial data with a band pass and a flat detector:

```
dials.refine $TEST_DATA/refine.phil $TEST_DATA/cspad_ref* refinement.reflections.outlier.algorithm=mcd mcd.threshold_probability=0.999 mcd.coordinates=deltatt_transverse
cctbx.xfel.detector_residuals refined.* colormap=RdYlBu_r tag=cspad_refined3 delta_scalar=25 
```

Output:
```
Detecting centroid outliers using the MCD algorithm
10374 reflections have been flagged as outliers
96127 reflections remain in the manager
```

![image](https://github.com/dials/dials/assets/13471434/64fdcc73-e2fb-416c-a8ba-5bb28ff20dce)

So fewer outliers are rejected, and the remaining reflections better fit the expected distribution.

The choice of MCD coordinates is now available through the new parameter: `coordinates = *xy radial_transverse deltatt_transverse`:
- xy: this is the current default: x_resid and y_resid.
- radial_transverse: this uses the radial displacement and transverse displacements of predictions from the observations, as computed in lab space relative to the beam vector.  This puts the data in a common frame, independent of the azimuthal angle of the reflection around the beam, as the radial component is always pointed at the beam center and the transverse is orthogonal to that vector.  The columns are named r_resid and t_resid.
- deltatt_transverse: this uses delta two theta instead of the radial displacement for one of the coordinates, keeping the transverse displacement.  This compacts the ellipsoid at high resolution, eliminating a resolution dependent effect from parallax that arises from using a flat detector.  The column is named twotheta_resid.

Additionally, deltaPsi is added as a coordinate for stills using mcd, formally it was only x_resid and y_resid.  This is the only change that could affect existing stills processing using mcd already without using the new coordinates parameter.

This PR also eliminates the assertions that sauter_poon is being used in the stills indexer, which means the default for dials.stills_process and for dials.ssx_index needs to be changed from null to sauter_poon.  Updating them further to be mcd should likely happen as well, after further review of these changes.

More detail on the changes:

- Add helper function compute_radial_and_transverse_residuals, adapted from cctbx.xfel.detector_residuals
- Add delpsical.rad as a data dimension for mcd for stills
- Add parameter mcd.coordinates = *xy radial_transverse, which chooses between x_resid/y_resid and r_resid/t_resid
- Use is_still when picking outlier algorithm from auto
- Allow stills_process and ssx_index to chose non-sauter_poon options, which means also updating their defaults from null to sauter_poon.
- Add alternate mcd coordinate axis: delta two theta