### PR TITLE
add rs-station forum links

### DIFF
--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -16,6 +16,7 @@ DIALS: Diffraction Integration for Advanced Light Sources
    documentation/tutorials/index
    How-to <howto>
    Knowledge Base <https://dials.github.io/kb>
+   Forum <https://discourse.rs-station.org/c/software/dials/10>
    workshops/index
    US National Resource <national_resource>
    publications
@@ -41,7 +42,7 @@ Contact
 
 For feature requests, bug reports or any other information, please contact
 the DIALS developers at dials-user-group@jiscmail.net, or post an
-`issue`_.
+`issue`_. Ask users and developers for help on the RS-Station `forum`_.
 
 Citing DIALS
 ============
@@ -115,3 +116,4 @@ Work at LBNL is performed under `Department of Energy`_ contract DE-AC02-05CH112
 .. _`Department of Energy`: http://www.energy.gov/
 .. _dials.github.io: https://dials.github.io/
 .. _`NIH`: https://www.nigms.nih.gov/
+.. _`forum`: https://discourse.rs-station.org/c/software/dials/10 

--- a/newsfragments/3152.doc
+++ b/newsfragments/3152.doc
@@ -1,0 +1,1 @@
+Added links to the DIALS category on the RS-Station Forum


### PR DESCRIPTION
The DIALS Category on the RS-Station forum could serve as a persistent, findable place for users to ask for help from other users and the DIALS developers. Users can log in with ORCID or GitHub and are able to post anonymously if they choose. The forum supports rich media and markdown formatting. Many of the DIALS developers already have accounts on RS-Station and have moderation privileges to manage the category.

In this PR, I added a link to the DIALS forum category to the Contact section of index.html and to the sidebar mimicking the pattern used for the Knowledge Base. 