### PR TITLE
Local indexing exp ids fix

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+``dials.index``: fix inconsistent experiment IDs after indexing with ``index_assignment.method=local``


### PR DESCRIPTION
This makes the `__call__` method of `AssignIndicesLocal` more like that in `AssignIndicesGlobal`. In particular, it ensures experiment IDs are set consistently, which `AssignIndicesGlobal` did, but `AssignIndicesLocal` did not.

There is also now a loop over imagesets in `AssignIndicesLocal`, which was not there before. I don't know if that was intentional.

There is plenty of code duplication between these classes. Perhaps this is due a refactor. It may also be worth adding a test for #2757. I want to see if CI passes first...