### PR TITLE
Enable PinkIndexer to be used with joint indexing and polychromatic data

### DIFF
--- a/newsfragments/XXX.feature
+++ b/newsfragments/XXX.feature
@@ -1,0 +1,1 @@
+Enable `PinkIndexer` to be used with joint indexing and with polychromatic experiments.

--- a/src/dials/algorithms/indexing/lattice_search/pinkindexer.py
+++ b/src/dials/algorithms/indexing/lattice_search/pinkindexer.py
@@ -8,8 +8,10 @@ from scipy.spatial.transform import Rotation
 
 import iotbx.phil
 from dxtbx.model import Crystal
+from scitbx import matrix
 
 from dials.algorithms.indexing import DialsIndexError
+from dials.array_family import flex
 
 from .strategy import Strategy
 
@@ -189,8 +191,7 @@ class Indexer:
 
     def index_pink(
         self,
-        s0,
-        s1,
+        rlps,
         max_refls=50,
         rotogram_grid_points=200,
         voxel_grid_points=200,
@@ -201,8 +202,7 @@ class Indexer:
     ):
         """
         Args:
-            s0 (array): An array of 3 floating point numbers corresponding to the s0 vector. This will be normalized.
-            s1 (array): An n x 3 array floating point numbers corresponding to the s1 vectors. This will be normalized.
+            rlps (array): An n x 3 array floating point numbers corresponding to the rlp vectors. This will be normalized.
             max_refls (int, optional): The maximum number of refls to consider.
             rotogram_grid_points (int, optional): The number of points at which to evaluate the rotograms.
             voxel_grid_points (int, optional): The fineness of the discretization used to quantitate rotograms.
@@ -214,10 +214,7 @@ class Indexer:
         Returns:
             iter_UB: an interable of crystal bases as numpy arrays
         """
-        s0_hat = normalize(np.asarray(s0, dtype=self.float_dtype))
-        s1_hat = normalize(np.asarray(s1, dtype=self.float_dtype))
-
-        q = s1_hat - s0_hat[None, :]
+        q = rlps
         q_len = norm2(q, keepdims=True)  # length of q if lambda is 1A
 
         # Possible resolution range for each observation considering wavelength range
@@ -229,8 +226,6 @@ class Indexer:
         if len(res_min) > max_refls:
             dmin = np.sort(res_min)[-max_refls]
             in_range = res_min >= dmin
-            s1_hat = s1_hat[in_range]
-            s1 = s1[in_range]
             q = q[in_range]
             q_len = q_len[in_range]
             res_min = res_min[in_range]
@@ -394,28 +389,53 @@ class PinkIndexer(Strategy):
         reflections["id"] *= 0
         reflections["id"] -= 1
 
-        if len(experiments) < 1:
-            msg = "pink_indexer received an experimentlist with length > 1. To use the pink_indexer method, you must set joint_indexing=False when you call dials.index"
-            raise ValueError(msg)
-
         expt = experiments[0]
         refls = reflections
 
         cell = gemmi.UnitCell(*self.cell.parameters())
 
-        beam = expt.beam
-        s0 = beam.get_s0()
         wav, bw = self.wavelength, self.percent_bandwidth
+        beam = expt.beam
         if wav is None:
-            wav = beam.get_wavelength()
+            if experiments.all_laue() or experiments.all_tof():
+                assert "wavelength" in reflections
+                wav = reflections["wavelength"]
+            else:
+                wav = beam.get_wavelength()
+
         if bw is None:
             bw = 1.0
         pidxr = Indexer(cell, wav, bw)
