### PR TITLE
Write integrate and scale history to MTZ

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,3 @@
+``dials.index``: Do not lose the
+``dials.export``: Write MTZ history lines for ``dials.integrate`` and ``dials.scale``
+

--- a/src/dials/command_line/index.py
+++ b/src/dials/command_line/index.py
@@ -234,6 +234,7 @@ def index(experiments, reflections, params):
                     tables_list.append(idx_refl)
                     indexed_experiments.extend(idx_expts)
         indexed_reflections = flex.reflection_table.concat(tables_list)
+
     return indexed_experiments, indexed_reflections
 
 
@@ -276,6 +277,11 @@ def run(args=None, phil=working_phil):
         )
     except (DialsIndexError, ValueError) as e:
         sys.exit(str(e))
+
+    # Copy history from the imported experiments to the output
+    history = experiments.consolidate_histories()
+    for experiment in indexed_experiments:
+        experiment.history = history
 
     # Save experiments
     logger.info("Saving refined experiments to %s", params.output.experiments)

--- a/src/dials/command_line/integrate.py
+++ b/src/dials/command_line/integrate.py
@@ -754,7 +754,7 @@ def run(args=None, phil=working_phil):
         )
         reflections.as_file(params.output.reflections)
         logger.info("Saving the experiments to %s", params.output.experiments)
-        experiments.as_file(params.output.experiments)
+        experiments.as_file(params.output.experiments, history_as_integrated=True)
 
         if report:
             report.as_file(params.output.report)

--- a/src/dials/command_line/scale.py
+++ b/src/dials/command_line/scale.py
@@ -238,7 +238,9 @@ def run(args: list[str] = None, phil: phil.scope = phil_scope) -> None:
             logger.info(
                 "Saving the scaled experiments to %s", params.output.experiments
             )
-            scaled_experiments.as_file(params.output.experiments)
+            scaled_experiments.as_file(
+                params.output.experiments, history_as_scaled=True
+            )
             logger.info(
                 "Saving the scaled reflections to %s", params.output.reflections
             )

--- a/src/dials/util/export_mtz.py
+++ b/src/dials/util/export_mtz.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from math import isclose
 
+import dateutil.parser
 import gemmi
 import numpy as np
 import pandas as pd
@@ -674,12 +675,28 @@ def export_mtz(
     # Create the mtz file
     mtz = gemmi.Mtz(with_base=True)
     mtz.title = f"From {env.dispatcher_name}"
-    date_str = time.strftime("%Y-%m-%d at %H:%M:%S %Z")
-    if time.strftime("%Z") != "GMT":
-        date_str += time.strftime("  (%Y-%m-%d at %H:%M:%S %Z)", time.gmtime())
-    mtz.history += [
-        f"From {dials_version()}, run on {date_str}",
-    ]
+    # If the experiments have history lines, use the integrated and scaled
+    # entries from these for MTZ history
+    filtered_lines = {}
+    if experiment_list[0].history:
+        history_lines = experiment_list[0].history.get_history()
+        for line in history_lines:
+            items = line.split("|")
+            if len(items) == 4 and ("integrated" in items[3] or "scaled" in items[3]):
+                program = items[1] + " " + items[2]
+                filtered_lines[program] = dateutil.parser.isoparse(items[0])
+        for program, date in filtered_lines.items():
+            mtz.history += [
+                f"From {program}, run on {date.strftime('%Y-%m-%d at %H:%M:%S %Z')}",
+            ]
+    if not filtered_lines:
+        # Retain the old approach when experiments don't have history
+        date_str = time.strftime("%Y-%m-%d at %H:%M:%S %Z")
+        if time.strftime("%Z") != "GMT":
+            date_str += time.strftime("  (%Y-%m-%d at %H:%M:%S %Z)", time.gmtime())
+        mtz.history += [
+            f"From {dials_version()}, run on {date_str}",
+        ]
 
     # Create the right gemmi spacegroup from the crystal's cctbx space_group
     # via a Hall symbol


### PR DESCRIPTION
This is the DIALS companion to https://github.com/cctbx/dxtbx/pull/816, and requires that to be merged first. Changes here:

- History is explicitly copied from the imported experiments in `dials.index`, fixing the issue that this got lost because of the way `dials.index` constructs experiments
- When `dials.integrate` and `dials.scale` write `.expt` files they flag that these lines are interesting for `dials.export`
- `dials.export` then takes these interesting lines and adds appropriate MTZ history items

As an example, these lines are written to the MTZ history for standard single crystal rotation processing:
```
From dials.integrate v3.22.dev0, run on 2025-05-14 at 10:53:02 UTC
From dials.scale v3.22.dev0, run on 2025-05-14 at 10:53:18 UTC
```

The version string looks a  bit odd. When I run `dials.version` on the same computer I see `3.dev.1314-g6a06be331`. The way version information is extracted for experiment history is by using `importlib.metadata.version`, which for DIALS gives:

```
>>> importlib.metadata.version("dials")
'3.22.dev0'
```

@ndevenish is this `importlib.metadata.version` call for DIALS correct? For the history functionality in dxtbx I could not rely on `dials.version`, because I can't be sure the software writing the `.expt` is actually DIALS. Indeed for `xia2.multiplex` I would get `'3.9.dev184+g8e8dffbc'` as the version string here on my computer.