### PR TITLE
Cache SpotFinder objects across stills and make masking architecture …

### DIFF
--- a/newsfragments/3157.misc
+++ b/newsfragments/3157.misc
@@ -1,0 +1,1 @@
+dials.stills_process performance improvements from caching masking objects

--- a/newsfragments/XXXX.misc
+++ b/newsfragments/XXXX.misc
@@ -1,0 +1,1 @@
+Cache the static geometry mask and spotfinding algorithm objects across stills frames, making the static/dynamic mask boundary explicit in ExtractPixelsFromImage.

--- a/newsfragments/XXXX.misc
+++ b/newsfragments/XXXX.misc
@@ -1,1 +1,0 @@
-Cache the static geometry mask and spotfinding algorithm objects across stills frames, making the static/dynamic mask boundary explicit in ExtractPixelsFromImage.

--- a/src/dials/algorithms/spot_finding/finder.py
+++ b/src/dials/algorithms/spot_finding/finder.py
@@ -45,6 +45,7 @@ class ExtractPixelsFromImage:
         region_of_interest,
         max_strong_pixel_fraction,
         compute_mean_background,
+        is_stills,
     ):
         """
         Initialise the class
@@ -54,16 +55,26 @@ class ExtractPixelsFromImage:
         :param mask: The image mask
         :param region_of_interest: A region of interest to process
         :param max_strong_pixel_fraction: The maximum fraction of pixels allowed
+        :param is_stills: Specifies if this is during processing stills. Then the object will be
+                          cached with the imageset being updated with each new frame.
         """
         self.threshold_function = threshold_function
-        self.imageset = imageset
-        self.mask = mask
         self.region_of_interest = region_of_interest
         self.max_strong_pixel_fraction = max_strong_pixel_fraction
         self.compute_mean_background = compute_mean_background
-        if self.mask is not None:
-            detector = self.imageset.get_detector()
-            assert len(self.mask) == len(detector)
+        self.imageset = imageset
+        self.image_mask = mask
+        self.is_stills = is_stills
+
+    def update_imageset(self, imageset):
+        """
+        In the case of stills processing, update the imageset while all other object attributes
+        remain the same. The per-frame dynamic mask (imageset.get_mask) is recomputed on each
+        __call__ because the trusted-range overload component varies between stills.
+
+        :param imageset: Next imageset to be processed with the cached spot-finding objects.
+        """
+        self.imageset = imageset
 
     def __call__(self, index):
         """
@@ -71,6 +82,19 @@ class ExtractPixelsFromImage:
 
         :param index: The index of the image
         """
+        # Get the per-frame dynamic mask. This combines:
+        #   - static components: external lookup mask + detector untrusted rectangles
+        #   - dynamic component: trusted-range overloads (different saturated pixels each still)
+        # The trusted-range component requires reading raw pixel data and must be recomputed
+        # for every frame; it cannot be cached across stills.
+        imageset_mask = self.imageset.get_mask(index)
+        assert len(self.image_mask) == len(imageset_mask)
+        assert len(self.image_mask) == len(self.imageset.get_detector())
+        mask = tuple(m1 & m2 for m1, m2 in zip(imageset_mask, self.image_mask))
+        logger.debug(
+            f"Number of masked pixels: {sum(m.count(False) for m in mask)}",
+        )
+
         # Get the frame number
         if isinstance(self.imageset, ImageSequence):
             frame = self.imageset.get_array_range()[0] + index
@@ -83,18 +107,8 @@ class ExtractPixelsFromImage:
         # Create the list of pixel lists
         pixel_list = []
 
-        # Get the image and mask
+        # Get the image
         image = self.imageset.get_corrected_data(index)
-        mask = self.imageset.get_mask(index)
-
-        # Set the mask
-        if self.mask is not None:
-            assert len(self.mask) == len(mask)
-            mask = tuple(m1 & m2 for m1, m2 in zip(mask, self.mask))
-
-        logger.debug(
-            f"Number of masked pixels for image {index}: {sum(m.count(False) for m in mask)}",
-        )
 
         # Add the images to the pixel lists
         num_strong = 0
@@ -184,6 +198,7 @@ class ExtractPixelsFromImage2DNoShoeboxes(ExtractPixelsFromImage):
         min_spot_size,
         max_spot_size,
         filter_spots,
