### PR TITLE
Remove 'Unity' requirement for Windows /bigobj

### DIFF
--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -1097,8 +1097,8 @@ conda activate {dist_root}/conda_base
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(dials)
 
-if (CMAKE_UNITY_BUILD AND MSVC)
-    # Windows can fail in this scenario because too many objects
+if (MSVC)
+    # Windows can fail because of too many objects
     add_compile_options(/bigobj)
 endif()
 

--- a/newsfragments/3019.bugfix
+++ b/newsfragments/3019.bugfix
@@ -1,0 +1,1 @@
+Fix failed builds on Visual Studio 2022 due to excessively large obj files.


### PR DESCRIPTION
Have seen this issue starting to creep in with newer windows builds and Visual Studio 2022.

Fixes #3019.