### PR TITLE
`dials.export format=xds`: ensure `SPOT.XDS` only contains `strong` reflections, in reverse intensity order

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+``dials.export format=xds``: Ensure only ``strong`` reflections are exported in ``SPOT.XDS`` and reverse-sort by intensity

--- a/src/dials/util/xds.py
+++ b/src/dials/util/xds.py
@@ -84,6 +84,8 @@ def dump(experiments, reflections, directory):
 
 
 def export_spot_xds(reflections, filename):
+    reflections = reflections.select(reflections.get_flags(reflections.flags.strong))
+    reflections.sort("intensity.sum.value", reverse=True)
     if reflections is not None and len(reflections) > 0:
         centroids = reflections["xyzobs.px.value"]
         intensities = reflections["intensity.sum.value"]


### PR DESCRIPTION
Part fix for #2960