### PR TITLE
Change scoring metric in dials.correlation_matrix clustering optimisation

### DIFF
--- a/tests/algorithms/correlation/test_analysis.py
+++ b/tests/algorithms/correlation/test_analysis.py
@@ -142,7 +142,7 @@ def test_filtered_corr_mat(proteinase_k, run_in_tmp_path):
 def test_optics_classification_definitive(
     coordinates, expected_labels, initial_min_samples
 ):
-    _, _, _, actual_labels, _ = CorrelationMatrix.optimise_clustering(
+    _, _, actual_labels, _ = CorrelationMatrix.optimise_clustering(
         coordinates, initial_min_samples=initial_min_samples
     )
 
@@ -161,7 +161,7 @@ def test_optics_classification_definitive(
 def test_optics_classification_variable(
     coordinates, expected_labels, initial_min_samples
 ):
-    _, _, _, actual_labels, _ = CorrelationMatrix.optimise_clustering(
+    _, _, actual_labels, _ = CorrelationMatrix.optimise_clustering(
         coordinates, initial_min_samples=initial_min_samples
     )
 


### PR DESCRIPTION
Was previously using davies-bouldin score to optimise OPTICS parameters, but have since found a new method that has been optimised for density based methods (DBSCAN, HDBSCAN, OPTICS). It accounts for noise better, so can simplify the optimisation logic by using it and the process is more robust. 

Also improved logging and made the optimisation optional, so that if a non-optimal solution is desired, it can easily be re-run and output using dials.correlation matrix. 

DRAFT: need to decide if it is ok to use the kDBCV library? (if so will need to update dependencies) 
Will also require an accompanying PR for multiplex. 