### PR TITLE
Allow bootstrap to build release branches with CMake

### DIFF
--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -847,17 +847,12 @@ def update_sources(options):
                 ("xia2/xia2", "main"),
             )
         }
-        if options.prebuilt_cctbx:
-            repositories["cctbx_project"]["branch-local"] = (
-                "releases/" + _prebuilt_cctbx_base
-            )
-        else:
-            repositories["cctbx_project"] = {
-                "base-repository": "cctbx/cctbx_project",
-                "effective-repository": "dials/cctbx",
-                "branch-remote": "master",
-                "branch-local": "stable",
-            }
+        repositories["cctbx_project"] = {
+            "base-repository": "cctbx/cctbx_project",
+            "effective-repository": "dials/cctbx",
+            "branch-remote": "master",
+            "branch-local": "stable",
+        }
     else:
         # Only what we need for CMake
         repositories = {

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -952,10 +952,10 @@ def run_tests():
     )
 
 
-def refresh_build(prebuilt_cctbx):
+def refresh_build():
     print("Running libtbx.refresh")
     run_indirect_command(
-        "libtbx.refresh" if prebuilt_cctbx else os.path.join("bin", "libtbx.refresh"),
+        os.path.join("bin", "libtbx.refresh"),
         args=[],
     )
 
@@ -1101,7 +1101,7 @@ add_subdirectory(dials)
     )
 
 
-def configure_build(config_flags, prebuilt_cctbx):
+def configure_build(config_flags):
     conda_python = _get_base_python()
 
     # write a new-style environment setup script
@@ -1119,12 +1119,6 @@ def configure_build(config_flags, prebuilt_cctbx):
         config_flags.append("--cxxstd=c++14")
 
     print("Setting up build directory")
-    if prebuilt_cctbx:
-        run_indirect_command(
-            command="libtbx.configure",
-            args=["cbflib", "dials", "dxtbx", "prime", "xia2"],
-        )
-        return
 
     configcmd = [
         os.path.join("..", "modules", "cctbx_project", "libtbx", "configure.py"),
@@ -1152,20 +1146,16 @@ def configure_build(config_flags, prebuilt_cctbx):
     )
 
 
-def make_build(prebuilt_cctbx):
+def make_build():
     try:
         nproc = len(os.sched_getaffinity(0))
     except AttributeError:
         nproc = multiprocessing.cpu_count()
-    if prebuilt_cctbx:
-        command = "libtbx.scons"
-    else:
-        command = os.path.join("bin", "libtbx.scons")
+    command = os.path.join("bin", "libtbx.scons")
 
     run_indirect_command(command, args=["-j", str(nproc)])
-    if not prebuilt_cctbx:
-        # run build again to make sure everything is built
-        run_indirect_command(command, args=["-j", str(nproc)])
+    # run build again to make sure everything is built
+    run_indirect_command(command, args=["-j", str(nproc)])
 
 
 def make_build_cmake():
@@ -1297,9 +1287,9 @@ be passed separately with quotes to avoid confusion (e.g
             configure_build_cmake()
             make_build_cmake()
         else:
-            configure_build(options.config_flags, prebuilt_cctbx=options.prebuilt_cctbx)
-            make_build(prebuilt_cctbx=options.prebuilt_cctbx)
-            refresh_build(prebuilt_cctbx=options.prebuilt_cctbx)
+            configure_build(options.config_flags)
+            make_build()
+            refresh_build()
         install_precommit(options.cmake)
 
     # Tests, tests

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -174,7 +174,15 @@ def install_micromamba(python, cmake):
     ]
     extra_deps = []
     if cmake:
-        extra_deps = ["cctbx-base=" + _prebuilt_cctbx_base, "pycbf", "cmake"]
+        extra_deps = [
+            "cctbx-base=" + _prebuilt_cctbx_base,
+            "pycbf",
+            "cmake",
+            "pre-commit",
+        ]
+        if _prebuilt_cctbx_base == "2024.7":
+            # Known minor incompatibility causes this to otherwise be removed
+            extra_deps.append("libboost-python-devel")
         # If we're running from an explicit requirements file, then we
         # need to install extra dependencies in a separate stage
         with open(filename) as dep_file:
@@ -183,10 +191,6 @@ def install_micromamba(python, cmake):
         if not is_explicit_reqs:
             command_list.extend(extra_deps)
             extra_deps = []
