### PR TITLE
Better import of integrate.hkl from xds

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,3 @@
+Reworked the import of INTEGRATE.HKL from XDS to have a more complete
+matchup between the data provided in that file and the reflection list
+expected by Dials.

--- a/src/dials/command_line/import_xds.py
+++ b/src/dials/command_line/import_xds.py
@@ -74,16 +74,19 @@ class SpotXDSImporter:
 
 
 class IntegrateHKLImporter:
-    """Class to import an integrate.hkl file to a reflection table."""
+    """Class to import an INTEGRATE.HKL file to a reflection table."""
 
-    def __init__(self, integrate_hkl, experiment):
+    def __init__(self, integrate_hkl, experiments):
         self._integrate_hkl = integrate_hkl
-        self._experiment = experiment
+        self._experiment = experiments[0]
+        self._experiments = experiments
 
     def __call__(self, params, options):
         """Import the integrate.hkl file."""
         # Get the unit cell to calculate the resolution
+        Command.start("Get the unit cell to calculate the resolution")
         uc = self._experiment.crystal.get_unit_cell()
+        print("\n")
 
         # Read the INTEGRATE.HKL file
         Command.start("Reading INTEGRATE.HKL")
@@ -94,13 +97,36 @@ class IntegrateHKLImporter:
         xyzobs = flex.vec3_double(handle.xyzobs)
         iobs = flex.double(handle.iobs)
         sigma = flex.double(handle.sigma)
+
+        # CV-20250507: for INTEGRATE.HKL this contains /only/ L - not P!
         rlp = flex.double(handle.rlp)
+
         peak = flex.double(handle.peak) * 0.01
+        corr = flex.double(handle.corr) * 0.01
         if len(handle.iseg):
             panel = flex.size_t(handle.iseg) - 1
         else:
             panel = flex.size_t(len(hkl), 0)
         Command.end(f"Read {len(hkl)} reflections from INTEGRATE.HKL file.")
+
+        undo_ab = True
+
+        # ideally we would like to do that - but because of limited precision in
+        # INTEGRATE.HKL we could get into trouble here ...
+        if (handle.variance_model and undo_ab):
+            variance_model_a = handle.variance_model[0]
+            variance_model_b = handle.variance_model[1]
+            print("Undoing input variance model a, b = %s %s" % (variance_model_a,variance_model_b))
+
+            # undo variance model:
+            vari0 = flex.pow2(sigma * peak / rlp)
+            isq  = flex.pow2(iobs * peak / rlp)
+            vari1 = (vari0/variance_model_a) - (variance_model_b*isq)
+            for i in range(0,(sigma.size()-1)):
+                if vari1[i] <= 0:
+                    print("WARNING:",i,iobs[i],sigma[i],vari1[i])
+                    vari1[i] = sigma[i]*sigma[i]
+            sigma = flex.sqrt(vari1) * rlp / peak
 
         if len(self._experiment.detector) > 1:
             for p_id, p in enumerate(self._experiment.detector):
@@ -125,14 +151,43 @@ class IntegrateHKLImporter:
         table["id"] = flex.int(len(hkl), 0)
         table["panel"] = panel
         table["miller_index"] = hkl
+
         table["xyzcal.px"] = xyzcal
         table["xyzobs.px.value"] = xyzobs
-        table["intensity.cor.value"] = iobs
-        table["intensity.cor.variance"] = flex.pow2(sigma)
+        # uncorrected "partials":
         table["intensity.prf.value"] = iobs * peak / rlp
         table["intensity.prf.variance"] = flex.pow2(sigma * peak / rlp)
-        table["lp"] = 1.0 / rlp
+        table.set_flags(flex.bool(table.size(), True), table.flags.integrated_prf)
+
         table["d"] = flex.double(uc.d(h) for h in hkl)
+
+        table["partiality"] = peak
+        table["profile.correlation"] = corr
+
+        table.centroid_px_to_mm(self._experiments)
+
+        # same as prf?
+        table["intensity.sum.value"] = iobs * peak / rlp
+        table["intensity.sum.variance"] = flex.pow2(sigma * peak / rlp)
+        table.map_centroids_to_reciprocal_space(self._experiments)
+        table["intensity.scale.value"] = flex.double(table.size(), 1.0)
+        table["intensity.scale.variance"] = flex.double(table.size(), 0.0)
+
+        # LP-corrected fulls:
+        table["intensity.cor.value"] = iobs
+        table["intensity.cor.variance"] = flex.pow2(sigma)
+        table["inverse_scale_factor"] = flex.double(table.size(), 1.0)
+
+        table["batch"] = flex.int(int(x[2])+handle.starting_frame for x in xyzcal)
+
+        # compute ZETA
+        table.compute_zeta(self._experiment)
+        # compute LP
+        table.compute_corrections(self._experiments)
+
+        table.set_flags(flex.bool(table.size(), True), table.flags.predicted)
+        table.set_flags(flex.bool(table.size(), True), table.flags.integrated)
+
         Command.end(f"Created table with {len(table)} reflections")
 
         # Output the table to pickle file
@@ -187,6 +242,14 @@ class XDSFileImporter:
         # Load the experiment list
         unhandled = []
         experiments = ExperimentListFactory.from_xds(xds_inp, xds_file)
+
+        # set some dummy epochs
+        nimg = experiments[0].scan.get_image_range()[1] - experiments[0].scan.get_image_range()[0] + 1
+        epochs = flex.double(nimg,0.)
+        for i in range(1,(nimg-1)):
+            epochs[i]=epochs[(i-1)]+1.0
+        experiments[0].scan.set_epochs(epochs)
+        experiments[0].scan.set_exposure_times(epochs)
 
         # Print out any unhandled files
         if len(unhandled) > 0:
@@ -287,6 +350,11 @@ class XDSFileImporter:
             )
             return
         experiment = experiments[0]
+
+        # NOTE: we are not reading SEGMENT information here - so HKL
+        # file needs also be without SEGMENT information, e.g. via
+        #
+        # egrep -v "^.SEGMENT=|^! .*=" INTEGRATE.HKL.orig | sed "s/,ISEG//g" | sed "s/^ \(.*\) [ ]*[0-9][0-9]*[ ]*$/ \1/g" > INTEGRATE.HKL
 
         # read required records from the file. Relies on them being in the
         # right order as we read through once
@@ -447,7 +515,7 @@ class Script:
             assert len(args) == 2
             experiments = ExperimentListFactory.from_json_file(args[1])
             assert len(experiments) == 1
-            return IntegrateHKLImporter(args[0], experiments[0])
+            return IntegrateHKLImporter(args[0], experiments)
         else:
             raise RuntimeError(f"expected (SPOT.XDS|INTEGRATE.HKL), got {filename}")
 

--- a/src/dials/command_line/reflection_viewer.py
+++ b/src/dials/command_line/reflection_viewer.py
@@ -40,6 +40,17 @@ class Script:
             self.parser.print_help()
             return
 
+        # list columns
+        cols = "\n showing columns:"
+        ikey = 0
+        for key in table[0].keys():
+            cols = cols + " " + key
+            ikey = ikey + 1
+            if ikey==5:
+                cols = cols + "\n                 "
+                ikey=0
+        print(cols+"\n")
+
         extract_n_show(table[0])
 
 


### PR DESCRIPTION
I've tested that quite  a bit over a large number of examples ... and am fairly confident it is doing "the right thing" (or: doing it at least better than the previous version). Using the resulting reflection list with dials.scale seems to work well now.
