### PR TITLE
dials.integrate - add a specialised inflight integrator to overcome high memory usage

### DIFF
--- a/src/dials/algorithms/background/glm/creator.h
+++ b/src/dials/algorithms/background/glm/creator.h
@@ -20,7 +20,6 @@
 #include <dials/model/data/image_volume.h>
 #include <dials/error.h>
 #include <unordered_map>
-#include <iostream>
 
 namespace dials { namespace algorithms {
 
@@ -276,7 +275,6 @@ namespace dials { namespace algorithms {
       // Compute the background
       double mean_background = result.mean();
       sbox.mean_background = mean_background;
-      std::cout << "Mean bg : " << mean_background << std::endl;
     }
 
     /**

--- a/src/dials/algorithms/background/glm/creator.h
+++ b/src/dials/algorithms/background/glm/creator.h
@@ -19,6 +19,8 @@
 #include <dials/model/data/shoebox.h>
 #include <dials/model/data/image_volume.h>
 #include <dials/error.h>
+#include <unordered_map>
+#include <iostream>
 
 namespace dials { namespace algorithms {
 
@@ -75,15 +77,26 @@ namespace dials { namespace algorithms {
      * @param sbox The shoeboxes
      * @returns Success True/False
      */
-    af::shared<bool> shoebox(af::ref<Shoebox<> > sbox) const {
+    af::shared<bool> shoebox(af::ref<Shoebox<> > sbox) {
       af::shared<bool> success(sbox.size(), true);
       for (std::size_t i = 0; i < sbox.size(); ++i) {
-        try {
-          single(sbox[i]);
-        } catch (scitbx::error const &) {
-          success[i] = false;
-        } catch (dials::error const &) {
-          success[i] = false;
+        if (sbox[i].n_valid_bg > 0) {
+          try {
+            compute_from_hist(sbox[i]);
+            // single_hist(sbox[i]);
+          } catch (scitbx::error const &) {
+            success[i] = false;
+          } catch (dials::error const &) {
+            success[i] = false;
+          }
+        } else {
+          try {
+            single(sbox[i]);
+          } catch (scitbx::error const &) {
+            success[i] = false;
+          } catch (dials::error const &) {
+            success[i] = false;
+          }
         }
       }
       return success;
@@ -168,6 +181,17 @@ namespace dials { namespace algorithms {
       };
     }
 
+    void compute_from_hist(Shoebox<> &sbox) {
+      switch (model_) {
+      case Constant3d:
+        compute_constant_3d_from_hist(sbox);
+        break;
+      default:
+        throw DIALS_ERROR(
+          "Unable to compute background from histogram if not constant3d model");
+      };
+    }
+
     /**
      * Compute the background values for a single shoebox
      * @param sbox The shoebox
@@ -230,6 +254,29 @@ namespace dials { namespace algorithms {
           }
         }
       }
+    }
+
+    void compute_constant_3d_from_hist(Shoebox<> &sbox) {
+      std::unordered_map<int, int> background_hist = sbox.background_hist;
+      af::shared<double> unrolled_background{};
+      for (const std::pair<int, int> pair : background_hist) {
+        for (int i = 0; i < pair.second; ++i) {
+          unrolled_background.push_back((double)pair.first);
+        }
+      }
+      double median = detail::median(unrolled_background.const_ref());
+      if (median == 0) {
+        median = 1.0;
+      }
+      // Compute the result
+      RobustPoissonMean result(
+        unrolled_background.const_ref(), median, tuning_constant_, 1e-3, max_iter_);
+      DIALS_ASSERT(result.converged());
+
+      // Compute the background
+      double mean_background = result.mean();
+      sbox.mean_background = mean_background;
+      std::cout << "Mean bg : " << mean_background << std::endl;
     }
 
     /**

--- a/src/dials/algorithms/integration/boost_python/integration_integrator_ext.cc
+++ b/src/dials/algorithms/integration/boost_python/integration_integrator_ext.cc
@@ -345,6 +345,21 @@ namespace dials { namespace algorithms { namespace boost_python {
       .def("finished", &ShoeboxProcessor::finished)
       .def("extract_time", &ShoeboxProcessor::extract_time)
       .def("process_time", &ShoeboxProcessor::process_time);
+    
+    class_<ShoeboxProcessorV2>("ShoeboxProcessorV2", no_init)
+      .def(init<af::reflection_table, std::size_t, int, int, bool,
+       const dxtbx::model::Scan&,const dxtbx::model::BeamBase&,
+       const dxtbx::model::Goniometer&,const dxtbx::model::Detector&, double,double>())
+      .def("next_data_only", &ShoeboxProcessorV2::next_data_only<double>)
+      .def("next_data_only", &ShoeboxProcessorV2::next_data_only<int>)
+      .def("frame0", &ShoeboxProcessorV2::frame0)
+      .def("frame1", &ShoeboxProcessorV2::frame1)
+      .def("frame", &ShoeboxProcessorV2::frame)
+      .def("nframes", &ShoeboxProcessorV2::nframes)
+      .def("npanels", &ShoeboxProcessorV2::npanels)
+      .def("finished", &ShoeboxProcessorV2::finished)
+      .def("extract_time", &ShoeboxProcessorV2::extract_time)
+      .def("process_time", &ShoeboxProcessorV2::process_time);
 
     def("max_memory_needed",
         &max_memory_needed,

--- a/src/dials/algorithms/integration/boost_python/integration_integrator_ext.cc
+++ b/src/dials/algorithms/integration/boost_python/integration_integrator_ext.cc
@@ -345,11 +345,19 @@ namespace dials { namespace algorithms { namespace boost_python {
       .def("finished", &ShoeboxProcessor::finished)
       .def("extract_time", &ShoeboxProcessor::extract_time)
       .def("process_time", &ShoeboxProcessor::process_time);
-    
+
     class_<ShoeboxProcessorV2>("ShoeboxProcessorV2", no_init)
-      .def(init<af::reflection_table, std::size_t, int, int, bool,
-       const dxtbx::model::Scan&,const dxtbx::model::BeamBase&,
-       const dxtbx::model::Goniometer&,const dxtbx::model::Detector&, double,double>())
+      .def(init<af::reflection_table,
+                std::size_t,
+                int,
+                int,
+                bool,
+                const dxtbx::model::Scan &,
+                const dxtbx::model::BeamBase &,
+                const dxtbx::model::Goniometer &,
+                const dxtbx::model::Detector &,
+                double,
+                double>())
       .def("next_data_only", &ShoeboxProcessorV2::next_data_only<double>)
       .def("next_data_only", &ShoeboxProcessorV2::next_data_only<int>)
       .def("frame0", &ShoeboxProcessorV2::frame0)
@@ -358,6 +366,8 @@ namespace dials { namespace algorithms { namespace boost_python {
       .def("nframes", &ShoeboxProcessorV2::nframes)
       .def("npanels", &ShoeboxProcessorV2::npanels)
       .def("finished", &ShoeboxProcessorV2::finished)
+      .def("finalise", &ShoeboxProcessorV2::finalise<double>)
+      .def("finalise", &ShoeboxProcessorV2::finalise<int>)
       .def("extract_time", &ShoeboxProcessorV2::extract_time)
       .def("process_time", &ShoeboxProcessorV2::process_time);
 

--- a/src/dials/algorithms/integration/integrator.py
+++ b/src/dials/algorithms/integration/integrator.py
@@ -1375,6 +1375,121 @@ Splitting reflection table into %s subsets for processing
         return tabulate(rows, headers="firstrow")
 
 
+from dials.model.data import make_image
+from dials_algorithms_integration_integrator_ext import ShoeboxProcessorV2
+
+
+def run_parallel_job(task, delta_b, delta_m):
+    # f0,f1 = t.job
+    experiment = task.experiments[0]
+    imageset = experiment.imageset
+    frame0, frame1 = task.job
+
+    try:
+        allowed_range = imageset.get_array_range()
+    except Exception:
+        allowed_range = 0, len(imageset)
+
+    try:
+        # range increasing
+        assert frame0 < frame1
+
+        # within an increasing range
+        assert allowed_range[1] > allowed_range[0]
+
+        # we are processing data which is within range
+        assert frame0 >= allowed_range[0]
+        assert frame1 <= allowed_range[1]
+
+        # I am 99% sure this is implied by all the code above
+        assert (frame1 - frame0) <= len(imageset)
+        if len(imageset) > 1:
+            # Slice imageset as a 0-based array
+            index0 = frame0 - allowed_range[0]
+            index1 = frame1 - allowed_range[0]
+            imageset = imageset[index0:index1]
+    except Exception as e:
+        raise RuntimeError(f"Programmer Error: bad array range: {e}")
+
+    try:
+        frame0, frame1 = imageset.get_array_range()
+    except Exception:
+        frame0, frame1 = (0, len(imageset))
+    print(frame0, frame1)
+    sel_refls = task.reflections
+    # print(f0,f1)
+    # print(len(t.reflections))
+    # assert 0
+    sel_refls["shoebox"] = flex.shoebox(
+        sel_refls["panel"],
+        sel_refls["bbox"],
+        allocate=False,
+        flatten=False,
+    )
+
+    shoebox_processor = ShoeboxProcessorV2(
+        sel_refls,
+        len(experiment.detector),
+        frame0,
+        frame1,
+        False,
+        experiment.scan,
+        experiment.beam,
+        experiment.goniometer,
+        experiment.detector,
+        delta_b,
+        delta_m,
+    )
+
+    for i in range(len(imageset)):
+        image = imageset.get_corrected_data(i)
+        if imageset.is_marked_for_rejection(i):
+            mask = tuple(flex.bool(im.accessor(), False) for im in image)
+        else:
+            mask = imageset.get_mask(i)
+        shoebox_processor.next_data_only(make_image(image, mask))
+        print(i)
+    print(sel_refls.size())
+    sel_refls["summation_success"] = flex.bool(sel_refls.size(), True)
+    """sel_refls.is_overloaded(self.experiments)
+    sel_refls.compute_mask(self.experiments)
+    sel_refls.contains_invalid_pixels()
+    centroid_algorithm = SimpleCentroidExt(
+        params=None, experiments=self.experiments
+    )
+    centroid_algorithm.compute_centroid(sel_refls)"""
+
+    valid_foreground_threshold = 0.75  # DIALS default
+    sbox = sel_refls["shoebox"]
+    nvalfg = sbox.count_mask_values(MaskCode.Valid | MaskCode.Foreground)
+    nforeg = sbox.count_mask_values(MaskCode.Foreground)
+    fraction_valid = nvalfg.as_double() / nforeg.as_double()
+    selection = fraction_valid < valid_foreground_threshold
+    sel_refls.set_flags(selection, sel_refls.flags.dont_integrate)
+
+    ##NEW METHODS
+    sel_refls["num_pixels.foreground"] = flex.int(sel_refls.size(), 0)
+    sel_refls["num_pixels.background"] = flex.int(sel_refls.size(), 0)
+    sel_refls["num_pixels.background_used"] = flex.int(sel_refls.size(), 0)
+    sel_refls["num_pixels.valid"] = flex.int(sel_refls.size(), 0)
+    intensity = shoebox_processor.finalise(
+        sel_refls
+    )  # similar to 'processer/executor' of standard integrator
+    sel_refls["intensity.sum.value"] = intensity.as_double()
+    sel_refls["intensity.sum.variance"] = intensity.as_double()
+    n_failed = (sel_refls["summation_success"] == False).count(True)
+    logger.info(f"{n_failed} reflections failed in summation integration")
+    sel_refls.set_flags(
+        sel_refls["summation_success"],
+        sel_refls.flags.integrated_sum,
+    )
+    sel_refls.set_flags(
+        ~sel_refls["summation_success"],
+        sel_refls.flags.foreground_includes_bad_pixels,
+    )
+    return sel_refls
+
+
 class InFlightIntegrator:
     """Process images in-flight"""
 
@@ -1444,12 +1559,12 @@ class InFlightIntegrator:
         self.reflections.compute_partiality(self.experiments)
         time_info = TimingInfo()
         ## first lets assume no splitting for simplicity.
-        self.reflections["shoebox"] = flex.shoebox(
+        """self.reflections["shoebox"] = flex.shoebox(
             self.reflections["panel"],
             self.reflections["bbox"],
             allocate=False,
             flatten=False,
-        )
+        )"""
         experiment = self.experiments[0]
         imageset = experiment.imageset
         frame0, frame1 = imageset.get_array_range()
@@ -1462,6 +1577,7 @@ class InFlightIntegrator:
         )  # Remove low zeta refls, as we don't have access to 'DontIntegrate' filter in
         # integrator.h via the processor's indices function.
         this_refls = self.reflections.select(selection_to_integrate)
+        import concurrent.futures
 
         processor = build_processor(
             Processor3D,
@@ -1469,15 +1585,28 @@ class InFlightIntegrator:
             this_refls,
             self.params.integration,
         )
-        processor.executor = "1" # We are not going to use this, but it must be not None to get the tasks.
-        print(dir(processor))
+        processor.executor = "1"  # We are not going to use this, but it must be not None to get the tasks.
         processor.manager.initialize()
 
-        from dials.model.data import make_image
-        import copy
-        from dials_algorithms_integration_integrator_ext import ShoeboxProcessorV2
         final_refls = flex.reflection_table([])
-        for t in processor.manager.tasks():
+        futures = {}
+        delta_b = sigma_b * n_sigma
+        delta_m = sigma_m * n_sigma
+        logger.info(f"Nproc={self.params.integration.mp.nproc}")
+        results = [None] * self.params.integration.mp.nproc
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=self.params.integration.mp.nproc
+        ) as pool:
+            for i, task in enumerate(processor.manager.tasks()):
+                futures[pool.submit(run_parallel_job, task, delta_b, delta_m)] = i
+            for future in concurrent.futures.as_completed(futures):
+                idx = futures[future]
+                sel_refls = future.result()
+                results[idx] = sel_refls
+        if all(results):
+            for r in results:
+                final_refls.extend(r)
+        '''for i, t in enumerate(processor.manager.tasks()):
             #f0,f1 = t.job
             imageset = copy.deepcopy(experiment.imageset)
             frame0, frame1 = t.job
@@ -1512,11 +1641,17 @@ class InFlightIntegrator:
                 frame0, frame1 = imageset.get_array_range()
             except Exception:
                 frame0, frame1 = (0, len(imageset))
+            print(frame0, frame1)
             sel_refls = t.reflections
             #print(f0,f1)
             #print(len(t.reflections))
             #assert 0
-
+            sel_refls["shoebox"] = flex.shoebox(
+                sel_refls["panel"],
+                sel_refls["bbox"],
+                allocate=False,
+                flatten=False,
+            )
 
             shoebox_processor = ShoeboxProcessorV2(
                 sel_refls,
@@ -1533,13 +1668,14 @@ class InFlightIntegrator:
             )
 
             for i in range(len(imageset)):
-                image = experiment.imageset.get_corrected_data(i)
+                image = imageset.get_corrected_data(i)
                 if imageset.is_marked_for_rejection(i):
                     mask = tuple(flex.bool(im.accessor(), False) for im in image)
                 else:
                     mask = imageset.get_mask(i)
                 shoebox_processor.next_data_only(make_image(image, mask))
                 print(i)
+            print(sel_refls.size())
             sel_refls["summation_success"] = flex.bool(sel_refls.size(), True)
             """sel_refls.is_overloaded(self.experiments)
             sel_refls.compute_mask(self.experiments)
@@ -1577,7 +1713,8 @@ class InFlightIntegrator:
                 ~sel_refls["summation_success"],
                 sel_refls.flags.foreground_includes_bad_pixels,
             )
-            final_refls.extend(this_refls)
+            final_refls.extend(sel_refls)
+            print(final_refls.size())'''
 
         self.reflections = final_refls
 

--- a/src/dials/algorithms/integration/integrator.py
+++ b/src/dials/algorithms/integration/integrator.py
@@ -1439,13 +1439,6 @@ class InFlightIntegrator:
         logger.info("")
         logger.info(heading("Integrating reflections"))
         logger.info("")
-        """print(self.reflections.size())
-        mask = (
-            flex.abs(self.reflections["zeta"]) < 0.05
-        )
-        self.reflections = self.reflections.select(~mask)
-        print(mask.count(True))
-        print(self.reflections.size())"""
 
         ## would call Processor3D, which calls the manager...
         self.reflections.compute_partiality(self.experiments)
@@ -1454,7 +1447,7 @@ class InFlightIntegrator:
         self.reflections["shoebox"] = flex.shoebox(
             self.reflections["panel"],
             self.reflections["bbox"],
-            allocate=False,  # change to False when implement new method
+            allocate=False,
             flatten=False,
         )
         experiment = self.experiments[0]
@@ -1473,7 +1466,6 @@ class InFlightIntegrator:
         from dials.model.data import make_image
         from dials_algorithms_integration_integrator_ext import ShoeboxProcessorV2
 
-        # self.reflections["summation_success"] = flex.bool(self.reflections.size(), True)
         shoebox_processor = ShoeboxProcessorV2(
             sel_refls,
             len(self.experiments[0].detector),
@@ -1488,7 +1480,7 @@ class InFlightIntegrator:
             sigma_m * n_sigma,
         )
 
-        for i in range(len(imageset)):  # len(experiment.imageset)):
+        for i in range(len(imageset)):
             image = experiment.imageset.get_corrected_data(i)
             if imageset.is_marked_for_rejection(i):
                 mask = tuple(flex.bool(im.accessor(), False) for im in image)
@@ -1513,36 +1505,14 @@ class InFlightIntegrator:
         selection = fraction_valid < valid_foreground_threshold
         sel_refls.set_flags(selection, sel_refls.flags.dont_integrate)
 
-        """self.reflections["num_pixels.valid"] = sboxs.count_mask_values(MaskCode.Valid)
-        self.reflections["num_pixels.background"] = sboxs.count_mask_values(
-            MaskCode.Valid | MaskCode.Background
-        )
-        self.reflections["num_pixels.background_used"] = sboxs.count_mask_values(
-            MaskCode.Valid | MaskCode.Background | MaskCode.BackgroundUsed
-        )
-        self.reflections["num_pixels.foreground"] = nvalfg"""
-        # selection_to_integrate = ~self.reflections.get_flags(self.reflections.flags.dont_integrate)
-        # sel_refls = self.reflections.select(selection_to_integrate)
-
-        """sel_refls.compute_background(self.experiments)
-        sel_refls.compute_centroid(self.experiments)
-        sel_refls.compute_summed_intensity()
-
-        sel_refls["num_pixels.valid"] = sbox.count_mask_values(MaskCode.Valid)
-        sel_refls["num_pixels.background"] = sbox.count_mask_values(
-            MaskCode.Valid | MaskCode.Background
-        )
-        sel_refls["num_pixels.background_used"] = sbox.count_mask_values(
-            MaskCode.Valid | MaskCode.Background | MaskCode.BackgroundUsed
-        )
-        sel_refls["num_pixels.foreground"] = nvalfg"""
-
         ##NEW METHODS
         sel_refls["num_pixels.foreground"] = flex.int(sel_refls.size(), 0)
         sel_refls["num_pixels.background"] = flex.int(sel_refls.size(), 0)
         sel_refls["num_pixels.background_used"] = flex.int(sel_refls.size(), 0)
         sel_refls["num_pixels.valid"] = flex.int(sel_refls.size(), 0)
-        intensity = shoebox_processor.finalise(sel_refls)
+        intensity = shoebox_processor.finalise(
+            sel_refls
+        )  # similar to 'processer/executor' of standard integrator
         sel_refls["intensity.sum.value"] = intensity.as_double()
         sel_refls["intensity.sum.variance"] = intensity.as_double()
         n_failed = (sel_refls["summation_success"] == False).count(True)

--- a/src/dials/algorithms/integration/integrator.py
+++ b/src/dials/algorithms/integration/integrator.py
@@ -1488,6 +1488,7 @@ def run_parallel_job(task, delta_b, delta_m):
     sel_refls["background.sum.value"] = flex.double(sel_refls.size(), 0)
     sel_refls["background.sum.variance"] = flex.double(sel_refls.size(), 0)
     sel_refls["intensity.sum.variance"] = flex.double(sel_refls.size(), 0)
+    sel_refls["xyzobs.px.value"] = flex.vec3_double(sel_refls.size())
     intensity = shoebox_processor.finalise(
         sel_refls
     )  # similar to 'processer/executor' of standard integrator

--- a/src/dials/algorithms/integration/integrator.py
+++ b/src/dials/algorithms/integration/integrator.py
@@ -1489,6 +1489,7 @@ def run_parallel_job(task, delta_b, delta_m):
     sel_refls["background.sum.variance"] = flex.double(sel_refls.size(), 0)
     sel_refls["intensity.sum.variance"] = flex.double(sel_refls.size(), 0)
     sel_refls["xyzobs.px.value"] = flex.vec3_double(sel_refls.size())
+    sel_refls["xyzobs.mm.value"] = flex.vec3_double(sel_refls.size())
     intensity = shoebox_processor.finalise(
         sel_refls
     )  # similar to 'processer/executor' of standard integrator

--- a/src/dials/algorithms/integration/integrator.py
+++ b/src/dials/algorithms/integration/integrator.py
@@ -1443,7 +1443,7 @@ def run_parallel_job(task, delta_b, delta_m):
         else:
             mask = imageset.get_mask(i)
         shoebox_processor.next_data_only(make_image(image, mask))
-
+    sel_refls.compute_background(task.experiments)
     sel_refls["summation_success"] = flex.bool(sel_refls.size(), True)
     """sel_refls.is_overloaded(self.experiments)
     sel_refls.compute_mask(self.experiments)
@@ -1466,11 +1466,13 @@ def run_parallel_job(task, delta_b, delta_m):
     sel_refls["num_pixels.background"] = flex.int(sel_refls.size(), 0)
     sel_refls["num_pixels.background_used"] = flex.int(sel_refls.size(), 0)
     sel_refls["num_pixels.valid"] = flex.int(sel_refls.size(), 0)
+    sel_refls["background.sum.value"] = flex.double(sel_refls.size(), 0)
+    sel_refls["background.sum.variance"] = flex.double(sel_refls.size(), 0)
     intensity = shoebox_processor.finalise(
         sel_refls
     )  # similar to 'processer/executor' of standard integrator
-    sel_refls["intensity.sum.value"] = intensity.as_double()
-    sel_refls["intensity.sum.variance"] = intensity.as_double()
+    sel_refls["intensity.sum.value"] = intensity  # .as_double()
+    sel_refls["intensity.sum.variance"] = intensity  # .as_double()
     n_failed = sel_refls["summation_success"].count(False)
     logger.info(f"{n_failed} reflections failed in summation integration")
     sel_refls.set_flags(

--- a/src/dials/algorithms/integration/integrator.py
+++ b/src/dials/algorithms/integration/integrator.py
@@ -1374,6 +1374,7 @@ Splitting reflection table into %s subsets for processing
             raise RuntimeError("Experiments must be all sequences or all stills")
         return tabulate(rows, headers="firstrow")
 
+
 class InFlightIntegrator:
     """Process images in-flight"""
 
@@ -1385,6 +1386,7 @@ class InFlightIntegrator:
         assert all(p.get_pedestal() == 0.0 for p in detector.iter_panels())
         from dials.extensions.auto_background_ext import AutoBackgroundExt
         from dials.extensions.glm_background_ext import GLMBackgroundExt
+
         assert params.integration.background.glm.model.algorithm == "constant3d"
         assert (
             reflections.background_algorithm.func == AutoBackgroundExt
@@ -1437,22 +1439,22 @@ class InFlightIntegrator:
         logger.info("")
         logger.info(heading("Integrating reflections"))
         logger.info("")
-        '''print(self.reflections.size())
+        """print(self.reflections.size())
         mask = (
             flex.abs(self.reflections["zeta"]) < 0.05
         )
         self.reflections = self.reflections.select(~mask)
         print(mask.count(True))
-        print(self.reflections.size())'''
+        print(self.reflections.size())"""
 
         ## would call Processor3D, which calls the manager...
         self.reflections.compute_partiality(self.experiments)
         time_info = TimingInfo()
-        ## first lets assume no splitting for simplicity. 
+        ## first lets assume no splitting for simplicity.
         self.reflections["shoebox"] = flex.shoebox(
             self.reflections["panel"],
             self.reflections["bbox"],
-            allocate=False, #change to False when implement new method
+            allocate=False,  # change to False when implement new method
             flatten=False,
         )
         experiment = self.experiments[0]
@@ -1462,17 +1464,15 @@ class InFlightIntegrator:
         sigma_m = experiment.profile.sigma_m(deg=False)
         n_sigma = 3  # self.params.profile.gaussian_rs.parameters.n_sigma
 
-        selection_to_integrate = ~self.reflections.get_flags(self.reflections.flags.dont_integrate)
-        print(self.reflections.size())
+        selection_to_integrate = ~self.reflections.get_flags(
+            self.reflections.flags.dont_integrate
+        )
         sel_refls = self.reflections.select(selection_to_integrate)
-        print(sel_refls.size())
-        assert 0
-        
-
 
         from dials.model.data import make_image
         from dials_algorithms_integration_integrator_ext import ShoeboxProcessorV2
-        #self.reflections["summation_success"] = flex.bool(self.reflections.size(), True)
+
+        # self.reflections["summation_success"] = flex.bool(self.reflections.size(), True)
         shoebox_processor = ShoeboxProcessorV2(
             sel_refls,
             len(self.experiments[0].detector),
@@ -1496,33 +1496,33 @@ class InFlightIntegrator:
             shoebox_processor.next_data_only(make_image(image, mask))
             print(i)
         from dials.extensions.simple_centroid_ext import SimpleCentroidExt
+
         sel_refls.is_overloaded(self.experiments)
         sel_refls.compute_mask(self.experiments)
         sel_refls.contains_invalid_pixels()
-        centroid_algorithm = SimpleCentroidExt(params=None, experiments=self.experiments)
+        centroid_algorithm = SimpleCentroidExt(
+            params=None, experiments=self.experiments
+        )
         centroid_algorithm.compute_centroid(sel_refls)
 
-        
         valid_foreground_threshold = 0.75  # DIALS default
         sbox = sel_refls["shoebox"]
         nvalfg = sbox.count_mask_values(MaskCode.Valid | MaskCode.Foreground)
         nforeg = sbox.count_mask_values(MaskCode.Foreground)
         fraction_valid = nvalfg.as_double() / nforeg.as_double()
         selection = fraction_valid < valid_foreground_threshold
-        sel_refls.set_flags(
-            selection, sel_refls.flags.dont_integrate
-        )
+        sel_refls.set_flags(selection, sel_refls.flags.dont_integrate)
 
-        '''self.reflections["num_pixels.valid"] = sboxs.count_mask_values(MaskCode.Valid)
+        """self.reflections["num_pixels.valid"] = sboxs.count_mask_values(MaskCode.Valid)
         self.reflections["num_pixels.background"] = sboxs.count_mask_values(
             MaskCode.Valid | MaskCode.Background
         )
         self.reflections["num_pixels.background_used"] = sboxs.count_mask_values(
             MaskCode.Valid | MaskCode.Background | MaskCode.BackgroundUsed
         )
-        self.reflections["num_pixels.foreground"] = nvalfg'''
-        #selection_to_integrate = ~self.reflections.get_flags(self.reflections.flags.dont_integrate)
-        #sel_refls = self.reflections.select(selection_to_integrate)
+        self.reflections["num_pixels.foreground"] = nvalfg"""
+        # selection_to_integrate = ~self.reflections.get_flags(self.reflections.flags.dont_integrate)
+        # sel_refls = self.reflections.select(selection_to_integrate)
         sel_refls.compute_background(self.experiments)
         sel_refls.compute_centroid(self.experiments)
         sel_refls.compute_summed_intensity()
@@ -1535,49 +1535,8 @@ class InFlightIntegrator:
             MaskCode.Valid | MaskCode.Background | MaskCode.BackgroundUsed
         )
         sel_refls["num_pixels.foreground"] = nvalfg
-        sel_refls.as_file("processed.refl")
+        self.reflections = sel_refls
 
-        # usually, we have some c++ method like set_selected_rows which copies everything, have to do manually in python?
-        self.reflections["intensity.sum.value"] = flex.double(self.reflections.size(), 0)
-        self.reflections["intensity.sum.variance"] = flex.double(self.reflections.size(), 0)
-        self.reflections["background.sum.value"] = flex.double(self.reflections.size(), 0)
-        self.reflections["background.sum.variance"] = flex.double(self.reflections.size(), 0)
-        self.reflections["num_pixels.valid"] = flex.int(self.reflections.size(), 0)
-        self.reflections["num_pixels.background"] = flex.int(self.reflections.size(), 0)
-        self.reflections["num_pixels.background_used"] = flex.int(self.reflections.size(), 0)
-        self.reflections["num_pixels.foreground"] = flex.int(self.reflections.size(), 0)
-
-        self.reflections["intensity.sum.value"].set_selected(selection_to_integrate, sel_refls["intensity.sum.value"])
-        self.reflections["intensity.sum.variance"].set_selected(selection_to_integrate, sel_refls["intensity.sum.variance"])
-        self.reflections["background.sum.value"].set_selected(selection_to_integrate, sel_refls["background.sum.value"])
-        self.reflections["background.sum.variance"].set_selected(selection_to_integrate, sel_refls["background.sum.variance"])
-        self.reflections["num_pixels.valid"].set_selected(selection_to_integrate, sel_refls["num_pixels.valid"])
-        self.reflections["num_pixels.background"].set_selected(selection_to_integrate, sel_refls["num_pixels.background"])
-        self.reflections["num_pixels.background_used"].set_selected(selection_to_integrate, sel_refls["num_pixels.background_used"])
-        self.reflections["num_pixels.foreground"].set_selected(selection_to_integrate, sel_refls["num_pixels.foreground"])
-        integrated_sum = self.reflections.get_flags(self.reflections.flags.integrated_sum)
-        integrated_sum.set_selected(sel_refls.get_flags(sel_refls.flags.integrated_sum))
-        self.reflections.set_flags(self.reflections.flags.integrated_sum, integrated_sum)
-
-        '''
-
-        self.reflections["num_pixels.foreground"] = flex.int(self.reflections.size(), 0)
-        self.reflections["num_pixels.background"] = flex.int(self.reflections.size(), 0)
-        self.reflections["num_pixels.background_used"] = flex.int(self.reflections.size(), 0)
-        self.reflections["num_pixels.valid"] = flex.int(self.reflections.size(), 0)
-        intensity = shoebox_processor.finalise(self.reflections)
-        self.reflections["intensity.sum.value"] = intensity.as_double()
-        self.reflections["intensity.sum.variance"] = intensity.as_double()
-        n_failed = (self.reflections["summation_success"] == False).count(True)
-        logger.info(f"{n_failed} reflections failed in summation integration")
-        self.reflections.set_flags(
-            self.reflections["summation_success"],
-            self.reflections.flags.integrated_sum,
-        )
-        self.reflections.set_flags(
-            ~self.reflections["summation_success"],
-            self.reflections.flags.foreground_includes_bad_pixels,
-        )'''
         # ignore overlaps filter
         self.reflections.compute_corrections(self.experiments)
 
@@ -1594,6 +1553,7 @@ class InFlightIntegrator:
         # Return the reflections
 
         return self.reflections
+
 
 class Integrator3D(Integrator):
     """

--- a/src/dials/algorithms/integration/integrator.py
+++ b/src/dials/algorithms/integration/integrator.py
@@ -1468,13 +1468,13 @@ def run_parallel_job(task, delta_b, delta_m):
     sel_refls["num_pixels.valid"] = flex.int(sel_refls.size(), 0)
     sel_refls["background.sum.value"] = flex.double(sel_refls.size(), 0)
     sel_refls["background.sum.variance"] = flex.double(sel_refls.size(), 0)
+    sel_refls["intensity.sum.variance"] = flex.double(sel_refls.size(), 0)
     intensity = shoebox_processor.finalise(
         sel_refls
     )  # similar to 'processer/executor' of standard integrator
     sel_refls["intensity.sum.value"] = intensity  # .as_double()
-    sel_refls["intensity.sum.variance"] = intensity  # .as_double()
     n_failed = sel_refls["summation_success"].count(False)
-    logger.info(f"{n_failed} reflections failed in summation integration")
+    logger.debug(f"{n_failed} reflections failed in summation integration")
     sel_refls.set_flags(
         sel_refls["summation_success"],
         sel_refls.flags.integrated_sum,
@@ -1609,7 +1609,7 @@ class InFlightIntegrator:
         logger.info("")
 
         # Return the reflections
-
+        del self.reflections["shoebox"]
         return self.reflections
 
 

--- a/src/dials/algorithms/integration/processor.h
+++ b/src/dials/algorithms/integration/processor.h
@@ -84,7 +84,7 @@ namespace dials { namespace algorithms {
       DIALS_ASSERT(data.is_consistent());
       DIALS_ASSERT(data.contains("shoebox"));
       DIALS_ASSERT(data.size() > 0);
-      af::const_ref<Shoebox<> > shoebox = data["shoebox"];
+      af::const_ref<Shoebox<>> shoebox = data["shoebox"];
       std::size_t size = nframes_ * npanels_;
       std::vector<std::size_t> num(size, 0);
       std::vector<std::size_t> count(size, 0);
@@ -127,8 +127,8 @@ namespace dials { namespace algorithms {
       using dials::af::boost_python::reflection_table_suite::select_rows_index;
       using dxtbx::af::flex_table_suite::set_selected_rows_index;
       typedef Shoebox<>::float_type float_type;
-      typedef af::ref<float_type, af::c_grid<3> > sbox_data_type;
-      typedef af::ref<int, af::c_grid<3> > sbox_mask_type;
+      typedef af::ref<float_type, af::c_grid<3>> sbox_data_type;
+      typedef af::ref<int, af::c_grid<3>> sbox_mask_type;
       DIALS_ASSERT(frame_ >= frame0_ && frame_ < frame1_);
       DIALS_ASSERT(image.npanels() == npanels_);
 
@@ -137,12 +137,12 @@ namespace dials { namespace algorithms {
 
       // For each image, extract shoeboxes of reflections recorded.
       // Allocate data where necessary
-      af::ref<Shoebox<> > shoebox = data_["shoebox"];
+      af::ref<Shoebox<>> shoebox = data_["shoebox"];
       af::shared<std::size_t> process_indices;
       for (std::size_t p = 0; p < image.npanels(); ++p) {
         af::const_ref<std::size_t> ind = indices(frame_, p);
-        af::const_ref<T, af::c_grid<2> > data = image.data(p);
-        af::const_ref<bool, af::c_grid<2> > mask = image.mask(p);
+        af::const_ref<T, af::c_grid<2>> data = image.data(p);
+        af::const_ref<bool, af::c_grid<2>> mask = image.mask(p);
         DIALS_ASSERT(data.accessor().all_eq(mask.accessor()));
         for (std::size_t i = 0; i < ind.size(); ++i) {
           DIALS_ASSERT(ind[i] < shoebox.size());
@@ -237,8 +237,8 @@ namespace dials { namespace algorithms {
       using dials::af::boost_python::reflection_table_suite::select_rows_index;
       using dxtbx::af::flex_table_suite::set_selected_rows_index;
       typedef Shoebox<>::float_type float_type;
-      typedef af::ref<float_type, af::c_grid<3> > sbox_data_type;
-      typedef af::ref<int, af::c_grid<3> > sbox_mask_type;
+      typedef af::ref<float_type, af::c_grid<3>> sbox_data_type;
+      typedef af::ref<int, af::c_grid<3>> sbox_mask_type;
       DIALS_ASSERT(frame_ >= frame0_ && frame_ < frame1_);
       DIALS_ASSERT(image.npanels() == npanels_);
 
@@ -247,12 +247,12 @@ namespace dials { namespace algorithms {
 
       // For each image, extract shoeboxes of reflections recorded.
       // Allocate data where necessary
-      af::ref<Shoebox<> > shoebox = data_["shoebox"];
+      af::ref<Shoebox<>> shoebox = data_["shoebox"];
       af::shared<std::size_t> process_indices;
       for (std::size_t p = 0; p < image.npanels(); ++p) {
         af::const_ref<std::size_t> ind = indices(frame_, p);
-        af::const_ref<T, af::c_grid<2> > data = image.data(p);
-        af::const_ref<bool, af::c_grid<2> > mask = image.mask(p);
+        af::const_ref<T, af::c_grid<2>> data = image.data(p);
+        af::const_ref<bool, af::c_grid<2>> mask = image.mask(p);
         DIALS_ASSERT(data.accessor().all_eq(mask.accessor()));
         for (std::size_t i = 0; i < ind.size(); ++i) {
           DIALS_ASSERT(ind[i] < shoebox.size());
@@ -414,30 +414,30 @@ namespace dials { namespace algorithms {
                        const dxtbx::model::Detector& detector,
                        const double delta_b,
                        const double delta_m)
-    : data_(data),
-      extract_time_(0.0),
-      process_time_(0.0),
-      save_(save),
-      npanels_(npanels),
-      frame0_(frame0),
-      frame1_(frame1),
-      frame_(frame0),
-      nframes_(frame1 - frame0),
-      phi0_(scan.get_oscillation()[0]),
-      dphi_(scan.get_oscillation()[1]),
-      s0_(beam.get_s0()),
-      m2_(gonio.get_rotation_axis()),
-      detector_(detector),
-      index0_(scan.get_array_range()[0]),
-      index1_(scan.get_array_range()[1]) {
-    delta_b_r2 = 1.0 / (std::pow(delta_b, 2));
-    delta_m_r2 = 1.0 / (std::pow(delta_m, 2));
-    DIALS_ASSERT(frame0_ < frame1_);
-    DIALS_ASSERT(npanels_ > 0);
-    DIALS_ASSERT(data.contains("shoebox"));
-    DIALS_ASSERT(data.size() > 0);
-    af::const_ref<Shoebox<>> shoebox = data["shoebox"];
-    std::size_t size = nframes_ * npanels_;
+        : data_(data),
+          extract_time_(0.0),
+          process_time_(0.0),
+          save_(save),
+          npanels_(npanels),
+          frame0_(frame0),
+          frame1_(frame1),
+          frame_(frame0),
+          nframes_(frame1 - frame0),
+          phi0_(scan.get_oscillation()[0]),
+          dphi_(scan.get_oscillation()[1]),
+          s0_(beam.get_s0()),
+          m2_(gonio.get_rotation_axis()),
+          detector_(detector),
+          index0_(scan.get_array_range()[0]),
+          index1_(scan.get_array_range()[1]) {
+      delta_b_r2 = 1.0 / (std::pow(delta_b, 2));
+      delta_m_r2 = 1.0 / (std::pow(delta_m, 2));
+      DIALS_ASSERT(frame0_ < frame1_);
+      DIALS_ASSERT(npanels_ > 0);
+      DIALS_ASSERT(data.contains("shoebox"));
+      DIALS_ASSERT(data.size() > 0);
+      af::const_ref<Shoebox<>> shoebox = data["shoebox"];
+      std::size_t size = nframes_ * npanels_;
       std::vector<std::size_t> num(size, 0);
       std::vector<std::size_t> count(size, 0);
       flatten_ = shoebox[0].flat;
@@ -477,8 +477,8 @@ namespace dials { namespace algorithms {
       using dials::af::boost_python::reflection_table_suite::select_rows_index;
       using dxtbx::af::flex_table_suite::set_selected_rows_index;
       typedef Shoebox<>::float_type float_type;
-      typedef af::ref<float_type, af::c_grid<3> > sbox_data_type;
-      typedef af::ref<int, af::c_grid<3> > sbox_mask_type;
+      typedef af::ref<float_type, af::c_grid<3>> sbox_data_type;
+      typedef af::ref<int, af::c_grid<3>> sbox_mask_type;
       DIALS_ASSERT(frame_ >= frame0_ && frame_ < frame1_);
       DIALS_ASSERT(image.npanels() == npanels_);
 
@@ -487,23 +487,27 @@ namespace dials { namespace algorithms {
 
       // For each image, extract shoeboxes of reflections recorded.
       // Allocate data where necessary
-      af::ref<Shoebox<> > shoebox = data_["shoebox"];
+      af::ref<Shoebox<>> shoebox = data_["shoebox"];
+      af::ref<vec3<double>> s1_vec = data_["s1"];
+      af::ref<vec3<double>> xyzcal_px = data_["xyzcal.px"];
+      double s0_length = s0_.length();
+
       af::shared<std::size_t> process_indices;
       for (std::size_t p = 0; p < image.npanels(); ++p) {
         af::const_ref<std::size_t> ind = indices(frame_, p);
-        af::const_ref<T, af::c_grid<2> > data = image.data(p);
-        af::const_ref<bool, af::c_grid<2> > mask = image.mask(p);
+        af::const_ref<T, af::c_grid<2>> data = image.data(p);
+        af::const_ref<bool, af::c_grid<2>> mask = image.mask(p);
         DIALS_ASSERT(data.accessor().all_eq(mask.accessor()));
         for (std::size_t i = 0; i < ind.size(); ++i) {
           DIALS_ASSERT(ind[i] < shoebox.size());
           Shoebox<>& sbox = shoebox[ind[i]];
-          if (frame_ == sbox.bbox[4]) {
+          /*if (frame_ == sbox.bbox[4]) {
             DIALS_ASSERT(sbox.is_allocated() == false);
             sbox.allocate();
-          }
+          }*/
           int6 b = sbox.bbox;
-          sbox_data_type sdata = sbox.data.ref();
-          sbox_mask_type smask = sbox.mask.ref();
+          // sbox_data_type sdata = sbox.data.ref();
+          // sbox_mask_type smask = sbox.mask.ref();
           DIALS_ASSERT(b[1] > b[0]);
           DIALS_ASSERT(b[3] > b[2]);
           DIALS_ASSERT(b[5] > b[4]);
@@ -518,6 +522,7 @@ namespace dials { namespace algorithms {
           int z = frame_ - z0;
           int yi = (int)data.accessor()[0];
           int xi = (int)data.accessor()[1];
+          // These bits make sure we only read within the image
           int xb = x0 >= 0 ? 0 : std::abs(x0);
           int yb = y0 >= 0 ? 0 : std::abs(y0);
           int xe = x1 <= xi ? xs : xs - (x1 - xi);
@@ -529,8 +534,8 @@ namespace dials { namespace algorithms {
           DIALS_ASSERT(xb >= 0 && xe <= xs);
           DIALS_ASSERT(yb + y0 >= 0 && ye + y0 <= yi);
           DIALS_ASSERT(xb + x0 >= 0 && xe + x0 <= xi);
-          DIALS_ASSERT(sbox.is_consistent());
-          if (flatten_) {
+          // DIALS_ASSERT(sbox.is_consistent());
+          /*if (flatten_) {
             for (std::size_t y = yb; y < ye; ++y) {
               for (std::size_t x = xb; x < xe; ++x) {
                 sdata(0, y, x) += data(y + y0, x + x0);
@@ -539,16 +544,181 @@ namespace dials { namespace algorithms {
                 smask(0, y, x) = (mv && (z == 0 ? true : sv) ? Valid : 0);
               }
             }
-          } else {
-            for (std::size_t y = yb; y < ye; ++y) {
-              for (std::size_t x = xb; x < xe; ++x) {
-                sdata(z, y, x) = data(y + y0, x + x0);
-                smask(z, y, x) = mask(y + y0, x + x0) ? Valid : 0;
+          } else {*/
+          const dxtbx::model::Panel& panel = detector_[p];
+          vec3<double> s1 = s1_vec[ind[i]];
+          vec3<double> xyzcal = xyzcal_px[ind[i]];
+          double phi = phi0_ + (xyzcal[2] - index0_) * dphi_;
+          profile_model::gaussian_rs::CoordinateSystem cs(m2_, s0_, s1, phi);
+          vec2<double> shoebox_centroid_px = panel.get_ray_intersection_px(s1);
+          double attenuation_length = panel.attenuation_length(shoebox_centroid_px);
+
+          af::versa<double, af::c_grid<2>> dxy_array(af::c_grid<2>(ys + 1, xs + 1));
+          for (int j2 = 0; j2 <= ys; ++j2) {
+            for (int i2 = 0; i2 <= xs; ++i2) {
+              vec2<double> gxy = cs.from_beam_vector(
+                panel
+                  .get_pixel_lab_coord(vec2<double>(x0 + i2, y0 + j2),
+                                       attenuation_length)
+                  .normalize()
+                * s0_length);
+              dxy_array(j2, i2) = (gxy[0] * gxy[0] + gxy[1] * gxy[1]) * delta_b_r2;
+            }
+          }
+
+          /*int j1=0;
+          for (std::size_t y = yb; y < ye; ++y, ++j1) {
+            int i1=0;
+            for (std::size_t x = xb; x < xe; ++x, ++i1) {*/
+          bool all_in_image_bounds = true;
+          af::versa<bool, af::c_grid<2>> in_image_array(af::c_grid<2>(ys, xs), true);
+          if ((x0 < 0) || (y0 < 0) || ((x1 >= xi) || (y1 >= yi))) {
+            all_in_image_bounds = false;
+            for (int j3 = 0; j3 < ys; ++j3) {
+              for (int i3 = 0; i3 < xs; ++i3) {
+                if ((j3 + y0 < 0) || (i3 + x0 < 0) || (x0 + i3 >= xi)
+                    || (y0 + j3 >= yi)) {
+                  in_image_array(j3, i3) = false;
+                }
               }
             }
           }
-          if (frame_ == sbox.bbox[5] - 1) {
-            process_indices.push_back(ind[i]);
+
+          for (int j3 = 0; j3 < ys; ++j3) {
+            for (int i3 = 0; i3 < xs; ++i3) {
+              double dxy1 = dxy_array(j3, i3);
+              double dxy2 = dxy_array(j3 + 1, i3);
+              double dxy3 = dxy_array(j3, i3 + 1);
+              double dxy4 = dxy_array(j3 + 1, i3 + 1);
+              double dxy = std::min(std::min(dxy1, dxy2), std::min(dxy3, dxy4));
+              // if (z>= index0_ && z < index1_){
+              /*double gz1 =
+                cs.from_rotation_angle_fast(phi0_ + (z - index0_) * dphi_);
+              double gz2 =
+                cs.from_rotation_angle_fast(phi0_ + (z + 1 - index0_) * dphi_);
+              double gz = std::abs(gz1) < std::abs(gz2) ? gz1 : gz2;
+              double gzc2 = gz * gz * delta_m_r2;*/
+              if (dxy <= 1.0) {
+                bool this_in_image_bounds = all_in_image_bounds;
+                if (!this_in_image_bounds) {  // if not all in bounds, check the
+                                              // specific pixel
+                  this_in_image_bounds = in_image_array(j3, i3);
+                }
+                if (this_in_image_bounds) {
+                  if (mask(j3 + y0, i3 + x0)) {
+                    sbox.total_intensity += data(j3 + y0, i3 + x0);
+                    sbox.n_valid_fg += 1;
+                  } else {
+                    sbox.masked_image_pixel = true;
+                    sbox.n_invalid_fg += 1;
+                  }
+                } else {
+                  sbox.masked_image_pixel = true;
+                  sbox.n_invalid_fg += 1;
+                }
+              } else {
+                bool this_in_image_bounds = all_in_image_bounds;
+                if (!this_in_image_bounds) {  // if not all in bounds, check the
+                                              // specific pixel
+                  this_in_image_bounds = in_image_array(j3, i3);
+                }
+                if (this_in_image_bounds) {
+                  if (mask(j3 + y0, i3 + x0)) {
+                    sbox.n_valid_bg += 1;
+                    int this_pixel = data(j3 + y0, i3 + x0);
+                    if (auto search = sbox.background_hist.find(this_pixel);
+                        search != sbox.background_hist.end()) {
+                      sbox.background_hist[this_pixel] += 1;
+                    } else {
+                      sbox.background_hist[this_pixel] = 1;
+                    }
+                  } else {
+                    sbox.n_invalid_bg += 1;
+                  }
+                } else {
+                  sbox.n_invalid_bg += 1;
+                }
+              }
+
+              /*if (dxy <= 1.0){
+                // is foreground
+                if ((x0 < 0) || (y0 < 0)){ // check if we might not be within the image
+              range if ((x0 + i3 < 0) || (y0 + j3 < 0) || (x0 + i3 >=xi) || (y0 + j3
+              >=yi)){ sbox.masked_image_pixel = true; sbox.n_invalid_fg += 1;
+                  }
+                  else {
+                    if ((j3 + y0 <0) || (i3 + x0 < 0) || (x0 + i3 >=xi) ||(y0 + j3
+              >=yi)){ std::cout << "Bad values1: " << x0 << " " << y0 << " " << i3 << "
+              " << j3 << " " << xi << " " << yi << std::endl; DIALS_ASSERT(0);
+                    }
+                    if (mask(j3 + y0, i3 + x0)) {
+                      sbox.total_intensity += data(j3 + y0, i3 + x0);
+                      sbox.n_valid_fg += 1;
+                    }
+                    else {
+                      sbox.masked_image_pixel = true;
+                      sbox.n_invalid_fg += 1;
+                    }
+                  }
+                }
+                else if ((x1 >= xi) || (y1 >= yi)){  // check if we might not be within
+              the image range if ((x0 + i3 >=xi) || (y0 + j3 >=yi) || (x0 + i3 < 0) ||
+              (y0 + j3 < 0)){ sbox.masked_image_pixel = true; sbox.n_invalid_fg += 1;
+                  }
+                  else {
+                    if ((j3 + y0 <0) || (i3 + x0 < 0) || (x0 + i3 >=xi) ||(y0 + j3
+              >=yi)){ std::cout << "Bad values2: " << x0 << " " << y0 << " " << i3 << "
+              " << j3 << " " << xi << " " << yi << std::endl; DIALS_ASSERT(0);
+                    }
+                    if (mask(j3 + y0, i3 + x0)) {
+                      sbox.total_intensity += data(j3 + y0, i3 + x0);
+                      sbox.n_valid_fg += 1;
+                    }
+                    else {
+                      sbox.masked_image_pixel = true;
+                      sbox.n_invalid_fg += 1;
+                    }
+                  }
+                }
+                else {
+                  if ((j3 + y0 <0) || (i3 + x0 < 0) || (x0 + i3 >=xi) ||(y0 + j3 >=yi)){
+                      std::cout << "Bad values3: " << x0 << " " << y0 << " " << i3 << "
+              " << j3 << " " << xi << " " << yi << std::endl; DIALS_ASSERT(0);
+                    }
+                  if (mask(j3 + y0, i3 + x0)) {
+                    sbox.total_intensity += data(j3 + y0, i3 + x0);
+                    sbox.n_valid_fg += 1;
+                  }
+                  else {
+                    sbox.masked_image_pixel = true;
+                    sbox.n_invalid_fg += 1;
+                  }
+                }
+              }*/
+              /*else {
+                if (mask(y + y0, x + x0)) {
+                  sbox.n_valid_bg += 1;
+                  int this_pixel = data(y + y0, x + x0);
+                  if (auto search = sbox.background_hist.find(this_pixel);
+                      search != sbox.background_hist.end()) {
+                    sbox.background_hist[this_pixel] += 1;
+                  }
+                  else {
+                    sbox.background_hist[this_pixel] = 1;
+                  }
+                }
+                else {
+                  sbox.n_invalid_bg += 1;
+                }
+              }*/
+              // sdata(z, y, x) = data(y + y0, x + x0);
+              // smask(z, y, x) = mask(y + y0, x + x0) ? Valid : 0;
+              // }
+            }
+            //}
+            if (frame_ == sbox.bbox[5] - 1) {
+              process_indices.push_back(ind[i]);
+            }
           }
         }
       }
@@ -561,7 +731,41 @@ namespace dials { namespace algorithms {
       frame_++;
     }
 
-        /** @returns The first frame.  */
+    template <typename T>
+    af::shared<int> finalise(af::reflection_table data) {
+      af::shared<int> total_intensity(data.size());
+      af::const_ref<Shoebox<>> shoebox = data["shoebox"];
+      af::shared<bool> success = data["summation_success"];
+      af::shared<int> nbg = data["num_pixels.background"];
+      af::shared<int> bg_used = data["num_pixels.background_used"];
+      af::shared<int> foreground = data["num_pixels.foreground"];
+      af::shared<int> valid = data["num_pixels.valid"];
+      for (int i = 0; i < data.size(); i++) {
+        total_intensity[i] = shoebox[i].total_intensity;
+        if (shoebox[i].n_invalid_fg > 0) {
+          success[i] = false;
+        }
+        nbg[i] = shoebox[i].n_valid_bg;
+        // bg_used[i] = shoebox[i].n_valid_bg;
+        foreground[i] = shoebox[i].n_valid_fg;
+        valid[i] = shoebox[i].n_valid_bg + shoebox[i].n_valid_fg;
+
+        /*int bg_size = shoebox[i].background_hist.size();
+        std::cout << "Number of elements in bg hist: " << bg_size << std::endl;
+        std::cout << "Number of elements in shoebox: " << ((shoebox[i].bbox[1] -
+        shoebox[i].bbox[0]) *(shoebox[i].bbox[3] - shoebox[i].bbox[2]) *
+        (shoebox[i].bbox[5] - shoebox[i].bbox[4]))<< std::endl; int total_bg_count = 0;
+        for (auto& it: shoebox[i].background_hist){
+          std::cout << "bg " << it.first << " " << it.second << std::endl;
+          total_bg_count += it.second;
+        }
+        std::cout << "Total background: " << total_bg_count<< std::endl;*/
+      }
+      return total_intensity;
+      // data["intensity_sum_value"] = total_intensity;
+    }
+
+    /** @returns The first frame.  */
     int frame0() const {
       return frame0_;
     }

--- a/src/dials/algorithms/integration/processor.h
+++ b/src/dials/algorithms/integration/processor.h
@@ -650,7 +650,7 @@ namespace dials { namespace algorithms {
     }
 
     template <typename T>
-    af::shared<int> finalise(af::reflection_table data) {
+    af::shared<int> finalise(af::reflection_table& data) {
       af::shared<int> total_intensity(data.size());
       af::const_ref<Shoebox<>> shoebox = data["shoebox"];
       af::shared<bool> success = data["summation_success"];

--- a/src/dials/algorithms/integration/processor.h
+++ b/src/dials/algorithms/integration/processor.h
@@ -658,16 +658,26 @@ namespace dials { namespace algorithms {
       af::shared<int> bg_used = data["num_pixels.background_used"];
       af::shared<int> foreground = data["num_pixels.foreground"];
       af::shared<int> valid = data["num_pixels.valid"];
+      af::shared<double> variance = data["intensity.sum.variance"];
       af::shared<double> background = data["background.mean"];
-      // af::shared<double> background_variance = data["background.sum.variance"];
+      af::shared<double> background_total =
+        data["background.sum.value"];  // this is the sum of the background under the
+                                       // foreground region
+      af::shared<double> background_variance = data["background.sum.variance"];
       for (int i = 0; i < data.size(); i++) {
         background[i] = shoebox[i].mean_background;
         // background_variance[i] = shoebox[i].mean_background;
-        total_intensity[i] = shoebox[i].total_intensity
-                             - (shoebox[i].mean_background * shoebox[i].n_valid_fg);
+        double bg_total = shoebox[i].mean_background * shoebox[i].n_valid_fg;
+        total_intensity[i] = shoebox[i].total_intensity - bg_total;
         if (shoebox[i].n_invalid_fg > 0) {
           success[i] = false;
         }
+        background_total[i] = bg_total;
+        double m_n = shoebox[i].n_valid_bg > 0
+                       ? (double)shoebox[i].n_valid_fg / (double)shoebox[i].n_valid_bg
+                       : 0.0;
+        variance[i] = std::abs(total_intensity[i]) + std::abs(bg_total) * (1.0 + m_n);
+        background_variance[i] = std::abs(bg_total) * (1.0 + m_n);
         nbg[i] = shoebox[i].n_valid_bg;
         bg_used[i] = shoebox[i].n_valid_bg;
         foreground[i] = shoebox[i].n_valid_fg;

--- a/src/dials/algorithms/integration/processor.h
+++ b/src/dials/algorithms/integration/processor.h
@@ -35,6 +35,7 @@
 
 namespace dials { namespace algorithms {
 
+  using af::BackgroundIncludesBadPixels;
   using model::Image;
   using model::Shoebox;
   using model::Valid;
@@ -661,6 +662,7 @@ namespace dials { namespace algorithms {
       af::shared<int6> bbox = data["bbox"];
       af::shared<bool> success = data["summation_success"];
       af::shared<int> nbg = data["num_pixels.background"];
+      af::ref<std::size_t> flags = data["flags"];
       af::shared<int> bg_used = data["num_pixels.background_used"];
       af::shared<int> foreground = data["num_pixels.foreground"];
       af::shared<int> valid = data["num_pixels.valid"];
@@ -690,6 +692,9 @@ namespace dials { namespace algorithms {
         bg_used[i] = shoebox[i].n_valid_bg;
         foreground[i] = shoebox[i].n_valid_fg;
         valid[i] = shoebox[i].n_valid_bg + shoebox[i].n_valid_fg;
+        if (shoebox[i].n_invalid_bg) {
+          flags[i] |= BackgroundIncludesBadPixels;
+        }
         if (shoebox[i].total_intensity) {
           xyzobs[i] =
             shoebox[i].sum_pixel_coords_intensity / shoebox[i].total_intensity;

--- a/src/dials/algorithms/integration/processor.h
+++ b/src/dials/algorithms/integration/processor.h
@@ -650,21 +650,26 @@ namespace dials { namespace algorithms {
     }
 
     template <typename T>
-    af::shared<int> finalise(af::reflection_table& data) {
-      af::shared<int> total_intensity(data.size());
+    af::shared<double> finalise(af::reflection_table& data) {
+      af::shared<double> total_intensity(data.size());
       af::const_ref<Shoebox<>> shoebox = data["shoebox"];
       af::shared<bool> success = data["summation_success"];
       af::shared<int> nbg = data["num_pixels.background"];
       af::shared<int> bg_used = data["num_pixels.background_used"];
       af::shared<int> foreground = data["num_pixels.foreground"];
       af::shared<int> valid = data["num_pixels.valid"];
+      af::shared<double> background = data["background.mean"];
+      // af::shared<double> background_variance = data["background.sum.variance"];
       for (int i = 0; i < data.size(); i++) {
-        total_intensity[i] = shoebox[i].total_intensity;
+        background[i] = shoebox[i].mean_background;
+        // background_variance[i] = shoebox[i].mean_background;
+        total_intensity[i] = shoebox[i].total_intensity
+                             - (shoebox[i].mean_background * shoebox[i].n_valid_fg);
         if (shoebox[i].n_invalid_fg > 0) {
           success[i] = false;
         }
         nbg[i] = shoebox[i].n_valid_bg;
-        // bg_used[i] = shoebox[i].n_valid_bg;
+        bg_used[i] = shoebox[i].n_valid_bg;
         foreground[i] = shoebox[i].n_valid_fg;
         valid[i] = shoebox[i].n_valid_bg + shoebox[i].n_valid_fg;
       }

--- a/src/dials/algorithms/symmetry/cosym/target.py
+++ b/src/dials/algorithms/symmetry/cosym/target.py
@@ -337,6 +337,9 @@ class Target:
         if self._weights:
             ## use the counts as weights
             wij_matrix = wij_matrix.toarray().astype(np.float64)
+            wij_matrix_sel = wij_matrix[wij_matrix > 0]
+            logger.info("Mean number of effective common reflections:")
+            logger.info(np.mean(wij_matrix_sel))
             if self._weights == "standard_error":
                 # N.B. using effective n due to sigma weighting, which can be below 2
                 # but approches 1 in the limit, so rather say efective sample size

--- a/src/dials/array_family/flex_ext.py
+++ b/src/dials/array_family/flex_ext.py
@@ -558,13 +558,13 @@ class _:
         # Both sets of reflections
         i1 = self["id"]
         h1 = self["miller_index"]
-        #e1 = self["entering"].as_int()
+        e1 = self["entering"].as_int()
         x1, y1, z1 = self["xyzcal.px"].parts()
         p1 = self["panel"]
 
         i2 = other["id"]
         h2 = other["miller_index"]
-        #e2 = other["entering"].as_int()
+        e2 = other["entering"].as_int()
         x2, y2, z2 = other["xyzcal.px"].parts()
         p2 = other["panel"]
 
@@ -576,12 +576,12 @@ class _:
         # Create the match lookup
         lookup = collections.defaultdict(Match)
         for i in range(len(self)):
-            item = h1[i] + (i1[i], p1[i])
+            item = h1[i] + (e1[i], i1[i], p1[i])
             lookup[item].a.append(i)
 
         # Add matches from input reflections
         for i in range(len(other)):
-            item = h2[i] + (i2[i], p2[i])
+            item = h2[i] + (e2[i], i2[i], p2[i])
             if item in lookup:
                 lookup[item].b.append(i)
 
@@ -627,10 +627,10 @@ class _:
         o2 = other.select(oind)
         h1 = s2["miller_index"]
         h2 = o2["miller_index"]
-        #e1 = s2["entering"]
-        #e2 = o2["entering"]
+        e1 = s2["entering"]
+        e2 = o2["entering"]
         assert (h1 == h2).all_eq(True)
-        #assert (e1 == e2).all_eq(True)
+        assert (e1 == e2).all_eq(True)
         x1, y1, z1 = s2["xyzcal.px"].parts()
         x2, y2, z2 = o2["xyzcal.px"].parts()
         distance = cctbx.array_family.flex.sqrt(

--- a/src/dials/array_family/flex_ext.py
+++ b/src/dials/array_family/flex_ext.py
@@ -558,13 +558,13 @@ class _:
         # Both sets of reflections
         i1 = self["id"]
         h1 = self["miller_index"]
-        e1 = self["entering"].as_int()
+        #e1 = self["entering"].as_int()
         x1, y1, z1 = self["xyzcal.px"].parts()
         p1 = self["panel"]
 
         i2 = other["id"]
         h2 = other["miller_index"]
-        e2 = other["entering"].as_int()
+        #e2 = other["entering"].as_int()
         x2, y2, z2 = other["xyzcal.px"].parts()
         p2 = other["panel"]
 
@@ -576,12 +576,12 @@ class _:
         # Create the match lookup
         lookup = collections.defaultdict(Match)
         for i in range(len(self)):
-            item = h1[i] + (e1[i], i1[i], p1[i])
+            item = h1[i] + (i1[i], p1[i])
             lookup[item].a.append(i)
 
         # Add matches from input reflections
         for i in range(len(other)):
-            item = h2[i] + (e2[i], i2[i], p2[i])
+            item = h2[i] + (i2[i], p2[i])
             if item in lookup:
                 lookup[item].b.append(i)
 
@@ -627,10 +627,10 @@ class _:
         o2 = other.select(oind)
         h1 = s2["miller_index"]
         h2 = o2["miller_index"]
-        e1 = s2["entering"]
-        e2 = o2["entering"]
+        #e1 = s2["entering"]
+        #e2 = o2["entering"]
         assert (h1 == h2).all_eq(True)
-        assert (e1 == e2).all_eq(True)
+        #assert (e1 == e2).all_eq(True)
         x1, y1, z1 = s2["xyzcal.px"].parts()
         x2, y2, z2 = o2["xyzcal.px"].parts()
         distance = cctbx.array_family.flex.sqrt(

--- a/src/dials/model/data/shoebox.h
+++ b/src/dials/model/data/shoebox.h
@@ -77,6 +77,7 @@ namespace dials { namespace model {
     int n_invalid_fg{0};
     int n_valid_bg{0};
     int n_invalid_bg{0};
+    double mean_background{0};
     bool masked_image_pixel{false};
     std::unordered_map<int, int> background_hist;
     /**

--- a/src/dials/model/data/shoebox.h
+++ b/src/dials/model/data/shoebox.h
@@ -77,6 +77,7 @@ namespace dials { namespace model {
     int n_invalid_fg{0};
     int n_valid_bg{0};
     int n_invalid_bg{0};
+    // int n_signal{0};
     double mean_background{0};
     bool masked_image_pixel{false};
     std::unordered_map<int, int> background_hist;

--- a/src/dials/model/data/shoebox.h
+++ b/src/dials/model/data/shoebox.h
@@ -77,7 +77,7 @@ namespace dials { namespace model {
     int n_invalid_fg{0};
     int n_valid_bg{0};
     int n_invalid_bg{0};
-    // int n_signal{0};
+    vec3<double> sum_pixel_coords_intensity{{0, 0, 0}};  // coord times intensity
     double mean_background{0};
     bool masked_image_pixel{false};
     std::unordered_map<int, int> background_hist;

--- a/src/dials/model/data/shoebox.h
+++ b/src/dials/model/data/shoebox.h
@@ -22,6 +22,7 @@
 #include <dials/model/data/mask_code.h>
 #include <dials/config.h>
 #include <dials/error.h>
+#include <unordered_map>
 
 namespace dials { namespace model {
 
@@ -71,7 +72,13 @@ namespace dials { namespace model {
     af::versa<FloatType, af::c_grid<3> > data;        ///< The shoebox data
     af::versa<int, af::c_grid<3> > mask;              ///< The shoebox mask
     af::versa<FloatType, af::c_grid<3> > background;  ///< The shoebox background
-
+    int total_intensity{0};
+    int n_valid_fg{0};
+    int n_invalid_fg{0};
+    int n_valid_bg{0};
+    int n_invalid_bg{0};
+    bool masked_image_pixel{false};
+    std::unordered_map<int, int> background_hist;
     /**
      * Initialise the shoebox
      */


### PR DESCRIPTION
Status: Proof of principle draft, for visibility.
Todo:
- [ ] Create separate classes for new behaviour rather than hacking onto existing data structures
- [ ] Add profile fitting (just summation at the moment).

This PR is an attempt to overcome the very high memory usage in dials for datasets with high mosaicity (see e.g. https://github.com/dials/dials/issues/659), for 'standard' rotation experiments.
It defines a new integrator class (`integrator=inflight`) which is a specialisation for data from counting detectors (i.e. what are used almost exclusively at synchrotrons) and constant 3d background model (our default choice). Rather than storing three arrays in the shoebox (data, background, flags) which are the size of the shoebox volume, the intensity summation and foreground/background/mask calculations are done as the data are loaded, while the background data is stored as a histogram, thus avoiding the need to allocate any of the three arrays. I plan to add the profile fitting in here as well.

To compare to the existing integrator, the two commands are:
`dials.integrate integrator=inflight refined.*`
which gives equivalent results to
`dials.integrate profile.fitting=False refined.*`

As an example, I tested on a mosaic dataset with sigma_m ~ 0.4, for the standard integrator I was getting a memory usage of ~13GB just running with nproc=1, whereas for the inflight integrator, I could use all the cores of my machine and each process was taking ~400MB.  When using the same nproc for both integrators, the calculation time is approximately the same.