+        is_stills,
     ):
         """
         Initialise the class
@@ -201,12 +216,14 @@ class ExtractPixelsFromImage2DNoShoeboxes(ExtractPixelsFromImage):
             region_of_interest,
             max_strong_pixel_fraction,
             compute_mean_background,
+            is_stills,
         )
 
         # Save some stuff
         self.min_spot_size = min_spot_size
         self.max_spot_size = max_spot_size
         self.filter_spots = filter_spots
+        self.is_stills = is_stills
 
     def __call__(self, index):
         """
@@ -383,6 +400,7 @@ class ExtractSpots:
         no_shoeboxes_2d=False,
         min_chunksize=50,
         write_hot_pixel_mask=False,
+        is_stills=False,
     ):
         """
         Initialise the class with the strategy
@@ -409,6 +427,8 @@ class ExtractSpots:
         self.no_shoeboxes_2d = no_shoeboxes_2d
         self.min_chunksize = min_chunksize
         self.write_hot_pixel_mask = write_hot_pixel_mask
+        self.function = None
+        self.is_stills = is_stills
 
     def __call__(self, imageset):
         """
@@ -474,14 +494,18 @@ class ExtractSpots:
         assert mp_chunksize > 0, "Invalid chunk size"
 
         # The extract pixels function
-        function = ExtractPixelsFromImage(
-            imageset=imageset,
-            threshold_function=self.threshold_function,
-            mask=self.mask,
-            max_strong_pixel_fraction=self.max_strong_pixel_fraction,
-            compute_mean_background=self.compute_mean_background,
-            region_of_interest=self.region_of_interest,
-        )
+        if self.function is None or not self.is_stills:
+            self.function = ExtractPixelsFromImage(
+                imageset=imageset,
+                threshold_function=self.threshold_function,
+                mask=self.mask,
+                max_strong_pixel_fraction=self.max_strong_pixel_fraction,
+                compute_mean_background=self.compute_mean_background,
+                region_of_interest=self.region_of_interest,
+                is_stills=self.is_stills,
+            )
+        else:
+            self.function.update_imageset(imageset)
 
         # The indices to iterate over
         indices = list(range(len(imageset)))
@@ -507,7 +531,7 @@ class ExtractSpots:
                     plabeller.add(plist)
 
             batch_multi_node_parallel_map(
-                func=ExtractSpotsParallelTask(function),
+                func=ExtractSpotsParallelTask(self.function),
                 iterable=indices,
                 nproc=mp_nproc,
                 njobs=mp_njobs,
@@ -517,7 +541,7 @@ class ExtractSpots:
             )
         else:
             for task in indices:
-                result = function(task)
+                result = self.function(task)
                 assert len(pixel_labeller) == len(result), "Inconsistent size"
                 for plabeller, plist in zip(pixel_labeller, result):
                     plabeller.add(plist)
@@ -565,17 +589,19 @@ class ExtractSpots:
         assert mp_chunksize > 0, "Invalid chunk size"
 
         # The extract pixels function
-        function = ExtractPixelsFromImage2DNoShoeboxes(
-            imageset=imageset,
-            threshold_function=self.threshold_function,
-            mask=self.mask,
-            max_strong_pixel_fraction=self.max_strong_pixel_fraction,
-            compute_mean_background=self.compute_mean_background,
-            region_of_interest=self.region_of_interest,
-            min_spot_size=self.min_spot_size,
-            max_spot_size=self.max_spot_size,
-            filter_spots=self.filter_spots,
-        )
+        if self.function is None or not self.is_stills:
+            self.function = ExtractPixelsFromImage2DNoShoeboxes(
+                imageset=imageset,
+                threshold_function=self.threshold_function,
+                mask=self.mask,
+                max_strong_pixel_fraction=self.max_strong_pixel_fraction,
+                compute_mean_background=self.compute_mean_background,
+                region_of_interest=self.region_of_interest,
+                min_spot_size=self.min_spot_size,
+                max_spot_size=self.max_spot_size,
+                filter_spots=self.filter_spots,
+                is_stills=self.is_stills,
+            )
 
         # The indices to iterate over
         indices = list(range(len(imageset)))
@@ -600,7 +626,7 @@ class ExtractSpots:
                 result[0][0] = None
 
             batch_multi_node_parallel_map(
-                func=ExtractSpotsParallelTask(function),
+                func=ExtractSpotsParallelTask(self.function),
                 iterable=indices,
                 nproc=mp_nproc,
                 njobs=mp_njobs,
@@ -610,7 +636,7 @@ class ExtractSpots:
             )
         else:
             for task in indices:
