### PR TITLE
Bugfix for dials.stills_process

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Bugfix for dials.stills_process in multiprocessing mode

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -1900,6 +1900,9 @@ The detector is reporting a gain of {panel.get_gain():f} but you have also suppl
                     info.mtime = time.time()
                     tar.addfile(tarinfo=info, fileobj=string)
                 tar.close()
+        if self.debug_file_handle:
+            self.debug_file_handle
+            del self.debug_file_handle
 
 
 @dials.util.show_mail_handle_errors()


### PR DESCRIPTION
Close the processor debug file handle.  Fixes multiprocessing mode.