### PR TITLE
Add Scan.has_property("oscillation") checks in px<->mm methods

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Add extra checks for Scans having oscillation values in `centroid_px_to_mm_panel` and `Indexer._xyzcal_mm_to_px`

--- a/src/dials/algorithms/centroid/__init__.py
+++ b/src/dials/algorithms/centroid/__init__.py
@@ -24,7 +24,7 @@ def centroid_px_to_mm_panel(panel, scan, position, variance, sd_error):
         return tof_centroid_px_to_mm_panel(panel, scan, position, variance, sd_error)
 
     pixel_size = panel.get_pixel_size()
-    if scan is None:
+    if scan is None or not scan.has_property("oscillation"):
         oscillation = (0, 0)
     else:
         oscillation = scan.get_oscillation(deg=False)
@@ -36,7 +36,7 @@ def centroid_px_to_mm_panel(panel, scan, position, variance, sd_error):
         x, y, z = position
         xy_mm = panel.pixel_to_millimeter((x, y))
 
-        if scan is None:
+        if scan is None or not scan.has_property("oscillation"):
             z_rad = 0
         else:
             z_rad = scan.get_angle_from_array_index(z, deg=False)
@@ -53,7 +53,7 @@ def centroid_px_to_mm_panel(panel, scan, position, variance, sd_error):
         x, y, z = position.parts()
         xy_mm = panel.pixel_to_millimeter(flex.vec2_double(x, y))
 
-        if scan is None:
+        if scan is None or not scan.has_property("oscillation"):
             z_rad = flex.double(z.size(), 0)
         else:
             z_rad = scan.get_angle_from_array_index(z, deg=False)

--- a/src/dials/algorithms/indexing/indexer.py
+++ b/src/dials/algorithms/indexing/indexer.py
@@ -890,8 +890,10 @@ class Indexer:
                     z.set_selected(z < min(tof), min(tof))
                     z.set_selected(z > max(tof), max(tof))
                     z_px = flex.double(tof_to_frame(z))
-                else:
+                elif expt.scan.has_property("oscillation"):
                     z_px = expt.scan.get_array_index_from_angle(z, deg=False)
+                else:
+                    z_px = z
             else:
                 # must be a still image, z centroid not meaningful
                 z_px = z


### PR DESCRIPTION
In `centroid_px_to_mm_panel` and `Indexer._xyzcal_mm_to_px` Scans are assumed to have oscillation. This adds extra checks to ensure oscillation values are present, and fixes these methods giving an error for experiments that have Scans without this property.