### PR TITLE
Make projection methods in ``dials.search_beam_position`` work for each detector separately 

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+Fix printing of the beam center in ``dials.search_beam_position``.

--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,1 +1,1 @@
-Fix printing of the beam center in ``dials.search_beam_position``.
+Projection methods in ``dials.search_beam_position`` now work for each detector separately.

--- a/src/dials/algorithms/beam_position/compute_beam_position.py
+++ b/src/dials/algorithms/beam_position/compute_beam_position.py
@@ -38,14 +38,17 @@ def compute_beam_position(image, params, image_index=None, imageset_index=None):
     else:
         imageset_str = ""
 
-    fig = Figure(f"beam_position{imageset_str}{image_str}.png")
+    if params.projection.plot:
+        fig = Figure(f"beam_position{imageset_str}{image_str}.png")
 
-    fig.plot_main(image, params, beam_position=(x, y))
-    solver_x.plot(fig)
-    solver_y.plot(fig)
+        fig.plot_main(image, params, beam_position=(x, y))
+        solver_x.plot(fig)
+        solver_y.plot(fig)
 
-    fig.save_and_close()
+        fig.save_and_close()
 
+    if not params.projection.per_image:
+        print(f"{x:.2f}, {y:.2f}")
     return x, y
 
 

--- a/src/dials/algorithms/beam_position/compute_beam_position.py
+++ b/src/dials/algorithms/beam_position/compute_beam_position.py
@@ -8,7 +8,7 @@ from dials.algorithms.beam_position import (
 from dials.algorithms.beam_position.plot import Figure
 
 
-def compute_beam_position(image, params, image_index=None, imageset_index=None):
+def compute_beam_position(image, params, image_index=None, detector_index=None):
     method_x, method_y = resolve_projection_methods(params)
 
     if method_x == "midpoint":
@@ -33,13 +33,13 @@ def compute_beam_position(image, params, image_index=None, imageset_index=None):
     else:
         image_str = ""
 
-    if imageset_index is not None:
-        imageset_str = "_imageset_%05d" % imageset_index
+    if detector_index is not None:
+        detector_str = "_detector_%d" % detector_index
     else:
-        imageset_str = ""
+        detector_str = ""
 
     if params.projection.plot:
-        fig = Figure(f"beam_position{imageset_str}{image_str}.png")
+        fig = Figure(f"beam_position{detector_str}{image_str}.png")
 
         fig.plot_main(image, params, beam_position=(x, y))
         solver_x.plot(fig)
@@ -47,8 +47,6 @@ def compute_beam_position(image, params, image_index=None, imageset_index=None):
 
         fig.save_and_close()
 
-    if not params.projection.per_image:
-        print(f"{x:.2f}, {y:.2f}")
     return x, y
 
 

--- a/src/dials/algorithms/beam_position/helper_functions.py
+++ b/src/dials/algorithms/beam_position/helper_functions.py
@@ -67,26 +67,6 @@ def smooth(curve, width=2):
     return smooth_curve
 
 
-def get_indices_from_slices(nmax, slices):
-    """
-    Takes a string of comma-separated numpy slices (e.g. "::2, 2, 3:5:7")
-    and turns it into a list of indices. The indices are selected from a range
-    [0, nmax] using each slice, and each comma-separated component is included
-    in the final array.
-    """
-
-    indices = np.array([], dtype=np.dtype("uint"))
-    full_range = np.arange(0, nmax, dtype=np.dtype("uint"))
-
-    for slice_str in slices.split(","):
-        slice_str = slice_str.replace(" ", "")
-        parsed_slice = parse_numpy_slice(slice_str)
-        selected = full_range[parsed_slice]
-        indices = np.append(indices, selected)
-
-    return np.unique(indices)
-
-
 def parse_numpy_slice(slice_str):
     if slice_str is None:
         return None
@@ -94,3 +74,35 @@ def parse_numpy_slice(slice_str):
         return eval(f"np.s_[{slice_str}]")
     except Exception as e:
         raise ValueError(f"Invalid slice format: {slice_str}") from e
+
+
+def print_progress(image_index, n_images, set_index, n_sets, bar_length=40):
+    image_index += 1
+    set_index += 1
+
+    percent_images = 1.0 * image_index / n_images
+    percent_sets = 1.0 * set_index / n_sets
+
+    move_up = "\033[F"
+
+    img_bar_full = int(percent_images * bar_length)
+    image_bar = "=" * img_bar_full + " " * (bar_length - img_bar_full)
+
+    set_bar_full = int(percent_sets * bar_length)
+    set_bar = "=" * set_bar_full + " " * (bar_length - set_bar_full)
+
+    bar = f" Set:   [{set_bar}] {100 * percent_sets:0.2f} % "
+    bar += f"{set_index:4d}/{n_sets:d}\n"
+    bar += f" Image: [{image_bar}] {100 * percent_images:0.2f} % "
+    bar += f"{image_index:4d}/{n_images}\n"
+
+    condition_01 = abs(percent_sets - 1.0) < 1.0e-15
+    condition_02 = abs(percent_images - 1.0) < 1.0e-15
+
+    if condition_01 and condition_02:
+        end_str = ""
+    else:
+        end_str = f"{move_up}{move_up}\r"
+
+    bar += end_str
+    print(bar, end="")

--- a/src/dials/algorithms/beam_position/labelit_method.py
+++ b/src/dials/algorithms/beam_position/labelit_method.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+import cmath
+import concurrent.futures
+import copy
+import itertools
+import logging
+import math
+
+import iotbx.phil
+from libtbx.test_utils import approx_equal
+from libtbx.utils import plural_s
+from rstbx.dps_core import Direction, Directional_FFT
+from rstbx.indexing_api import dps_extended
+from rstbx.indexing_api.lattice import DPS_primitive_lattice
+from rstbx.phil.phil_preferences import indexing_api_defs
+from scitbx import matrix
+from scitbx.array_family import flex
+from scitbx.simplex import simplex_opt
+
+from dials.algorithms.indexing.indexer import find_max_cell
+from dials.util import Sorry
+
+logger = logging.getLogger("dials.command_line.search_beam_position")
+
+
+def optimize_origin_offset_local_scope(
+    experiments,
+    reflection_lists,
+    solution_lists,
+    amax_lists,
+    mm_search_scope=4,
+    wide_search_binning=1,
+    plot_search_scope=False,
+):
+    """Local scope: find the optimal origin-offset closest to the current
+    overall detector position (local minimum, simple minimization)"""
+
+    beam = experiments[0].beam
+    s0 = matrix.col(beam.get_s0())
+    # construct two vectors that are perpendicular to the beam.
+    # Gives a basis for refining beam
+    axis = matrix.col((1, 0, 0))
+    beamr0 = s0.cross(axis).normalize()
+    beamr1 = beamr0.cross(s0).normalize()
+    beamr2 = beamr1.cross(s0).normalize()
+
+    assert approx_equal(s0.dot(beamr1), 0.0)
+    assert approx_equal(s0.dot(beamr2), 0.0)
+    assert approx_equal(beamr2.dot(beamr1), 0.0)
+    # so the orthonormal vectors are s0, beamr1 and beamr2
+
+    if mm_search_scope:
+        plot_px_sz = experiments[0].detector[0].get_pixel_size()[0]
+        plot_px_sz *= wide_search_binning
+        grid = max(1, int(mm_search_scope / plot_px_sz))
+        widegrid = 2 * grid + 1
+
+        def get_experiment_score_for_coord(x, y):
+            new_origin_offset = x * plot_px_sz * beamr1 + y * plot_px_sz * beamr2
+            return sum(
+                _get_origin_offset_score(
+                    new_origin_offset,
+                    solution_lists[i],
+                    amax_lists[i],
+                    reflection_lists[i],
+                    experiment,
+                )
+                for i, experiment in enumerate(experiments)
+            )
+
+        scores = flex.double(
+            get_experiment_score_for_coord(x, y)
+            for y in range(-grid, grid + 1)
+            for x in range(-grid, grid + 1)
+        )
+
+        def igrid(x):
+            return x - (widegrid // 2)
+
+        idxs = [igrid(i) * plot_px_sz for i in range(widegrid)]
+
+        # if there are several similarly high scores, then choose the closest
+        # one to the current beam centre
+        potential_offsets = flex.vec3_double()
+        if scores.all_eq(0):
+            raise Sorry("No valid scores")
+        sel = scores > (0.9 * flex.max(scores))
+        for i in sel.iselection():
+            offset = (idxs[i % widegrid]) * beamr1 + (idxs[i // widegrid]) * beamr2
+            potential_offsets.append(offset.elems)
+            # print offset.length(), scores[i]
+        wide_search_offset = matrix.col(
+            potential_offsets[flex.min_index(potential_offsets.norms())]
+        )
+
+    else:
+        wide_search_offset = None
+
+    # Do a simplex minimization
+    class simplex_minimizer:
+        def __init__(self, wide_search_offset):
+            self.n = 2
+            self.wide_search_offset = wide_search_offset
+            self.optimizer = simplex_opt(
+                dimension=self.n,
+                matrix=[flex.random_double(self.n) for _ in range(self.n + 1)],
+                evaluator=self,
+                tolerance=1e-7,
+            )
+            self.x = self.optimizer.get_solution()
+            self.offset = self.x[0] * 0.2 * beamr1 + self.x[1] * 0.2 * beamr2
+            if self.wide_search_offset is not None:
+                self.offset += self.wide_search_offset
+
+        def target(self, vector):
+            trial_origin_offset = vector[0] * 0.2 * beamr1 + vector[1] * 0.2 * beamr2
+            if self.wide_search_offset is not None:
+                trial_origin_offset += self.wide_search_offset
+            target = 0
+            for i, experiment in enumerate(experiments):
+                target -= _get_origin_offset_score(
+                    trial_origin_offset,
+                    solution_lists[i],
+                    amax_lists[i],
+                    reflection_lists[i],
+                    experiment,
+                )
+            return target
+
+    new_offset = simplex_minimizer(wide_search_offset).offset
+
+    if plot_search_scope:
+        plot_px_sz = experiments[0].get_detector()[0].get_pixel_size()[0]
+        grid = max(1, int(mm_search_scope / plot_px_sz))
+        scores = flex.double()
+        for y in range(-grid, grid + 1):
+            for x in range(-grid, grid + 1):
+                new_origin_offset = x * plot_px_sz * beamr1 + y * plot_px_sz * beamr2
+                score = 0
+                for i, experiment in enumerate(experiments):
+                    score += _get_origin_offset_score(
+                        new_origin_offset,
+                        solution_lists[i],
+                        amax_lists[i],
+                        reflection_lists[i],
+                        experiment,
+                    )
+                scores.append(score)
+
+        def show_plot(widegrid, excursi):
+            excursi.reshape(flex.grid(widegrid, widegrid))
+            idx_max = flex.max_index(excursi)
+
+            def igrid(x):
+                return x - (widegrid // 2)
+
+            idxs = [igrid(i) * plot_px_sz for i in range(widegrid)]
+
+            from matplotlib import pyplot as plt
+
+            plt.figure()
+            CS = plt.contour(
+                [igrid(i) * plot_px_sz for i in range(widegrid)],
+                [igrid(i) * plot_px_sz for i in range(widegrid)],
+                excursi.as_numpy_array(),
+            )
+            plt.clabel(CS, inline=1, fontsize=10, fmt="%6.3f")
+            plt.title("Wide scope search for detector origin offset")
+            plt.scatter([0.0], [0.0], color="g", marker="o")
+            plt.scatter([new_offset[0]], [new_offset[1]], color="r", marker="*")
+            plt.scatter(
+                [idxs[idx_max % widegrid]],
+                [idxs[idx_max // widegrid]],
+                color="k",
+                marker="s",
+            )
+            plt.axes().set_aspect("equal")
+            plt.xlabel("offset (mm) along beamr1 vector")
+            plt.ylabel("offset (mm) along beamr2 vector")
+            plt.savefig("search_scope.png")
+
+            # changing value
+            trial_origin_offset = (
+                (idxs[idx_max % widegrid]) * beamr1
+                + (idxs[idx_max // widegrid]) * beamr2
+            )
+            return trial_origin_offset
+
+        show_plot(widegrid=2 * grid + 1, excursi=scores)
+
+    new_experiments = copy.deepcopy(experiments)
+    for expt in new_experiments:
+        expt.detector = dps_extended.get_new_detector(expt.detector, new_offset)
+    return new_experiments
+
+
+def _get_origin_offset_score(
+    trial_origin_offset, solutions, amax, spots_mm, experiment
+):
+    trial_detector = dps_extended.get_new_detector(
+        experiment.detector, trial_origin_offset
+    )
+    experiment = copy.copy(experiment)
+    experiment.detector = trial_detector
+
+    # Key point for this is that the spots must correspond to detector
+    # positions not to the correct RS position => reset any fixed rotation
+    # to identity
+
+    experiment.goniometer.set_fixed_rotation((1, 0, 0, 0, 1, 0, 0, 0, 1))
+    spots_mm.map_centroids_to_reciprocal_space([experiment])
+    return _sum_score_detail(spots_mm["rlp"], solutions, amax=amax)
+
+
+def _sum_score_detail(reciprocal_space_vectors, solutions, granularity=None, amax=None):
+    """Evaluates the probability that the trial value of
+    (S0_vector | origin_offset) is correct, given the current estimate and the
+    observations. The trial value comes through the reciprocal space vectors,
+    and the current estimate comes through the short list of DPS solutions.
+    Actual return value is a sum of NH terms, one for each DPS solution,
+    each ranging from -1.0 to 1.0"""
+
+    nh = min(solutions.size(), 20)  # extended API
+    sum_score = 0.0
+    for t in range(nh):
+        dfft = Directional_FFT(
+            angle=Direction(solutions[t]),
+            xyzdata=reciprocal_space_vectors,
+            granularity=5.0,
+            amax=amax,  # extended API XXX
+            F0_cutoff=11,
+        )
+        kval = dfft.kval()
+        kmax = dfft.kmax()
+        kval_cutoff = reciprocal_space_vectors.size() / 4.0
+        if kval > kval_cutoff:
+            ff = dfft.fft_result
+            kbeam = ((-dfft.pmin) / dfft.delta_p) + 0.5
+            Tkmax = cmath.phase(ff[kmax])
+            backmax = math.cos(
+                Tkmax + (2 * math.pi * kmax * kbeam / (2 * ff.size() - 1))
+            )
+            # Here it should be possible to calculate a gradient.
+            # Then minimize with respect to two coordinates.
+            # Use lbfgs?  Have second derivatives?
+            # can I do something local to model the cosine wave?
+            # direction of wave travel.  Period. phase.
+            sum_score += backmax
+    return sum_score
+
+
+def run_dps(experiment, spots_mm, max_cell):
+    # max_cell: max possible cell in Angstroms; set to None,
+    # determine from data
+    # recommended_grid_sampling_rad: grid sampling in radians; guess for now
+
+    horizon_phil = iotbx.phil.parse(input_string=indexing_api_defs).extract()
+    DPS = DPS_primitive_lattice(
+        max_cell=max_cell, recommended_grid_sampling_rad=None, horizon_phil=horizon_phil
+    )
+
+    DPS.S0_vector = matrix.col(experiment.beam.get_s0())
+    DPS.inv_wave = 1.0 / experiment.beam.get_wavelength()
+    if experiment.goniometer is None:
+        DPS.axis = matrix.col((1, 0, 0))
+    else:
+        DPS.axis = matrix.col(experiment.goniometer.get_rotation_axis())
+    DPS.set_detector(experiment.detector)
+
+    # transform input into what DPS needs
+    # i.e., construct a flex.vec3 double consisting of mm spots, phi in degrees
+    data = flex.vec3_double()
+    for spot in spots_mm.rows():
+        data.append(
+            (
+                spot["xyzobs.mm.value"][0],
+                spot["xyzobs.mm.value"][1],
+                spot["xyzobs.mm.value"][2] * 180.0 / math.pi,
+            )
+        )
+
+    logger.info("Running DPS using %i reflections", len(data))
+
+    DPS.index(
+        raw_spot_input=data,
+        panel_addresses=flex.int(s["panel"] for s in spots_mm.rows()),
+    )
+    solutions = DPS.getSolutions()
+
+    logger.info(
+        "Found %i solution%s with max unit cell %.2f Angstroms.",
+        len(solutions),
+        plural_s(len(solutions))[1],
+        DPS.amax,
+    )
+
+    # There must be at least 3 solutions to make a set,
+    # otherwise return empty result
+    if len(solutions) < 3:
+        return {}
+    return {"solutions": flex.vec3_double(s.dvec for s in solutions), "amax": DPS.amax}
+
+
+def discover_better_experimental_model(
+    experiments,
+    reflections,
+    params,
+    nproc=1,
+    d_min=None,
+    mm_search_scope=4.0,
+    wide_search_binning=1,
+    plot_search_scope=False,
+):
+    assert len(experiments) == len(reflections)
+    assert len(experiments) > 0
+
+    refl_lists = []
+    max_cell_list = []
+
+    # The detector/beam of the first experiment is used to define the basis
+    # for the optimisation, so assert that the beam intersects with
+    # the detector
+    detector = experiments[0].detector
+    beam = experiments[0].beam
+    beam_panel = detector.get_panel_intersection(beam.get_s0())
+    if beam_panel == -1:
+        raise Sorry("input beam does not intersect detector")
+
+    for expt, refl in zip(experiments, reflections):
+        refl = copy.deepcopy(refl)
+        refl["imageset_id"] = flex.int(len(refl), 0)
+        refl.centroid_px_to_mm([expt])
+        refl.map_centroids_to_reciprocal_space([expt])
+
+        if d_min is not None:
+            d_spacings = 1 / refl["rlp"].norms()
+            sel = d_spacings > d_min
+            refl = refl.select(sel)
+
+        # derive a max_cell from mm spots
+        if params.max_cell is None:
+            max_cell = find_max_cell(
+                refl, max_cell_multiplier=1.3, step_size=45
+            ).max_cell
+            max_cell_list.append(max_cell)
+
+        refl_condition = refl.size() > params.max_reflections
+        if params.max_reflections is not None and refl_condition:
+            logger.info(
+                "Selecting subset of %i reflections for analysis",
+                params.max_reflections,
+            )
+            perm = flex.random_permutation(refl.size())
+            sel = perm[: params.max_reflections]
+            refl = refl.select(sel)
+
+        refl_lists.append(refl)
+
+    if params.max_cell is None:
+        max_cell = flex.median(flex.double(max_cell_list))
+    else:
+        max_cell = params.max_cell
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=nproc) as pool:
+        solution_lists = []
+        amax_list = []
+        for result in pool.map(
+            run_dps, experiments, refl_lists, itertools.repeat(max_cell)
+        ):
+            if result.get("solutions"):
+                solution_lists.append(result["solutions"])
+                amax_list.append(result["amax"])
+
+    if not solution_lists:
+        raise Sorry("No solutions found")
+
+    new_experiments = optimize_origin_offset_local_scope(
+        experiments,
+        refl_lists,
+        solution_lists,
+        amax_list,
+        mm_search_scope=mm_search_scope,
+        wide_search_binning=wide_search_binning,
+        plot_search_scope=plot_search_scope,
+    )
+    new_detector = new_experiments[0].detector
+    old_panel, old_beam_centre = detector.get_ray_intersection(beam.get_s0())
+    (new_panel, new_beam_centre) = new_detector.get_ray_intersection(beam.get_s0())
+
+    old_bc_px = detector[old_panel].millimeter_to_pixel(old_beam_centre)
+    new_bc_px = new_detector[new_panel].millimeter_to_pixel(new_beam_centre)
+
+    logger.info(
+        "Old beam centre: {:.2f}, {:.2f} mm".format(*old_beam_centre)
+        + " ({:.1f}, {:.1f} px)".format(*old_bc_px)
+    )
+    logger.info(
+        "New beam centre: {:.2f}, {:.2f} mm".format(*new_beam_centre)
+        + " ({:.1f}, {:.1f} px)".format(*new_bc_px)
+    )
+    logger.info(
+        "Shift: {:.2f}, {:.2f} mm".format(
+            *(matrix.col(old_beam_centre) - matrix.col(new_beam_centre)).elems
+        )
+        + " ({:.1f}, {:.1f} px)".format(
+            *(matrix.col(old_bc_px) - matrix.col(new_bc_px)).elems
+        )
+    )
+    return new_experiments

--- a/src/dials/algorithms/beam_position/plot.py
+++ b/src/dials/algorithms/beam_position/plot.py
@@ -52,7 +52,7 @@ class Figure:
         if params.projection.color_cutoff:
             vmax = float(params.projection.color_cutoff)
         else:
-            temp_image = remove_pixels_by_intensity(image, percent=0.0045)
+            temp_image = remove_pixels_by_intensity(image, percent=0.2)
             vmax = temp_image.max()
         img = self.main_axis.imshow(
             image,

--- a/src/dials/command_line/search_beam_position.py
+++ b/src/dials/command_line/search_beam_position.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-import cmath
-import concurrent.futures
 import copy
-import itertools
 import json
 import logging
-import math
 import random
 import sys
 
@@ -15,20 +11,16 @@ import numpy as np
 import iotbx.phil
 import libtbx
 from dxtbx import flumpy
-from libtbx.test_utils import approx_equal
-from libtbx.utils import plural_s
-from rstbx.dps_core import Direction, Directional_FFT
-from rstbx.indexing_api import dps_extended
-from rstbx.indexing_api.lattice import DPS_primitive_lattice
-from rstbx.phil.phil_preferences import indexing_api_defs
-from scitbx import matrix
 from scitbx.array_family import flex
-from scitbx.simplex import simplex_opt
 
 import dials.util
 from dials.algorithms.beam_position.compute_beam_position import compute_beam_position
-from dials.algorithms.beam_position.helper_functions import get_indices_from_slices
-from dials.algorithms.indexing.indexer import find_max_cell
+from dials.algorithms.beam_position.helper_functions import (
+    print_progress,
+)
+from dials.algorithms.beam_position.labelit_method import (
+    discover_better_experimental_model,
+)
 from dials.util import Sorry, log
 from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 from dials.util.slice import slice_reflections
@@ -108,16 +100,6 @@ projection {
     .type = str
     .help = "The projection method along the y-axis."
 
-    image_ranges = "::"
-    .type = str
-    .help = "A list of comma-separated numpy slices used to select specific "
-            "images in the dataset (e.g. 0:5:2,1,7:15)."
-
-    imageset_ranges = "::"
-    .type = str
-    .help = "A list of comma-separated numpy slices used to select specific "
-            "imagesets (see image_ranges)."
-
     plot = True
     .type = bool
     .help = "Plot the diffraction image with the computed beam center."
@@ -149,19 +131,6 @@ projection {
     .type = bool
     .help = "Compute the beam position for each image. Otherwise, compute the "
             "beam position for a single (average) image."
-
-    save_average_image = False
-    .type = bool
-    .help = "Saves the average diffraction image to an npz file "
-            "(i.e., average_image.npz). Works only when per_image=False. "
-            "Use this to save the average image for later use "
-            "(see the load_average_image option)."
-
-    load_average_image = False
-    .type = bool
-    .help = "Loads the average diffraction image from an npz file. "
-            "Works only when `per_image=False`. If an average image was saved "
-            "before, DIALS will use that image instead of computing it again."
 
     color_cutoff = None
     .type = float
@@ -270,392 +239,6 @@ output {
 )
 
 
-def optimize_origin_offset_local_scope(
-    experiments,
-    reflection_lists,
-    solution_lists,
-    amax_lists,
-    mm_search_scope=4,
-    wide_search_binning=1,
-    plot_search_scope=False,
-):
-    """Local scope: find the optimal origin-offset closest to the current
-    overall detector position (local minimum, simple minimization)"""
-
-    beam = experiments[0].beam
-    s0 = matrix.col(beam.get_s0())
-    # construct two vectors that are perpendicular to the beam.
-    # Gives a basis for refining beam
-    axis = matrix.col((1, 0, 0))
-    beamr0 = s0.cross(axis).normalize()
-    beamr1 = beamr0.cross(s0).normalize()
-    beamr2 = beamr1.cross(s0).normalize()
-
-    assert approx_equal(s0.dot(beamr1), 0.0)
-    assert approx_equal(s0.dot(beamr2), 0.0)
-    assert approx_equal(beamr2.dot(beamr1), 0.0)
-    # so the orthonormal vectors are s0, beamr1 and beamr2
-
-    if mm_search_scope:
-        plot_px_sz = experiments[0].detector[0].get_pixel_size()[0]
-        plot_px_sz *= wide_search_binning
-        grid = max(1, int(mm_search_scope / plot_px_sz))
-        widegrid = 2 * grid + 1
-
-        def get_experiment_score_for_coord(x, y):
-            new_origin_offset = x * plot_px_sz * beamr1 + y * plot_px_sz * beamr2
-            return sum(
-                _get_origin_offset_score(
-                    new_origin_offset,
-                    solution_lists[i],
-                    amax_lists[i],
-                    reflection_lists[i],
-                    experiment,
-                )
-                for i, experiment in enumerate(experiments)
-            )
-
-        scores = flex.double(
-            get_experiment_score_for_coord(x, y)
-            for y in range(-grid, grid + 1)
-            for x in range(-grid, grid + 1)
-        )
-
-        def igrid(x):
-            return x - (widegrid // 2)
-
-        idxs = [igrid(i) * plot_px_sz for i in range(widegrid)]
-
-        # if there are several similarly high scores, then choose the closest
-        # one to the current beam centre
-        potential_offsets = flex.vec3_double()
-        if scores.all_eq(0):
-            raise Sorry("No valid scores")
-        sel = scores > (0.9 * flex.max(scores))
-        for i in sel.iselection():
-            offset = (idxs[i % widegrid]) * beamr1 + (idxs[i // widegrid]) * beamr2
-            potential_offsets.append(offset.elems)
-            # print offset.length(), scores[i]
-        wide_search_offset = matrix.col(
-            potential_offsets[flex.min_index(potential_offsets.norms())]
-        )
-
-    else:
-        wide_search_offset = None
-
-    # Do a simplex minimization
-    class simplex_minimizer:
-        def __init__(self, wide_search_offset):
-            self.n = 2
-            self.wide_search_offset = wide_search_offset
-            self.optimizer = simplex_opt(
-                dimension=self.n,
-                matrix=[flex.random_double(self.n) for _ in range(self.n + 1)],
-                evaluator=self,
-                tolerance=1e-7,
-            )
-            self.x = self.optimizer.get_solution()
-            self.offset = self.x[0] * 0.2 * beamr1 + self.x[1] * 0.2 * beamr2
-            if self.wide_search_offset is not None:
-                self.offset += self.wide_search_offset
-
-        def target(self, vector):
-            trial_origin_offset = vector[0] * 0.2 * beamr1 + vector[1] * 0.2 * beamr2
-            if self.wide_search_offset is not None:
-                trial_origin_offset += self.wide_search_offset
-            target = 0
-            for i, experiment in enumerate(experiments):
-                target -= _get_origin_offset_score(
-                    trial_origin_offset,
-                    solution_lists[i],
-                    amax_lists[i],
-                    reflection_lists[i],
-                    experiment,
-                )
-            return target
-
-    new_offset = simplex_minimizer(wide_search_offset).offset
-
-    if plot_search_scope:
-        plot_px_sz = experiments[0].get_detector()[0].get_pixel_size()[0]
-        grid = max(1, int(mm_search_scope / plot_px_sz))
-        scores = flex.double()
-        for y in range(-grid, grid + 1):
-            for x in range(-grid, grid + 1):
-                new_origin_offset = x * plot_px_sz * beamr1 + y * plot_px_sz * beamr2
-                score = 0
-                for i, experiment in enumerate(experiments):
-                    score += _get_origin_offset_score(
-                        new_origin_offset,
-                        solution_lists[i],
-                        amax_lists[i],
-                        reflection_lists[i],
-                        experiment,
-                    )
-                scores.append(score)
-
-        def show_plot(widegrid, excursi):
-            excursi.reshape(flex.grid(widegrid, widegrid))
-            idx_max = flex.max_index(excursi)
-
-            def igrid(x):
-                return x - (widegrid // 2)
-
-            idxs = [igrid(i) * plot_px_sz for i in range(widegrid)]
-
-            from matplotlib import pyplot as plt
-
-            plt.figure()
-            CS = plt.contour(
-                [igrid(i) * plot_px_sz for i in range(widegrid)],
-                [igrid(i) * plot_px_sz for i in range(widegrid)],
-                excursi.as_numpy_array(),
-            )
-            plt.clabel(CS, inline=1, fontsize=10, fmt="%6.3f")
-            plt.title("Wide scope search for detector origin offset")
-            plt.scatter([0.0], [0.0], color="g", marker="o")
-            plt.scatter([new_offset[0]], [new_offset[1]], color="r", marker="*")
-            plt.scatter(
-                [idxs[idx_max % widegrid]],
-                [idxs[idx_max // widegrid]],
-                color="k",
-                marker="s",
-            )
-            plt.axes().set_aspect("equal")
-            plt.xlabel("offset (mm) along beamr1 vector")
-            plt.ylabel("offset (mm) along beamr2 vector")
-            plt.savefig("search_scope.png")
-
-            # changing value
-            trial_origin_offset = (
-                (idxs[idx_max % widegrid]) * beamr1
-                + (idxs[idx_max // widegrid]) * beamr2
-            )
-            return trial_origin_offset
-
-        show_plot(widegrid=2 * grid + 1, excursi=scores)
-
-    new_experiments = copy.deepcopy(experiments)
-    for expt in new_experiments:
-        expt.detector = dps_extended.get_new_detector(expt.detector, new_offset)
-    return new_experiments
-
-
-def _get_origin_offset_score(
-    trial_origin_offset, solutions, amax, spots_mm, experiment
-):
-    trial_detector = dps_extended.get_new_detector(
-        experiment.detector, trial_origin_offset
-    )
-    experiment = copy.copy(experiment)
-    experiment.detector = trial_detector
-
-    # Key point for this is that the spots must correspond to detector
-    # positions not to the correct RS position => reset any fixed rotation
-    # to identity
-
-    experiment.goniometer.set_fixed_rotation((1, 0, 0, 0, 1, 0, 0, 0, 1))
-    spots_mm.map_centroids_to_reciprocal_space([experiment])
-    return _sum_score_detail(spots_mm["rlp"], solutions, amax=amax)
-
-
-def _sum_score_detail(reciprocal_space_vectors, solutions, granularity=None, amax=None):
-    """Evaluates the probability that the trial value of
-    (S0_vector | origin_offset) is correct, given the current estimate and the
-    observations. The trial value comes through the reciprocal space vectors,
-    and the current estimate comes through the short list of DPS solutions.
-    Actual return value is a sum of NH terms, one for each DPS solution,
-    each ranging from -1.0 to 1.0"""
-
-    nh = min(solutions.size(), 20)  # extended API
-    sum_score = 0.0
-    for t in range(nh):
-        dfft = Directional_FFT(
-            angle=Direction(solutions[t]),
-            xyzdata=reciprocal_space_vectors,
-            granularity=5.0,
-            amax=amax,  # extended API XXX
-            F0_cutoff=11,
-        )
-        kval = dfft.kval()
-        kmax = dfft.kmax()
-        kval_cutoff = reciprocal_space_vectors.size() / 4.0
-        if kval > kval_cutoff:
-            ff = dfft.fft_result
-            kbeam = ((-dfft.pmin) / dfft.delta_p) + 0.5
-            Tkmax = cmath.phase(ff[kmax])
-            backmax = math.cos(
-                Tkmax + (2 * math.pi * kmax * kbeam / (2 * ff.size() - 1))
-            )
-            # Here it should be possible to calculate a gradient.
-            # Then minimize with respect to two coordinates.
-            # Use lbfgs?  Have second derivatives?
-            # can I do something local to model the cosine wave?
-            # direction of wave travel.  Period. phase.
-            sum_score += backmax
-    return sum_score
-
-
-def run_dps(experiment, spots_mm, max_cell):
-    # max_cell: max possible cell in Angstroms; set to None,
-    # determine from data
-    # recommended_grid_sampling_rad: grid sampling in radians; guess for now
-
-    horizon_phil = iotbx.phil.parse(input_string=indexing_api_defs).extract()
-    DPS = DPS_primitive_lattice(
-        max_cell=max_cell, recommended_grid_sampling_rad=None, horizon_phil=horizon_phil
-    )
-
-    DPS.S0_vector = matrix.col(experiment.beam.get_s0())
-    DPS.inv_wave = 1.0 / experiment.beam.get_wavelength()
-    if experiment.goniometer is None:
-        DPS.axis = matrix.col((1, 0, 0))
-    else:
-        DPS.axis = matrix.col(experiment.goniometer.get_rotation_axis())
-    DPS.set_detector(experiment.detector)
-
-    # transform input into what DPS needs
-    # i.e., construct a flex.vec3 double consisting of mm spots, phi in degrees
-    data = flex.vec3_double()
-    for spot in spots_mm.rows():
-        data.append(
-            (
-                spot["xyzobs.mm.value"][0],
-                spot["xyzobs.mm.value"][1],
-                spot["xyzobs.mm.value"][2] * 180.0 / math.pi,
-            )
-        )
-
-    logger.info("Running DPS using %i reflections", len(data))
-
-    DPS.index(
-        raw_spot_input=data,
-        panel_addresses=flex.int(s["panel"] for s in spots_mm.rows()),
-    )
-    solutions = DPS.getSolutions()
-
-    logger.info(
-        "Found %i solution%s with max unit cell %.2f Angstroms.",
-        len(solutions),
-        plural_s(len(solutions))[1],
-        DPS.amax,
-    )
-
-    # There must be at least 3 solutions to make a set,
-    # otherwise return empty result
-    if len(solutions) < 3:
-        return {}
-    return {"solutions": flex.vec3_double(s.dvec for s in solutions), "amax": DPS.amax}
-
-
-def discover_better_experimental_model(
-    experiments,
-    reflections,
-    params,
-    nproc=1,
-    d_min=None,
-    mm_search_scope=4.0,
-    wide_search_binning=1,
-    plot_search_scope=False,
-):
-    assert len(experiments) == len(reflections)
-    assert len(experiments) > 0
-
-    refl_lists = []
-    max_cell_list = []
-
-    # The detector/beam of the first experiment is used to define the basis
-    # for the optimisation, so assert that the beam intersects with
-    # the detector
-    detector = experiments[0].detector
-    beam = experiments[0].beam
-    beam_panel = detector.get_panel_intersection(beam.get_s0())
-    if beam_panel == -1:
-        raise Sorry("input beam does not intersect detector")
-
-    for expt, refl in zip(experiments, reflections):
-        refl = copy.deepcopy(refl)
-        refl["imageset_id"] = flex.int(len(refl), 0)
-        refl.centroid_px_to_mm([expt])
-        refl.map_centroids_to_reciprocal_space([expt])
-
-        if d_min is not None:
-            d_spacings = 1 / refl["rlp"].norms()
-            sel = d_spacings > d_min
-            refl = refl.select(sel)
-
-        # derive a max_cell from mm spots
-        if params.max_cell is None:
-            max_cell = find_max_cell(
-                refl, max_cell_multiplier=1.3, step_size=45
-            ).max_cell
-            max_cell_list.append(max_cell)
-
-        refl_condition = refl.size() > params.max_reflections
-        if params.max_reflections is not None and refl_condition:
-            logger.info(
-                "Selecting subset of %i reflections for analysis",
-                params.max_reflections,
-            )
-            perm = flex.random_permutation(refl.size())
-            sel = perm[: params.max_reflections]
-            refl = refl.select(sel)
-
-        refl_lists.append(refl)
-
-    if params.max_cell is None:
-        max_cell = flex.median(flex.double(max_cell_list))
-    else:
-        max_cell = params.max_cell
-
-    with concurrent.futures.ProcessPoolExecutor(max_workers=nproc) as pool:
-        solution_lists = []
-        amax_list = []
-        for result in pool.map(
-            run_dps, experiments, refl_lists, itertools.repeat(max_cell)
-        ):
-            if result.get("solutions"):
-                solution_lists.append(result["solutions"])
-                amax_list.append(result["amax"])
-
-    if not solution_lists:
-        raise Sorry("No solutions found")
-
-    new_experiments = optimize_origin_offset_local_scope(
-        experiments,
-        refl_lists,
-        solution_lists,
-        amax_list,
-        mm_search_scope=mm_search_scope,
-        wide_search_binning=wide_search_binning,
-        plot_search_scope=plot_search_scope,
-    )
-    new_detector = new_experiments[0].detector
-    old_panel, old_beam_centre = detector.get_ray_intersection(beam.get_s0())
-    (new_panel, new_beam_centre) = new_detector.get_ray_intersection(beam.get_s0())
-
-    old_bc_px = detector[old_panel].millimeter_to_pixel(old_beam_centre)
-    new_bc_px = new_detector[new_panel].millimeter_to_pixel(new_beam_centre)
-
-    logger.info(
-        "Old beam centre: {:.2f}, {:.2f} mm".format(*old_beam_centre)
-        + " ({:.1f}, {:.1f} px)".format(*old_bc_px)
-    )
-    logger.info(
-        "New beam centre: {:.2f}, {:.2f} mm".format(*new_beam_centre)
-        + " ({:.1f}, {:.1f} px)".format(*new_bc_px)
-    )
-    logger.info(
-        "Shift: {:.2f}, {:.2f} mm".format(
-            *(matrix.col(old_beam_centre) - matrix.col(new_beam_centre)).elems
-        )
-        + " ({:.1f}, {:.1f} px)".format(
-            *(matrix.col(old_bc_px) - matrix.col(new_bc_px)).elems
-        )
-    )
-    return new_experiments
-
-
 @dials.util.show_mail_handle_errors()
 def run(args=None):
     usage = """
@@ -691,15 +274,16 @@ def run(args=None):
         params.input.reflections, params.input.experiments
     )
 
-    if params.method[0] == "default" and not (
-        len(params.projection.method_x) == 1 or len(params.projection.method_y) == 1
-    ):
+    cond_01 = len(params.projection.method_x) == 1
+    cond_02 = len(params.projection.method_y) == 1
+
+    # Configure the logging
+    log.config(logfile=params.output.log)
+
+    if params.method[0] == "default" and not (cond_01 or cond_02):
         if len(experiments) == 0 or len(reflections) == 0:
             parser.print_help()
             exit(0)
-
-        # Configure the logging
-        log.config(logfile=params.output.log)
 
         # Log the diff phil
         diff_phil = parser.diff_phil.as_str()
@@ -724,7 +308,10 @@ def run(args=None):
         ]
 
         assert len(imagesets) > 0
-        assert len(reflections) == len(imagesets)
+        # assert len(reflections) == len(imagesets)
+        if len(reflections) != len(imagesets):
+            log.info("No reflections found.")
+            sys.exit()
 
         if (
             params.default.image_range is not None
@@ -750,145 +337,136 @@ def run(args=None):
             )
             logger.info("")
 
-        logger.info("Saving optimised experiments to %s", params.output.experiments)
+        msg = "Saving optimised experiments to %s" % params.output.experiments
+        logger.info(msg)
         experiments.as_file(params.output.experiments)
 
     else:  # Other methods (midpoint, maximum, inversion)
-        if len(experiments) == 0:
+        new_experiments = copy.deepcopy(experiments)
+
+        if len(new_experiments) == 0:
             parser.print_help()
             sys.exit(0)
 
-        imagesets = experiments.imagesets()
-
-        imageset_ranges = params.projection.imageset_ranges
-        image_ranges = params.projection.image_ranges
-
-        selected_set_indices = get_indices_from_slices(len(imagesets), imageset_ranges)
-        selected_sets = [imagesets[i] for i in selected_set_indices]
-        num_imagesets = len(selected_sets)
+        # Compute the starting positions for all imagesets
+        imageset_positions = {}
+        start_index = 0
+        for exp in new_experiments:
+            imageset_positions[exp.imageset] = start_index
+            start_index += exp.imageset.size()
 
         json_output = []
 
-        for set_run_index in range(num_imagesets):
-            set_index = selected_set_indices[set_run_index]
-            image_set = selected_sets[set_run_index]
-            num_images = image_set.size()
-            selected_image_indices = get_indices_from_slices(num_images, image_ranges)
-            num_selected_images = len(selected_image_indices)
+        # Map imagesets to detectors
+        detector_to_imagesets = {d: [] for d in new_experiments.detectors()}
+        for expt in new_experiments:
+            detector_to_imagesets[expt.detector].append(expt.imageset)
 
-            # Compute beam position for each image separetely
-            if params.projection.per_image:
-                for image_run_index in range(num_selected_images):
-                    image_index = selected_image_indices[image_run_index]
-                    image_index = np.uint64(image_index)
+        for det_index, detector in enumerate(detector_to_imagesets.keys()):
+            average_image = None
+            image_counter = 0
+            positions_x = []
+            positions_y = []
 
-                    image = image_set.get_corrected_data(image_index)
+            n_imagesets = len(detector_to_imagesets[detector])
+
+            for jj, imageset in enumerate(detector_to_imagesets[detector]):
+                start_index = imageset_positions[imageset]
+                end_index = start_index + imageset.size()
+
+                for i, ii in enumerate(range(start_index, end_index)):
+                    if params.projection.bar and not params.projection.per_image:
+                        print_progress(
+                            image_index=i,
+                            n_images=abs(end_index - start_index),
+                            set_index=jj,
+                            n_sets=n_imagesets,
+                        )
+
+                    index = np.uint64(i)
+                    image = imageset.get_corrected_data(index)
                     image = flumpy.to_numpy(image[0])
 
-                    mask = image_set.get_mask(0)
+                    mask = imageset.get_mask(0)
                     mask = flumpy.to_numpy(mask[0])
 
                     image[mask == 0] = 0
 
-                    x, y = compute_beam_position(image, params, image_index, set_index)
-                    json_output.append(
-                        (int(set_index), int(image_index), float(x), float(y))
-                    )
-
-                    if params.projection.bar:
-                        print_progress(
-                            image_index=image_run_index,
-                            n_images=num_selected_images,
-                            set_index=set_run_index,
-                            n_sets=num_imagesets,
-                            x=x,
-                            y=y,
+                    if params.projection.per_image:
+                        x, y = compute_beam_position(
+                            image, params, image_counter, det_index
                         )
-                    else:
-                        out_str = f"set {int(set_index):04d}, "
-                        out_str += f"image {int(image_index):04d}: "
-                        out_str += f"{x:.2f} {y:.2f}"
-                        print(out_str)
 
-            # Compute beam position for the average image
-            else:
-                save_img = params.projection.save_average_image
-                load_img = params.projection.load_average_image
+                        msg = f"[Detector {int(det_index)}] "
+                        msg += f"image {int(image_counter):05d}: "
+                        msg += f"{x:.2f} {y:.2f}"
+                        logger.info(msg)
 
-                if not load_img:  # Compute the average image
-                    for image_run_index in range(num_selected_images):
-                        image_index = selected_image_indices[image_run_index]
-
-                        image = image_set.get_corrected_data(image_index)
-                        image = flumpy.to_numpy(image[0])
-
-                        if image_run_index == 0:
-                            avg_image = image
-                        else:
-                            avg_image = avg_image + image
-
-                        if params.projection.bar:
-                            print_progress(
-                                image_index=image_run_index,
-                                n_images=num_selected_images,
-                                set_index=set_run_index,
-                                n_sets=num_imagesets,
-                                x=None,
-                                y=None,
+                        if x is not None and y is not None:
+                            positions_x.append(x)
+                            positions_y.append(y)
+                            json_output.append(
+                                (
+                                    int(det_index),
+                                    int(image_counter),
+                                    float(x),
+                                    float(y),
+                                )
                             )
 
-                    image = avg_image / num_selected_images
-                    mask = image_set.get_mask(0)
-                    mask = flumpy.to_numpy(mask[0])
-                    image[mask == 0] = 0
+                        else:
+                            log.warn("WARNING: beam position not found.")
 
-                    if save_img:
-                        np.savez("average_image.npz", image=image)
+                    else:
+                        if average_image is None:
+                            average_image = image
+                        else:
+                            average_image = average_image + image
 
-                else:  # Do not compute the average images, but load it
-                    data = np.load("average_image.npz")
-                    image = data["image"]
+                    image_counter += 1
 
-                compute_beam_position(image, params)
+            if params.projection.per_image:
+                x = np.array(positions_x).mean()
+                y = np.array(positions_y).mean()
+                msg = 40 * "=" + "\n"
+                msg += f"[Detector {det_index}] "
+                msg += "Average (per image) beam position: \n"
+                msg += f" {x:.2f} {y:.2f}"
+                logger.info(msg)
+            else:
+                average_image = average_image / image_counter
+                x, y = compute_beam_position(image, params, detector_index=det_index)
+                msg = f"[Detector {det_index}] "
+                msg += "Beam position from the average image: \n "
+                msg += f" {x:.2f} {y:.2f}"
+                logger.info(msg)
+
+            if x is not None and y is not None:
+                for panel in detector:
+                    xy = panel.pixel_to_millimeter((float(x), float(y)))
+
+                    beam = experiments[0].beam
+                    beam_direction = np.array(beam.get_s0())
+
+                    norm = np.linalg.norm(beam_direction)
+                    beam_direction = beam_direction / norm
+
+                    distance = panel.get_distance()
+                    beam_vec = beam_direction * distance
+
+                    fast = np.array(panel.get_fast_axis())
+                    slow = np.array(panel.get_slow_axis())
+
+                    new_origin = beam_vec - fast * xy[0] - slow * xy[1]
+                    panel.set_frame(fast, slow, new_origin)
+
+        msg = "Saving optimised experiments to %s" % params.output.experiments
+        logger.info(msg)
+        new_experiments.as_file(params.output.experiments)
 
         if params.projection.per_image:
             with open(params.output.json, "w") as json_file:
                 json.dump(json_output, json_file, indent=4)
-
-            if params.projection.bar:
-                print()
-
-
-def print_progress(image_index, n_images, set_index, n_sets, x, y, bar_length=40):
-    image_index += 1
-    set_index += 1
-
-    percent_images = 1.0 * image_index / n_images
-    percent_sets = 1.0 * set_index / n_sets
-
-    move_up = "\033[F"
-
-    img_bar_full = int(percent_images * bar_length)
-    image_bar = "=" * img_bar_full + " " * (bar_length - img_bar_full)
-
-    set_bar_full = int(percent_sets * bar_length)
-    set_bar = "=" * set_bar_full + " " * (bar_length - set_bar_full)
-
-    bar = f" Set:   [{set_bar}] {100 * percent_sets:0.2f} % "
-    bar += f"{set_index:4d}/{n_sets:d}\n"
-    bar += f" Image: [{image_bar}] {100 * percent_images:0.2f} % "
-    bar += f"{image_index:4d}/{n_images}\n"
-
-    if abs(percent_sets - 1.0) < 1.0e-15 and abs(percent_images - 1.0) < 1.0e-15:
-        end_str = ""
-    else:
-        end_str = f"{move_up}{move_up}\r"
-
-    if x is None or y is None:
-        bar += end_str
-    else:
-        bar += f"{x:.1f}, {y:.1f}          {end_str}"
-    print(bar, end="")
 
 
 if __name__ == "__main__":

--- a/src/dials/command_line/search_beam_position.py
+++ b/src/dials/command_line/search_beam_position.py
@@ -122,9 +122,9 @@ projection {
     .type = bool
     .help = "Plot the diffraction image with the computed beam center."
 
-    verbose = True
+    bar = True
     .type = bool
-    .help = "Print the beam position to the output."
+    .help = "Print progress bar."
 
     exclude_pixel_range_x = None
     .type = ints
@@ -795,7 +795,7 @@ def run(args=None):
                         (int(set_index), int(image_index), float(x), float(y))
                     )
 
-                    if params.projection.verbose:
+                    if params.projection.bar:
                         print_progress(
                             image_index=image_run_index,
                             n_images=num_selected_images,
@@ -804,6 +804,11 @@ def run(args=None):
                             x=x,
                             y=y,
                         )
+                    else:
+                        out_str = f"set {int(set_index):04d}, "
+                        out_str += f"image {int(image_index):04d}: "
+                        out_str += f"{x:.2f} {y:.2f}"
+                        print(out_str)
 
             # Compute beam position for the average image
             else:
@@ -822,7 +827,7 @@ def run(args=None):
                         else:
                             avg_image = avg_image + image
 
-                        if params.projection.verbose:
+                        if params.projection.bar:
                             print_progress(
                                 image_index=image_run_index,
                                 n_images=num_selected_images,
@@ -850,7 +855,7 @@ def run(args=None):
             with open(params.output.json, "w") as json_file:
                 json.dump(json_output, json_file, indent=4)
 
-            if params.projection.verbose:
+            if params.projection.bar:
                 print()
 
 


### PR DESCRIPTION
- Beam position is now computed for each detector in the experiment.
- All three projection methods now write ``optimised.expt`` file.
- ``per_image=True`` option now averages all the beam positions from individual images and saves it in the ``optimised.expt``.
- Removed options for data slicing (image and imageset ranges) since they were not compatible with data averaging per detector.
