### PR TITLE
Avoid `FutureWarning` in test

### DIFF
--- a/newsfragments/xxx.misc
+++ b/newsfragments/xxx.misc
@@ -1,0 +1,1 @@
+Avoid a ``FutureWarning`` in ``test_scaler.py``

--- a/tests/algorithms/scaling/test_scaler.py
+++ b/tests/algorithms/scaling/test_scaler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, Mock
 
+import numpy as np
 import pytest
 
 from dxtbx import flumpy
@@ -30,7 +31,7 @@ from dials.util.options import ArgumentParser
 def side_effect_update_var(variances, intensities):
     """Side effect to mock configure reflection table
     call during initialisation."""
-    return flex.double(range(1, len(variances) + 1))
+    return np.arange(1, len(variances) + 1)
 
 
 @pytest.fixture


### PR DESCRIPTION
```
pytest --regression -s -W error::FutureWarning tests/algorithms/scaling/test_scaler.py::test_update_error_model
```
fails with
```
FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '<scitbx_array_family_flex_ext.double object at 0x7f33849ee440>' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
```

It seems this is an artefact of a `MagicMock` used in the tests. Changing this to return a `numpy` array fixes the issue.