### PR TITLE
Correctly filter outliers during stills refinement in the indexer?

### DIFF
--- a/src/dials/algorithms/indexing/stills_indexer.py
+++ b/src/dials/algorithms/indexing/stills_indexer.py
@@ -781,6 +781,9 @@ class StillsIndexer(Indexer):
         )
         ref_experiments = R.get_experiments()
 
+        acceptance_flags = flex.bool(reflections.size(), False)
+        acceptance_flags.set_selected(R.get_matches()["iobs"], True)
+
         nv = NaveParameters(
             params=self.all_params,
             experiments=ref_experiments,
@@ -789,6 +792,7 @@ class StillsIndexer(Indexer):
             graph_verbose=False,
         )
         nv()
+        acceptance_flags_nv1 = nv.nv_acceptance_flags
         rmsd, _ = calc_2D_rmsd_and_displacements(
             R.predict_for_reflection_table(reflections)
         )
@@ -810,6 +814,8 @@ class StillsIndexer(Indexer):
                 exp.crystal.set_half_mosaicity_deg(
                     self.all_params.indexing.stills.set_mosaic_half_deg_value
                 )
+
+        reflections = reflections.select(acceptance_flags_nv1 & acceptance_flags)
 
         return ref_experiments, reflections
 


### PR DESCRIPTION
Hi @phyy-nx , this is a PR into your mcd_stills branch of something I think is missing in terms of filtering out the outliers. You see similar code to this above after the first time of Nave refinement.

This solves my issues that I found when reviewing your PR, here is a small dataset to reproduce the problem:

[split_9.zip](https://github.com/user-attachments/files/17165177/split_9.zip)

`dials.ssx_index outlier.algorithm=mcd split_9.{expt,refl} unit_cell=96,96,96,90,90,90 space_group=P213 -vv`

Before this change:
```
Image 1: Indexed 52/138 spots with real_space_grid_search method.

Summary of images successfully indexed
+----------------------+-----------+----------------+----------+----------+-------------+
| Image                |   expt_id | n_indexed      |   RMSD X |   RMSD Y |   RMSD dPsi |
|----------------------+-----------+----------------+----------+----------+-------------|
| merlin0047_17009.cbf |         0 | 52/138 (37.7%) |  227.912 |  353.136 |   0.0321698 |
+----------------------+-----------+----------------+----------+----------+-------------+
52 spots indexed on 1 images
```
With this change
```
Image 1: Indexed 45/138 spots with real_space_grid_search method.

Summary of images successfully indexed
+----------------------+-----------+----------------+----------+----------+-------------+
| Image                |   expt_id | n_indexed      |   RMSD X |   RMSD Y |   RMSD dPsi |
|----------------------+-----------+----------------+----------+----------+-------------|
| merlin0047_17009.cbf |         0 | 45/138 (32.6%) |  0.38933 | 0.227429 |   0.0271457 |
+----------------------+-----------+----------------+----------+----------+-------------+
45 spots indexed on 1 images
```

