### PR TITLE
Add additional spot finding filter for time-of-flight data

### DIFF
--- a/newsfragments/XXX.feature
+++ b/newsfragments/XXX.feature
@@ -1,0 +1,1 @@
+Add spot finding filter of time-of-flight data to filter out spots within close proximity in reciprocal space.

--- a/src/dials/algorithms/spot_finding/factory.py
+++ b/src/dials/algorithms/spot_finding/factory.py
@@ -131,6 +131,14 @@ def generate_phil_scope():
         .type = int(value_min=1)
         .help = "When chunksize is auto, this is the minimum chunksize"
     }
+    tof {
+        rs_proximity_threshold_multiplier = None
+          .type = float
+          .help = "If not None, spots in close proximity in reciprocal space"
+                  "are filtered out based on this value. The distance is"
+                  "calculated as the first peak of a histrogram of distances,"
+                  "multiplied by the rs_proximity_threshold_multiplier"
+    }
   }
   """,
         process_includes=True,
@@ -487,6 +495,7 @@ class SpotFinderFactory:
                 min_spot_size=params.spotfinder.filter.min_spot_size,
                 max_spot_size=params.spotfinder.filter.max_spot_size,
                 min_chunksize=params.spotfinder.mp.min_chunksize,
+                rs_proximity_threshold_multiplier=params.spotfinder.tof.rs_proximity_threshold_multiplier,
             )
 
         filter_spots = SpotFinderFactory.configure_filter(params)

--- a/src/dials/algorithms/spot_finding/finder.py
+++ b/src/dials/algorithms/spot_finding/finder.py
@@ -7,9 +7,16 @@ from __future__ import annotations
 import logging
 import math
 import pickle
+from collections import defaultdict
 from collections.abc import Iterable
+from copy import deepcopy
+
+import numpy as np
+from scipy.signal import find_peaks
+from scipy.spatial import cKDTree
 
 import libtbx
+from dxtbx import flumpy
 from dxtbx.format.image import ImageBool
 from dxtbx.imageset import ImageSequence, ImageSet
 from dxtbx.model import ExperimentList
@@ -871,6 +878,7 @@ class TOFSpotFinder(SpotFinder):
         min_spot_size=1,
         max_spot_size=20,
         min_chunksize=50,
+        rs_proximity_threshold_multiplier=None,
     ):
         super().__init__(
             threshold_function=threshold_function,
@@ -895,6 +903,7 @@ class TOFSpotFinder(SpotFinder):
         )
 
         self.experiments = experiments
+        self.rs_proximity_threshold_multiplier = rs_proximity_threshold_multiplier
 
     def _correct_centroid_tof(self, reflections):
         """
