### PR TITLE
Optimise db score

### DIFF
--- a/.conda-envs/linux.txt
+++ b/.conda-envs/linux.txt
@@ -28,6 +28,7 @@ msgpack-python
 natsort
 numpy
 nxmx
+optuna
 ordered-set
 pandas
 pillow>=5.4.1

--- a/.conda-envs/macos.txt
+++ b/.conda-envs/macos.txt
@@ -26,6 +26,7 @@ msgpack-python
 natsort
 numpy
 nxmx
+optuna
 ordered-set
 pandas
 pillow>=5.4.1

--- a/.conda-envs/windows.txt
+++ b/.conda-envs/windows.txt
@@ -25,6 +25,7 @@ msgpack-python
 natsort
 numpy
 nxmx
+optuna
 ordered-set
 pandas
 pillow>=5.4.1

--- a/newsfragments/xxxx.feature
+++ b/newsfragments/xxxx.feature
@@ -1,0 +1,1 @@
+``dials.correlation_matrix``: Optimise the input parameters to OPTICS for better detection of clusters

--- a/src/dials/algorithms/correlation/analysis.py
+++ b/src/dials/algorithms/correlation/analysis.py
@@ -407,6 +407,8 @@ class CorrelationMatrix:
                 self.cosym_analysis.coords[mask], optics_model.labels_[mask]
             )
 
+            trial.set_user_attr("db_score", score)
+
             # Include penalty for noise as don't want to bias for only tiny dense groups if majority a bit less dense
 
             noise_ratio = 1 - np.sum(mask) / len(optics_model.labels_)
@@ -427,7 +429,7 @@ class CorrelationMatrix:
 
         return (
             study.best_params["min_samples"],
-            study.best_value,
+            study.best_trial.user_attrs["db_score"],
             study.best_trial.user_attrs["labels"],
             study.best_trial.user_attrs["model"],
         )


### PR DESCRIPTION
A few cases were found where the OPTICS analysis did a poor job of identifying clusters in the cosym coordinate plot. This is a significant concern as we are running this analysis automatically and providing clusters to users, but they may not have experience interpreting the clustering plots (or even know where to look for them!). 

See this example with 4 obvious clusters that OPTICS decided were actually 3. This is about the most text book, clear cut case, and we should be able to separate these groups automatically.  
<img width="1451" height="515" alt="before_optimise" src="https://github.com/user-attachments/assets/9c910e59-ff6f-420b-844b-5e5352f63808" />
This came about because the OPTICS analysis is quite sensitive to the initial choice of the min_samples parameter - ie what is the minimum number of samples for a cluster to be a cluster. 

As the number of groups is linked to the number of systematic differences (ie dimensions), we had been using a heuristic that the min_samples parameter should be equal to the number of datasets / number of dimensions * some buffer to account for groups of different sizes. This was a reasonable starting point, as we have no idea in advance of the analysis what the size of the smallest cluster is. However, in this case, the size of the smallest cluster was BELOW where this heuristic had set the min_samples parameter. Therefore, it was not identified as a separate cluster. 

This PR introduces a new package (optuna), which essentially brute forces the testing of different parameters. The benefit of optuna (https://github.com/optuna/optuna) is that it doesn't just randomly pick values to try, instead it uses results of previous trials to inform new parameters to test. The brute force approach is not a significant downside, given the OPTICS analysis is already much faster than the rest of the clustering analysis, and in this case, such an obviously wrong result would require re-running the entire clustering analysis from scratch (including the calculation of rij - the most time intensive part), to get the right groups separated out. Therefore, sacrificing a small amount of time to optimise in the first instance saves significant computation time later.

The Davies-Bouldin Score (https://scikit-learn.org/stable/modules/generated/sklearn.metrics.davies_bouldin_score.html) is a measure of how well defined the clusters are, therefore optimising min_samples to minimise this parameter results in clusters that are denser and better separated. To avoid tiny "super-dense" groups being identified with most of the data being classified as noise, a penalty was added for noise. Currently, the DB-Score and Noise penalty are weighted equally, though the penalty applied for noise has been added as a phil parameter. 

With all this, OPTICS automatically classifies the data as expected:
<img width="1373" height="476" alt="after_optimise" src="https://github.com/user-attachments/assets/1db48b0b-ba1b-4a31-b902-560042904766" />

This approach also gives equivalent results when analysing the cows, pigs and people data from the recent publication. 