-
-    if os.name == "nt":
-        # Installing pre-commit via precommittbx does not work on windows
-        command_list.append("pre-commit")
 
     print(
         "{text} dials environment from {filename} with Python {python}".format(
@@ -207,7 +211,6 @@ def install_micromamba(python, cmake):
             mamba_prefix,
             "install",
             "--yes",
-            "--freeze-installed",
             "--channel",
             "conda-forge",
             "--override-channels",

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -172,13 +172,14 @@ def install_micromamba(python, cmake):
         "mamba",
         python_requirement,
     ]
+    extra_deps = []
     if cmake:
+        extra_deps = ["cctbx-base=" + _prebuilt_cctbx_base, "pycbf", "cmake"]
         # If we're running from an explicit requirements file, then we
         # need to install extra dependencies in a separate stage
         with open(filename) as dep_file:
             is_explicit_reqs = "@EXPLICIT" in dep_file.read()
 
-        extra_deps = ["cctbx-base=" + _prebuilt_cctbx_base, "pycbf", "cmake"]
         if not is_explicit_reqs:
             command_list.extend(extra_deps)
             extra_deps = []
@@ -206,6 +207,7 @@ def install_micromamba(python, cmake):
             mamba_prefix,
             "install",
             "--yes",
+            "--freeze-installed",
             "--channel",
             "conda-forge",
             "--override-channels",

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -61,7 +61,7 @@ def make_executable(filepath):
         os.chmod(filepath, mode)
 
 
-def install_micromamba(python, include_cctbx, cmake):
+def install_micromamba(python, cmake):
     """Download and install Micromamba"""
     if sys.platform.startswith("linux"):
         conda_platform = "linux"
@@ -145,10 +145,10 @@ def install_micromamba(python, include_cctbx, cmake):
         "mamba",
         python_requirement,
     ]
-    if include_cctbx or cmake:
-        command_list.append("cctbx-base=" + _prebuilt_cctbx_base)
     if cmake:
+        command_list.append("cctbx-base=" + _prebuilt_cctbx_base)
         command_list.extend(["pycbf", "cmake"])
+
     if os.name == "nt":
         # Installing pre-commit via precommittbx does not work on windows
         command_list.append("pre-commit")
@@ -232,7 +232,7 @@ def install_miniconda(location):
     run_command(command=command, workdir=".")
 
 
-def install_conda(python, include_cctbx, cmake):
+def install_conda(python, cmake):
     # Find relevant conda base installation
     conda_base = os.path.realpath("miniconda")
     if os.name == "nt":
@@ -341,10 +341,10 @@ environments exist and are working.
         "--override-channels",
         python_requirement,
     ]
-    if include_cctbx or cmake:
-        command_list.append("cctbx-nightly::cctbx-base=" + _prebuilt_cctbx_base)
     if cmake:
+        command_list.append("cctbx-nightly::cctbx-base=" + _prebuilt_cctbx_base)
         command_list.extend(["pycbf", "cmake", "pre-commit"])
+
     if os.name == "nt":
         command_list = [
             "cmd.exe",
@@ -1453,14 +1453,6 @@ be passed separately with quotes to avoid confusion (e.g
         action="store_true",
     )
     parser.add_argument(
-        # Use the conda-forge cctbx package instead of compiling cctbx from scratch
-        # This is not currently supported outside of CI builds
-        "--prebuilt-cctbx",
-        help=argparse.SUPPRESS,
-        default=False,
-        action="store_true",
-    )
-    parser.add_argument(
         "--cmake",
         help="Use the CMake build system. Implies --prebuilt-cctbx.",
         action="store_true",
@@ -1479,7 +1471,6 @@ be passed separately with quotes to avoid confusion (e.g
         if options.conda:
             install_conda(
                 options.python,
-                include_cctbx=options.prebuilt_cctbx,
                 cmake=options.cmake,
             )
             if options.clean:
@@ -1487,7 +1478,6 @@ be passed separately with quotes to avoid confusion (e.g
         else:
             install_micromamba(
                 options.python,
-                include_cctbx=options.prebuilt_cctbx,
                 cmake=options.cmake,
             )
             if options.clean:


### PR DESCRIPTION
This failed before, because the dependency list was "explicit" and conda ignores additional package specs for that case.

Strip out the old tbx-build prebuilt-cctbx handling, as it was always somewhat broken and only supported in CI (which we use the CMake build for now).