### PR TITLE
Return None from do_work() when using mp.method=multiprocessing

### DIFF
--- a/newsfragments/3156.bugfix
+++ b/newsfragments/3156.bugfix
@@ -1,0 +1,1 @@
+Fix a pickling error when running dials.stills_process with mp.method=multiprocessing.

--- a/newsfragments/XXXX.bugfix
+++ b/newsfragments/XXXX.bugfix
@@ -1,1 +1,0 @@
-Fix a pickling error when running dials.stills_process with mp.method=multiprocessing.

--- a/newsfragments/XXXX.bugfix
+++ b/newsfragments/XXXX.bugfix
@@ -1,0 +1,1 @@
+Fix a pickling error when running dials.stills_process with mp.method=multiprocessing.

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -675,7 +675,10 @@ class Script:
                     imageset.clear_cache()
                 if finalize:
                     processor.finalize()
-                return processor
+                if self.params.mp.method == "multiprocessing":
+                    return None
+                else:
+                    return processor
 
             iterable = list(zip(tags, range(len(split_experiments))))
 
@@ -746,7 +749,10 @@ class Script:
                     processor.process_experiments(tag, experiments)
                 if finalize:
                     processor.finalize()
-                return processor
+                if self.params.mp.method == "multiprocessing":
+                    return None
+                else:
+                    return processor
 
             iterable = list(zip(tags, all_paths))
 


### PR DESCRIPTION
When mp.method=multiprocessing, easy_mp tries to pickle the return value of do_work() to pass it back to the parent process. The Processor object contains C++ extension objects that are not picklable.

The Processor return value is used only to hand off cached state between calls in MPI/serial mode; under multiprocessing each worker is independent and the return value is unused. Return None in that case.