@@ -903,11 +912,114 @@ class TOFSpotFinder(SpotFinder):
         centroid for spallation sources.
         """
 
-        x, y, tof = reflections["xyzobs.px.value"].parts()
-        peak_x, peak_y, peak_tof = reflections["shoebox"].peak_coordinates().parts()
+        x, y, _ = reflections["xyzobs.px.value"].parts()
+        _, _, peak_tof = reflections["shoebox"].peak_coordinates().parts()
         reflections["xyzobs.px.value"] = flex.vec3_double(x, y, peak_tof)
 
         return reflections
+
+    def _filter_reflections_by_rs_proximity(
+        self, reflections, threshold_multiplier=0.5
+    ):
+        """
+        Calculates distances between reflections in reciprocal space.
+        A histogram of these distances is used to estimate erroneous reflections.
+        For reflections in closer proximity than the distance to
+        the first peak * threshold_multiplier, only the reflection with the
+        largest bounding box is retained.
+        """
+
+        def find(parent, i):
+            if parent[i] != i:
+                parent[i] = find(parent, parent[i])
+            return parent[i]
+
+        def union(parent, i, j):
+            pi, pj = find(parent, i), find(parent, j)
+            if pi != pj:
+                parent[pi] = pj
+
+        def calculate_threshold(points, threshold_multiplier):
+            """
+            Threshold is based on a histogram of distances in reciprocal space
+            and taking the distance to the first peak * threshold_multiplier
+            """
+
+            # Sample points for efficiency
+            sample_size = min(1000, len(points))
+            sample_indices = np.random.choice(
+                len(points), size=sample_size, replace=False
+            )
+            sample_points = points[sample_indices]
+            sample_tree = cKDTree(sample_points)
+            sample_pairs = sample_tree.query_pairs(r=5)
+            pair_dists = np.array(
+                [
+                    np.linalg.norm(sample_points[i] - sample_points[j])
+                    for i, j in sample_pairs
+                ]
+            )
+
+            hist, bin_edges = np.histogram(pair_dists, bins=1000)
+            bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+
+            peaks, _ = find_peaks(hist, prominence=0.05 * np.max(hist))
+
+            threshold = bin_centers[peaks[0]] * threshold_multiplier
+            return threshold
+
+        filtered_reflections = deepcopy(reflections)
+        filtered_reflections.map_centroids_to_reciprocal_space(self.experiments)
+        filter_mask = flex.bool(len(filtered_reflections))
+
+        for i, _ in enumerate(self.experiments):
+            if "imageset_id" in filtered_reflections:
+                sel_expt = filtered_reflections["imageset_id"] == i
+            else:
+                sel_expt = filtered_reflections["id"] == i
+
+            expt_reflections = filtered_reflections.select(sel_expt)
+            expt_filter_mask = filter_mask.select(sel_expt)
+
+            ## Extract required data
+            points = flumpy.to_numpy(expt_reflections["rlp"])
+            x0, x1, y0, y1, z0, z1 = expt_reflections["bbox"].parts()
+            bbox_volumes = flumpy.to_numpy((x1 - x0) * (y1 - y0) * (z1 - z0))
+
+            distance_threshold = calculate_threshold(points, threshold_multiplier)
+
+            ## Cluster points
+            tree = cKDTree(points)
+            pairs = tree.query_pairs(r=distance_threshold)
+
+            N = len(points)
+            parent = list(range(N))
+            for i, j in pairs:
+                union(parent, i, j)
+
+            # Build clusters
+            clusters = defaultdict(list)
+            for i in range(N):
+                root = find(parent, i)
+                clusters[root].append(i)
+
+            for group_indices in clusters.values():
+                if len(group_indices) == 1:
+                    # Unique point
+                    expt_filter_mask[group_indices[0]] = True
+                else:
+                    # Select largest reflection
+                    group_bbox_volumes = bbox_volumes[group_indices]
+                    best_idx = group_indices[np.argmax(group_bbox_volumes)]
+                    expt_filter_mask[best_idx] = True
+
+            filter_mask.set_selected(sel_expt, expt_filter_mask)
+
+        filtered_reflections = reflections.select(filter_mask)
+        logger.info(
+            f"Filtered {len(filtered_reflections)} of {len(reflections)} by reciprocal space proximity"
+        )
+        return filtered_reflections
 
     def _post_process(self, reflections):
         reflections = self._correct_centroid_tof(reflections)
@@ -958,4 +1070,11 @@ class TOFSpotFinder(SpotFinder):
                 reflections["wavelength"].set_selected(sel, wavelengths)
                 reflections["s0"].set_selected(sel, s0s)
                 reflections["L1"].set_selected(sel, L1)
+
+        if self.rs_proximity_threshold_multiplier is not None:
+            reflections = self._filter_reflections_by_rs_proximity(
+                reflections=reflections,
+                threshold_multiplier=self.rs_proximity_threshold_multiplier,
+            )
+
         return reflections


### PR DESCRIPTION
Occasionally the DIALS spot finder algorithms erroneously identify multiple spots along the time-of-flight direction, owing to the diffuse profile. DIALS will index all of these spots and it can make indexing and integration worse:

<img width="884" height="252" alt="peak_example" src="https://github.com/user-attachments/assets/e8a3bb09-3500-4fc8-a992-b4f3df3efe17" />

In reciprocal space this looks like clusters of spots:

<img width="1521" height="917" alt="Screenshot from 2025-07-22 14-55-13" src="https://github.com/user-attachments/assets/f599e6b4-0c1b-41ca-89ac-13097be9234c" />

This PR adds an additional filter in TOFSpotFinder._post_process that filters spots based on distances in reciprocal space. Using this the data above is modified to something more sensible:

<img width="1521" height="917" alt="Screenshot from 2025-07-22 14-55-32" src="https://github.com/user-attachments/assets/e5663786-4792-4434-8ab2-2fdddb57bca7" />

The filter works by taking a histogram of distances in reciprocal space and removing spots within a closer distance than the first peak, multiplied by a constant. 

Example histogram with identified peaks highlighted:
<img width="628" height="469" alt="Screenshot from 2025-07-22 14-55-47" src="https://github.com/user-attachments/assets/7c452946-2662-478a-ac40-fe5530f824be" />

The noise before the first peak corresponds to the reflections being filtered out. This seems fairly robust for different cases. e.g:

<img width="628" height="469" alt="Screenshot from 2025-07-22 14-56-00" src="https://github.com/user-attachments/assets/d6328041-33c8-40d3-895e-b6728ae63362" />

This is not always needed, so is off by default.
