### PR TITLE
Fix pint dependency error causing failures

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -8,6 +8,7 @@ cxx-compiler
 dials-data>=2.4.72
 docutils
 eigen
+flexparser<0.4
 future
 gemmi>=0.6.5
 h5py>=3.1.0

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -8,6 +8,7 @@ cxx-compiler
 dials-data>=2.4.72
 docutils
 eigen
+flexparser<0.4
 future
 gemmi>=0.6.5
 h5py>=3.1.0

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -8,6 +8,7 @@ cxx-compiler
 dials-data>=2.4.72
 docutils
 eigen
+flexparser<0.4
 future
 gemmi>=0.6.5
 h5py>=3.1.0

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           OS="$(python -c "print('${{ runner.os }}'.lower())")"
           echo "ninja
+          flexparser<0.4
           pytest-md
           dials-data
           pytest-cov
@@ -87,6 +88,7 @@ jobs:
         run: |
           echo "pytest-md
           dials-data
+          flexparser<0.4
           pytest-cov
           pytest-timeout" >> modules/dials/.conda-envs/linux.txt
           python modules/dials/installer/bootstrap.py update base \

--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Fix CI dependency error causing test failures.


### PR DESCRIPTION
See https://github.com/hgrecco/pint/issues/1969#issuecomment-2461585046 - flexparser (a pint dependency) had a new release incompatible with the currently released version of pint, and this is causing test failures.