-                reflections.extend(function(task)[0])
+                reflections.extend(self.function(task)[0])
 
         # Return the reflections
         return reflections, None
@@ -651,6 +677,7 @@ class SpotFinder:
         :param scan_range: The scan range to find spots over
         :param is_stills:   [ADVANCED] Force still-handling of experiment
                             ID remapping for dials.stills_process.
+                            Caching of the spotfinder.
         """
 
         # Set the filter and some other stuff
@@ -673,6 +700,8 @@ class SpotFinder:
         self.no_shoeboxes_2d = no_shoeboxes_2d
         self.min_chunksize = min_chunksize
         self.is_stills = is_stills
+        self.extract_spots = None
+        self.imageset_mask = None
 
     def find_spots(self, experiments: ExperimentList) -> flex.reflection_table:
         """
@@ -737,7 +766,6 @@ class SpotFinder:
                 # Write the hot mask
                 with open(imageset.external_lookup.mask.filename, "wb") as outfile:
                     pickle.dump(hot_mask, outfile, protocol=pickle.HIGHEST_PROTOCOL)
-
         # Set the strong spot flag
         reflections.set_flags(
             flex.size_t_range(len(reflections)), reflections.flags.strong
@@ -757,28 +785,35 @@ class SpotFinder:
         :return: The observed spots
         """
         # The input mask
-        mask = self.mask_generator(imageset)
-        if self.mask is not None:
-            mask = tuple(m1 & m2 for m1, m2 in zip(mask, self.mask))
+        if self.imageset_mask is None or not self.is_stills:
+            self.imageset_mask = self.mask_generator(imageset)
+            if self.mask is not None:
+                self.imageset_mask = tuple(
+                    m1 & m2 for m1, m2 in zip(self.imageset_mask, self.mask)
+                )
 
         # Set the spot finding algorithm
-        extract_spots = ExtractSpots(
-            threshold_function=self.threshold_function,
-            mask=mask,
-            region_of_interest=self.region_of_interest,
-            max_strong_pixel_fraction=self.max_strong_pixel_fraction,
-            compute_mean_background=self.compute_mean_background,
-            mp_method=self.mp_method,
-            mp_nproc=self.mp_nproc,
-            mp_njobs=self.mp_njobs,
-            mp_chunksize=self.mp_chunksize,
-            min_spot_size=self.min_spot_size,
-            max_spot_size=self.max_spot_size,
-            filter_spots=self.filter_spots,
-            no_shoeboxes_2d=self.no_shoeboxes_2d,
-            min_chunksize=self.min_chunksize,
-            write_hot_pixel_mask=self.write_hot_mask,
-        )
+        # In the case of processing stills, cache the object.
+        # Otherwise, create a new object each call.
+        if self.extract_spots is None or not self.is_stills:
+            self.extract_spots = ExtractSpots(
+                threshold_function=self.threshold_function,
+                mask=self.imageset_mask,
+                region_of_interest=self.region_of_interest,
+                max_strong_pixel_fraction=self.max_strong_pixel_fraction,
+                compute_mean_background=self.compute_mean_background,
+                mp_method=self.mp_method,
+                mp_nproc=self.mp_nproc,
+                mp_njobs=self.mp_njobs,
+                mp_chunksize=self.mp_chunksize,
+                min_spot_size=self.min_spot_size,
+                max_spot_size=self.max_spot_size,
+                filter_spots=self.filter_spots,
+                no_shoeboxes_2d=self.no_shoeboxes_2d,
+                min_chunksize=self.min_chunksize,
+                write_hot_pixel_mask=self.write_hot_mask,
+                is_stills=self.is_stills,
+            )
 
         # Get the max scan range
         if isinstance(imageset, ImageSequence):
@@ -810,9 +845,9 @@ class SpotFinder:
                 j0 -= imageset.get_array_range()[0]
                 j1 -= imageset.get_array_range()[0]
             if len(imageset) == 1:
-                r, h = extract_spots(imageset)
+                r, h = self.extract_spots(imageset)
             else:
-                r, h = extract_spots(imageset[j0:j1])
+                r, h = self.extract_spots(imageset[j0:j1])
             reflections.extend(r)
             if h is not None:
                 for h1, h2 in zip(hot_pixels, h):

--- a/src/dials/algorithms/spot_finding/threshold.py
+++ b/src/dials/algorithms/spot_finding/threshold.py
@@ -43,9 +43,6 @@ class DispersionThresholdStrategy(ThresholdStrategy):
         # Save the constant gain
         self._gain_map = None
 
-        # Create a buffer
-        self.algorithm = {}
-
     def __call__(self, image, mask):
         """
         Call the thresholding function
@@ -58,19 +55,14 @@ class DispersionThresholdStrategy(ThresholdStrategy):
         from dials.array_family import flex
 
         # Initialise the algorithm
-        try:
-            algorithm = self.algorithm[image.all()]
-        except Exception:
-            algorithm = threshold.DispersionThreshold(
-                image.all(),
-                self._kernel_size,
-                self._n_sigma_b,
-                self._n_sigma_s,
-                self._threshold,
-                self._min_count,
-            )
-            self.algorithm[image.all()] = algorithm
-
+        algorithm = threshold.DispersionThreshold(
+            image.all(),
+            self._kernel_size,
+            self._n_sigma_b,
+            self._n_sigma_s,
+            self._threshold,
+            self._min_count,
+        )
         # Set the gain
         if self._gain is not None:
             assert self._gain > 0
@@ -83,6 +75,7 @@ class DispersionThresholdStrategy(ThresholdStrategy):
             algorithm(image, mask, self._gain_map, result)
         else:
             algorithm(image, mask, result)
+        del algorithm
 
         # Return the result
         return result
@@ -112,9 +105,6 @@ class DispersionExtendedThresholdStrategy(ThresholdStrategy):
         # Save the constant gain
         self._gain_map = None
 
-        # Create a buffer
-        self.algorithm = {}
-
     def __call__(self, image, mask):
         """
         Call the thresholding function
@@ -127,19 +117,14 @@ class DispersionExtendedThresholdStrategy(ThresholdStrategy):
         from dials.array_family import flex
 
         # Initialise the algorithm
-        try:
-            algorithm = self.algorithm[image.all()]
-        except Exception:
-            algorithm = threshold.DispersionExtendedThreshold(
-                image.all(),
-                self._kernel_size,
-                self._n_sigma_b,
-                self._n_sigma_s,
-                self._threshold,
-                self._min_count,
-            )
-            self.algorithm[image.all()] = algorithm
-
+        algorithm = threshold.DispersionExtendedThreshold(
+            image.all(),
+            self._kernel_size,
+            self._n_sigma_b,
+            self._n_sigma_s,
+            self._threshold,
+            self._min_count,
+        )
         # Set the gain
         if self._gain is not None:
             assert self._gain > 0
@@ -152,6 +137,6 @@ class DispersionExtendedThresholdStrategy(ThresholdStrategy):
             algorithm(image, mask, self._gain_map, result)
         else:
             algorithm(image, mask, result)
-
+        del algorithm
         # Return the result
         return result

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -11,6 +11,7 @@ import tarfile
 import time
 from io import BytesIO
 
+import libtbx
 from dxtbx.model.experiment_list import (
     Experiment,
     ExperimentList,
@@ -929,6 +930,8 @@ class Processor:
 
             self.setup_filenames(composite_tag)
 
+        self.spot_finder_factory = None
+
     def setup_filenames(self, tag):
         # before processing, set output paths according to the templates
         if (
@@ -1151,6 +1154,27 @@ class Processor:
 The detector is reporting a gain of {panel.get_gain():f} but you have also supplied a gain of {gain:f}. Since the detector gain is not 1.0, your supplied gain will be multiplicatively applied in addition to the detector's gain, which is unlikely to be correct. Please re-run, removing spotfinder.dispersion.gain and integration.summation.detector_gain from your parameters. You can override this exception by setting input.ignore_gain_mismatch=True."""
                             )
 
