### PR TITLE
Display both total and non-ice unindexed reflections

### DIFF
--- a/src/dials/algorithms/indexing/indexer.py
+++ b/src/dials/algorithms/indexing/indexer.py
@@ -926,8 +926,8 @@ class Indexer:
             [
                 "Imageset",
                 "# indexed",
-                "# unindexed",
-                "# non-ice",
+                "# unindexed\ntotal",
+                "# unindexed\nnon-ice",
                 "% indexed",
             ]
         ]
@@ -949,7 +949,7 @@ class Indexer:
                     str(indexed_count),
                     str(unindexed_count),
                     str(unindexed_noice),
-                    f"{indexed_count / (indexed_count + unindexed_count)*100:.1f}",
+                    f"{indexed_count / (indexed_count + unindexed_count) * 100:.1f}",
                 ]
             )
         logger.info(dials.util.tabulate(rows, headers="firstrow"))


### PR DESCRIPTION
Changed the names of the two columns, "unindexed" and "non-ice" to "unindexed total" and "unindexed non-ice" while respecting the desired 80-character-per-row limit.

I think the new names are more descriptive, though I am open to other suggestions as well.