### PR TITLE
`dials.find_spots`: do not write out an empty `strong.refl`

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+``dials.find_spots``: do not write out an empty ``strong.refl`` if no reflections are found.

--- a/src/dials/command_line/find_spots.py
+++ b/src/dials/command_line/find_spots.py
@@ -160,11 +160,13 @@ def do_spotfinding(
             for k in reflections.experiment_identifiers().keys():
                 del reflections.experiment_identifiers()[k]
 
-    reflections.as_file(params.output.reflections)
-
-    logger.info(
-        "Saved %s reflections to %s", len(reflections), params.output.reflections
-    )
+    if len(reflections):
+        reflections.as_file(params.output.reflections)
+        logger.info(
+            "Saved %s reflections to %s", len(reflections), params.output.reflections
+        )
+    else:
+        logger.warning("No reflections found")
 
     # Reset the trusted ranges
     if params.maximum_trusted_value is not None:


### PR DESCRIPTION
Some programs don't like an empty `strong.refl` (#2966). Simple solution - don't write one if there are no reflections found.