+    def get_spot_finder_factory(self, experiments):
+        from dials.algorithms.spot_finding.factory import SpotFinderFactory
+
+        if self.params.spotfinder.filter.min_spot_size is libtbx.Auto:
+            detector = experiments[0].imageset.get_detector()
+            if detector[0].get_type() == "SENSOR_PAD":
+                # smaller default value for pixel array detectors
+                self.params.spotfinder.filter.min_spot_size = 3
+            else:
+                self.params.spotfinder.filter.min_spot_size = 6
+            logger.info(
+                "Setting spotfinder.filter.min_spot_size=%i",
+                self.params.spotfinder.filter.min_spot_size,
+            )
+
+        # Get the spot-finder from the input parameters
+        logger.info("Configuring spot finder from input parameters")
+        return SpotFinderFactory.from_parameters(
+            experiments=experiments, params=self.params, is_stills=True
+        )
+
     def find_spots(self, experiments):
         st = time.time()
 
@@ -1159,9 +1183,9 @@ The detector is reporting a gain of {panel.get_gain():f} but you have also suppl
         logger.info("*" * 80)
 
         # Find the strong spots
-        observed = flex.reflection_table.from_observations(
-            experiments, self.params, is_stills=True
-        )
+        if self.spot_finder_factory is None:
+            self.spot_finder_factory = self.get_spot_finder_factory(experiments)
+        observed = self.spot_finder_factory.find_spots(experiments)
 
         # Reset z coordinates for dials.image_viewer; see Issues #226 for details
         xyzobs = observed["xyzobs.px.value"]

