### PR TITLE
Use unbiased formula for the standard error of the pearson correlation in cosym.

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``dials.cosym``: Use unbiased formula for standard error

--- a/src/dials/algorithms/symmetry/cosym/__init__.py
+++ b/src/dials/algorithms/symmetry/cosym/__init__.py
@@ -93,7 +93,7 @@ weights = count standard_error
   .help = "If not None, a weights matrix is used in the cosym procedure."
           "weights=count uses the number of reflections used to calculate a pairwise correlation coefficient as its weight"
           "weights=standard_error uses the reciprocal of the standard error as the weight. The standard error is given by"
-          "(1-CC*2)/sqrt(n-2), where (n-2) are the degrees of freedom in a pairwise CC calculation."
+          "(1-CC*2)/sqrt(N), where N=(n-2) or N=(neff-1) depending on the cc_weights option."
 cc_weights = None sigma
   .type = choice
   .help = "If not None, a weighted cc-half formula is used for calculating pairwise correlation coefficients and degrees of"

--- a/src/dials/algorithms/symmetry/cosym/__init__.py
+++ b/src/dials/algorithms/symmetry/cosym/__init__.py
@@ -93,7 +93,7 @@ weights = count standard_error
   .help = "If not None, a weights matrix is used in the cosym procedure."
           "weights=count uses the number of reflections used to calculate a pairwise correlation coefficient as its weight"
           "weights=standard_error uses the reciprocal of the standard error as the weight. The standard error is given by"
-          "the sqrt of (1-CC*2)/(n-2), where (n-2) are the degrees of freedom in a pairwise CC calculation."
+          "(1-CC*2)/sqrt(n-2), where (n-2) are the degrees of freedom in a pairwise CC calculation."
 cc_weights = None sigma
   .type = choice
   .help = "If not None, a weighted cc-half formula is used for calculating pairwise correlation coefficients and degrees of"

--- a/src/dials/algorithms/symmetry/cosym/target.py
+++ b/src/dials/algorithms/symmetry/cosym/target.py
@@ -179,8 +179,9 @@ class Target:
             is to use no weights. If "count" is set, then weights are equal to the
             number of pairs of reflections used in calculating each value of the
             rij matrix. If "standard_error" is used, then weights are defined as
-            :math:`w_{ij} = 1/s`, where :math:`s = \sqrt{(1-r_{ij}^2)/(n-2)}`.
-            See also http://www.sjsu.edu/faculty/gerstman/StatPrimer/correlation.pdf.
+            :math:`w_{ij} = 1/s`, where :math:`s = (1-r_{ij}^2)/sqrt(N)`.
+            Where N=(n-2) or N=(neff-1) depending on the cc_weights option.
+            See also  https://doi.org/10.1525/collabra.87615.
           min_pairs (int): Only calculate the correlation coefficient between two
             datasets if they have more than `min_pairs` of common reflections.
           lattice_group (cctbx.sgtbx.space_group): Optionally set the lattice

--- a/src/dials/algorithms/symmetry/cosym/target.py
+++ b/src/dials/algorithms/symmetry/cosym/target.py
@@ -338,7 +338,7 @@ class Target:
                 # but approches 1 in the limit, so rather say efective sample size
                 # for standard error calc is n-1
                 sel = np.where(wij_matrix > 1)
-                se = np.sqrt((1 - np.square(rij_matrix[sel])) / (wij_matrix[sel] - 1))
+                se = (1 - np.square(rij_matrix[sel])) / np.sqrt(wij_matrix[sel] - 1)
                 wij_matrix = np.zeros_like(rij_matrix)
                 wij_matrix[sel] = 1 / se
 
@@ -443,8 +443,8 @@ class Target:
                 # corresponding correlation coefficient
                 # http://www.sjsu.edu/faculty/gerstman/StatPrimer/correlation.pdf
                 with np.errstate(divide="ignore", invalid="ignore"):
-                    reciprocal_se = np.sqrt(
-                        (wij[right_up] - 2) / (1 - np.square(rij[right_up]))
+                    reciprocal_se = np.sqrt((wij[right_up] - 2)) / (
+                        1 - np.square(rij[right_up])
                     )
 
                 wij[right_up] = np.where(wij[right_up] > 2, reciprocal_se, 0)

--- a/tests/algorithms/symmetry/cosym/test_cosym_target.py
+++ b/tests/algorithms/symmetry/cosym/test_cosym_target.py
@@ -50,5 +50,5 @@ def test_cosym_target(space_group):
         g = t.compute_gradients(minimizer.coords)
         g_fd = t.compute_gradients_fd(minimizer.coords)
         assert f < f0
-        assert pytest.approx(g, abs=1e-3) == [0] * len(g)
-        assert pytest.approx(g_fd, abs=1e-3) == [0] * len(g)
+        assert pytest.approx(list(g), abs=3e-3) == [0] * len(g)
+        assert pytest.approx(g_fd, abs=3e-3) == [0] * len(g)


### PR DESCRIPTION
Use a standard error formula of the form se = (1-r^2) / sqrt(N), as opposed to se = sqrt((1-r^2) / N), which is biased.

See e.g. https://doi.org/10.1525/collabra.87615