### PR TITLE
DIALS 3.24.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.24.1 (2025-05-13)
+=========================
+
+Bugfixes
+--------
+
+- Add missing implementation in multi-dataset-handling OrderedSet. This caused a crash running ``xia2.ssx_reduce``. (`#2916 <https://github.com/dials/dials/issues/2916>`_)
+
+
 DIALS 3.24.0 (2025-04-29)
 =========================
 

--- a/newsfragments/2916.bugfix
+++ b/newsfragments/2916.bugfix
@@ -1,0 +1,1 @@
+Add missing implementation in multi-dataset-handling OrderedSet. This caused a crash running ``xia2.ssx_reduce``.

--- a/newsfragments/2916.bugfix
+++ b/newsfragments/2916.bugfix
@@ -1,1 +1,0 @@
-Add missing implementation in multi-dataset-handling OrderedSet. This caused a crash running ``xia2.ssx_reduce``.

--- a/src/dials/util/multi_dataset_handling.py
+++ b/src/dials/util/multi_dataset_handling.py
@@ -52,6 +52,9 @@ class OrderedSet:
     def index(self, item):
         return self._dict[item]
 
+    def __contains__(self, item):
+        return item in self._dict
+
     def __iter__(self):
         return iter(self._dict)
 


### PR DESCRIPTION
Bugfixes
--------

- Add missing implementation in multi-dataset-handling OrderedSet. This caused a crash running ``xia2.ssx_reduce``. (#2916)