### PR TITLE
`dials.ssx integrate`: do not write out zero length reflection list

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+``dials.ssx_integrate``: do not output a reflection file if no reflections were integrated.

--- a/src/dials/command_line/ssx_integrate.py
+++ b/src/dials/command_line/ssx_integrate.py
@@ -497,10 +497,15 @@ def run(args: List[str] = None, phil=working_phil) -> None:
             int_expt = elist
         reflections_filename = f"integrated_{i+1}.refl"
         experiments_filename = f"integrated_{i+1}.expt"
-        logger.info(f"Saving {int_refl.size()} reflections to {reflections_filename}")
-        int_refl.as_file(reflections_filename)
-        logger.info(f"Saving the experiments to {experiments_filename}")
-        int_expt.as_file(experiments_filename)
+        if int_refl.size() > 0:
+            logger.info(
+                f"Saving {int_refl.size()} reflections to {reflections_filename}"
+            )
+            int_refl.as_file(reflections_filename)
+            logger.info(f"Saving the experiments to {experiments_filename}")
+            int_expt.as_file(experiments_filename)
+        else:
+            logger.info("No reflections integrated")
 
         integrated_crystal_symmetries.extend(
             [


### PR DESCRIPTION
If no reflections were integrated, we do not want `.{expt,refl}` output.