--- a/src/dials/extensions/dispersion_extended_spotfinder_threshold_ext.py
+++ b/src/dials/extensions/dispersion_extended_spotfinder_threshold_ext.py
@@ -31,6 +31,7 @@ class DispersionExtendedSpotFinderThresholdExt:
         :param params: The input parameters
         """
         self.params = params
+        self._algorithm = None
 
     def compute_threshold(self, image, mask, **kwargs):
         r"""
@@ -42,25 +43,26 @@ class DispersionExtendedSpotFinderThresholdExt:
         :returns: A boolean mask showing foreground/background pixels
         """
 
-        params = self.params
-        if params.spotfinder.threshold.dispersion.global_threshold is libtbx.Auto:
-            params.spotfinder.threshold.dispersion.global_threshold = int(
-                estimate_global_threshold(image, mask)
-            )
-            logger.info(
-                "Setting global_threshold: %i",
-                params.spotfinder.threshold.dispersion.global_threshold,
-            )
+        if self._algorithm is None:
+            params = self.params
+            if params.spotfinder.threshold.dispersion.global_threshold is libtbx.Auto:
+                params.spotfinder.threshold.dispersion.global_threshold = int(
+                    estimate_global_threshold(image, mask)
+                )
+                logger.info(
+                    "Setting global_threshold: %i",
+                    params.spotfinder.threshold.dispersion.global_threshold,
+                )
 
-        self._algorithm = DispersionExtendedThresholdStrategy(
-            kernel_size=params.spotfinder.threshold.dispersion.kernel_size,
-            gain=params.spotfinder.threshold.dispersion.gain,
-            mask=params.spotfinder.lookup.mask,
-            n_sigma_b=params.spotfinder.threshold.dispersion.sigma_background,
-            n_sigma_s=params.spotfinder.threshold.dispersion.sigma_strong,
-            min_count=params.spotfinder.threshold.dispersion.min_local,
-            global_threshold=params.spotfinder.threshold.dispersion.global_threshold,
-        )
+            self._algorithm = DispersionExtendedThresholdStrategy(
+                kernel_size=params.spotfinder.threshold.dispersion.kernel_size,
+                gain=params.spotfinder.threshold.dispersion.gain,
+                mask=params.spotfinder.lookup.mask,
+                n_sigma_b=params.spotfinder.threshold.dispersion.sigma_background,
+                n_sigma_s=params.spotfinder.threshold.dispersion.sigma_strong,
+                min_count=params.spotfinder.threshold.dispersion.min_local,
+                global_threshold=params.spotfinder.threshold.dispersion.global_threshold,
+            )
 
         return self._algorithm(image, mask)
 

--- a/src/dials/extensions/dispersion_spotfinder_threshold_ext.py
+++ b/src/dials/extensions/dispersion_spotfinder_threshold_ext.py
@@ -72,6 +72,7 @@ class DispersionSpotFinderThresholdExt:
         :param params: The input parameters
         """
         self.params = params
