### PR TITLE
Faster test for `dials.model_background`

### DIFF
--- a/newsfragments/xxx.misc
+++ b/newsfragments/xxx.misc
@@ -1,0 +1,1 @@
+The test of ``dials.modify_background`` is now faster as it uses a smaller data set.


### PR DESCRIPTION
For #2920. The main time spent in this test is looping over pixels in `dials.model_background`. Using a P2M data set rather than a P6M data set helps a fair bit.

Before:
```
time pytest --regression tests/command_line/test_model_background.py
...
real	1m6.116s
user	1m7.664s
sys	0m4.868s
```

After:
```
time pytest --regression tests/command_line/test_model_background.py
...
real	0m31.057s
user	0m36.148s
sys	0m2.645s
```