### PR TITLE
Fix trusted range mask display bug when viewing stacked images

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+``dials.image_viewer``: Fix display bug with the trusted range mask when viewed stacked images.

--- a/src/dials/util/image_viewer/spotfinder_frame.py
+++ b/src/dials/util/image_viewer/spotfinder_frame.py
@@ -1096,6 +1096,11 @@ class SpotFrame(XrayFrame):
         if self.params.stack_images > 1:
             self.settings.display = "image"
             image = self.pyslip.tiles.raw_image
+
+            # This clears the cached image data in chooser_wrapper and forces image reload
+            # See https://github.com/dials/dials/issues/2174
+            image.set_image_data(None)
+
             image_data = image.get_image_data()
             if not isinstance(image_data, tuple):
                 image_data = (image_data,)


### PR DESCRIPTION
Simple fix for #2174 thanks to @biochem-fan 