+        self._algorithm = None
 
     def compute_threshold(self, image, mask, **kwargs):
         r"""
@@ -85,27 +86,30 @@ class DispersionSpotFinderThresholdExt:
 
         import libtbx
 
-        params = self.params
-        if params.spotfinder.threshold.dispersion.global_threshold is libtbx.Auto:
-            params.spotfinder.threshold.dispersion.global_threshold = int(
-                estimate_global_threshold(image, mask)
-            )
-            logger.info(
-                "Setting global_threshold: %i",
-                params.spotfinder.threshold.dispersion.global_threshold,
+        if self._algorithm is None:
+            params = self.params
+            if params.spotfinder.threshold.dispersion.global_threshold is libtbx.Auto:
+                params.spotfinder.threshold.dispersion.global_threshold = int(
+                    estimate_global_threshold(image, mask)
+                )
+                logger.info(
+                    "Setting global_threshold: %i",
+                    params.spotfinder.threshold.dispersion.global_threshold,
+                )
+
+            from dials.algorithms.spot_finding.threshold import (
+                DispersionThresholdStrategy,
             )
 
-        from dials.algorithms.spot_finding.threshold import DispersionThresholdStrategy
-
-        self._algorithm = DispersionThresholdStrategy(
-            kernel_size=params.spotfinder.threshold.dispersion.kernel_size,
-            gain=params.spotfinder.threshold.dispersion.gain,
-            mask=params.spotfinder.lookup.mask,
-            n_sigma_b=params.spotfinder.threshold.dispersion.sigma_background,
-            n_sigma_s=params.spotfinder.threshold.dispersion.sigma_strong,
-            min_count=params.spotfinder.threshold.dispersion.min_local,
-            global_threshold=params.spotfinder.threshold.dispersion.global_threshold,
-        )
+            self._algorithm = DispersionThresholdStrategy(
+                kernel_size=params.spotfinder.threshold.dispersion.kernel_size,
+                gain=params.spotfinder.threshold.dispersion.gain,
+                mask=params.spotfinder.lookup.mask,
+                n_sigma_b=params.spotfinder.threshold.dispersion.sigma_background,
+                n_sigma_s=params.spotfinder.threshold.dispersion.sigma_strong,
+                min_count=params.spotfinder.threshold.dispersion.min_local,
+                global_threshold=params.spotfinder.threshold.dispersion.global_threshold,
+            )
 
         return self._algorithm(image, mask)
 


### PR DESCRIPTION
…explicit

imageset.get_mask(index) returns two components combined:
  - static: external lookup mask + detector untrusted rectangles
  - dynamic: trusted-range overload mask (which pixels saturated this frame)

The static component is identical across all stills from the same setup. SpotFinder pre-computes it once via MaskGenerator (resolution shells, detector border, ice rings) and propagates it through ExtractSpots into ExtractPixelsFromImage as image_mask. Inside ExtractPixelsFromImage.__call__, imageset.get_mask(index) is called every frame to obtain the per-frame overload mask; the two are then combined:

    mask = tuple(m1 & m2 for m1, m2 in zip(imageset_mask, self.image_mask))

This makes the static/dynamic boundary explicit in the code. The attribute previously named self.mask is renamed self.image_mask in ExtractPixelsFromImage to make the distinction clear. The old guard 'if self.mask is not None' is removed; the static mask is now always present.

With the masking architecture explicit, ExtractPixelsFromImage can be safely reused across stills via a new update_imageset() method. ExtractSpots caches self.function (the ExtractPixelsFromImage instance) and calls update_imageset() on subsequent stills instead of constructing a new object (gated on is_stills=True). This avoids repeated object allocation and threshold parameter parsing.

At the extension layer, the dispersion threshold wrapper classes (extensions/dispersion_spotfinder_threshold_ext.py and extensions/dispersion_extended_spotfinder_threshold_ext.py) now lazily initialize self._algorithm (the C++ Strategy wrapper) on the first call and reuse it; previously it was rebuilt every frame including re-running estimate_global_threshold.

At the algorithm layer, DispersionThresholdStrategy and DispersionExtendedThresholdStrategy (algorithms/spot_finding/threshold.py) no longer maintain self.algorithm = {}, a dict that retained one C++ threshold object per image shape for the lifetime of the Strategy. With the wrapper now cached at the extension layer the dict is redundant; the C++ object is constructed per-call and explicitly deleted (del algorithm).

Processor.find_spots() (command_line/stills_process.py): cache the SpotFinder returned by SpotFinderFactory.from_parameters() and call find_spots(experiments) directly on subsequent stills.