### PR TITLE
dials.import: Expand globs recursively

### DIFF
--- a/newsfragments/XXX.feature
+++ b/newsfragments/XXX.feature
@@ -1,0 +1,1 @@
+``dials.import``: Expand recursive wildcards (``./some/**/*.h5``).

--- a/src/dials/util/options.py
+++ b/src/dials/util/options.py
@@ -269,7 +269,7 @@ class Importer:
         for arg in args:
             # Don't expand wildcards if URI-style filename
             if "*" in arg and not get_url_scheme(arg):
-                filenames = glob(arg)
+                filenames = glob(arg, recursive=True)
                 if filenames:
                     args_new.extend(filenames)
                 else:


### PR DESCRIPTION
Came up in dials-support-group -  I don't think there's any good reason not to turn this on?