-        s1 = np.array(refls["s1"], dtype="float32")
+
+        rlps = flex.vec3_double(len(refls))
+        s1 = refls["s1"]
+        s1_hat = s1 / s1.norms()
+        s0_hat = beam.get_unit_s0()
+
+        # Rotate reflections to common coordinate frame
+        for i, expt in enumerate(experiments):
+            if expt.goniometer is not None:
+                sel_expt = refls["imageset_id"] == i
+                s1_hat_expt = s1_hat.select(sel_expt)
+                q = s1_hat_expt - s0_hat
+
+                setting_rotation = matrix.sqr(expt.goniometer.get_setting_rotation())
+                rotation_axis = expt.goniometer.get_rotation_axis_datum()
+                sample_rotation = matrix.sqr(expt.goniometer.get_fixed_rotation())
+                q = tuple(setting_rotation.inverse()) * q
+
+                if expt.scan is not None and expt.scan.has_property("oscillation"):
+                    _, _, z = refls["xyzobs.mm.value"].select(sel_expt).parts()
+                    q.rotate_around_origin(rotation_axis, -z)
+
+                q = tuple(sample_rotation.inverse()) * q
+
+                rlps.set_selected(sel_expt, q)
+
+        rlps = np.array(rlps, dtype="float32")
         self.candidate_crystal_models = []
         for UB in pidxr.index_pink(
-            s0,
-            s1,
+            rlps,
             self.max_refls,
             rotogram_grid_points=self.rotogram_grid_points,
             voxel_grid_points=self.voxel_grid_points,


### PR DESCRIPTION
This modifies the `PinkIndexer` algorithm to allow for joint indexing by first mapping all `s1`  vectors to a common coordinate frame. It also enables `PinkIndexer` to be used with polychromatic experiments by setting wavelength ranges from current reflection wavelength values.

Example below for time-of-flight data, consisting of an experiment of 8 orientations, indexed jointly with both `PinkIndexer` and `fft3d`:

`PinkIndexer`
```
Crystal:
    Unit cell: 8.9905(2), 12.2552(5), 16.6293(11), 90.0, 90.0, 90.0
    Space group: P n a 21
    U matrix:  {{-0.582246, -0.318917,  0.747851},
                { 0.199886,  0.835465,  0.511903},
                {-0.788058,  0.447538, -0.422699}}
    B matrix:  {{ 0.111228,  0.000000,  0.000000},
                {-0.000000,  0.081598,  0.000000},
                { 0.000000, -0.000000,  0.060135}}
    A = UB:    {{-0.064762, -0.026023,  0.044972},
                { 0.022233,  0.068172,  0.030783},
                {-0.087654,  0.036518, -0.025419}}
+------------+-------------+---------------+---------------+-------------+
|   Imageset |   # indexed |   # unindexed |   # unindexed |   % indexed |
|            |             |         total |       non-ice |             |
|------------+-------------+---------------+---------------+-------------|
|          0 |        1005 |            94 |            78 |        91.4 |
|          1 |         227 |             6 |             6 |        97.4 |
|          2 |         765 |            19 |            19 |        97.6 |
|          3 |         846 |            14 |            13 |        98.4 |
|          4 |         758 |            21 |            20 |        97.3 |
|          5 |         733 |            47 |            38 |        94   |
|          6 |        1111 |            29 |            25 |        97.5 |
|          7 |        1203 |            28 |            25 |        97.7 |
+------------+-------------+---------------+---------------+-------------+
Target d_min_final reached: finished with refinement

Saving refined experiments to indexed.expt
Saving refined reflections to indexed.refl

real    0m7.224s
user    0m8.741s
sys     0m0.180s
```
`fft3d`
```
Crystal:
    Unit cell: 8.991, 12.256, 16.630, 90.000, 90.000, 90.000
    Space group: P n a 21
    U matrix:  {{ 0.582220, -0.318933, -0.747864},
                {-0.199882,  0.835466, -0.511902},
                { 0.788078,  0.447524,  0.422676}}
    B matrix:  {{ 0.111221,  0.000000,  0.000000},
                { 0.000000,  0.081596,  0.000000},
                { 0.000000,  0.000000,  0.060134}}
    A = UB:    {{ 0.064755, -0.026024, -0.044972},
                {-0.022231,  0.068170, -0.030782},
                { 0.087651,  0.036516,  0.025417}}
+------------+-------------+---------------+---------------+-------------+
|   Imageset |   # indexed |   # unindexed |   # unindexed |   % indexed |
|            |             |         total |       non-ice |             |
|------------+-------------+---------------+---------------+-------------|
|          0 |        1005 |            93 |            77 |        91.5 |
|          1 |         227 |             6 |             6 |        97.4 |
|          2 |         765 |            19 |            19 |        97.6 |
|          3 |         844 |            16 |            15 |        98.1 |
|          4 |         758 |            21 |            20 |        97.3 |
|          5 |         733 |            47 |            38 |        94   |
|          6 |        1110 |            30 |            27 |        97.4 |
|          7 |        1204 |            27 |            23 |        97.8 |
+------------+-------------+---------------+---------------+-------------+

Saving refined experiments to indexed.expt
Saving refined reflections to indexed.refl

real    0m48.526s
user    0m49.800s
sys     0m0.459s
```

In this case the results are very similar, but `PinkIndexer` is nearly 6x faster.
This algorithm could be useful for time-of-flight data, as there is often some uncertainty in the measurement along the time-of-flight (wavelength) direction.



