### PR TITLE
Cache Indexer objects and PHIL scopes in stills_process Processor

### DIFF
--- a/newsfragments/3158.misc
+++ b/newsfragments/3158.misc
@@ -1,0 +1,1 @@
+Cache Indexer objects across stills frames in stills_process.py to avoid repeated PHIL parsing and internal solver setup overhead, and eliminate expensive copy.deepcopy calls on the parameter scope.

--- a/newsfragments/XXXX.misc
+++ b/newsfragments/XXXX.misc
@@ -1,1 +1,0 @@
-Cache Indexer objects across stills frames in stills_process.py to avoid repeated PHIL parsing and internal solver setup overhead, and eliminate expensive copy.deepcopy calls on the parameter scope.

--- a/newsfragments/XXXX.misc
+++ b/newsfragments/XXXX.misc
@@ -1,0 +1,1 @@
+Cache Indexer objects across stills frames in stills_process.py to avoid repeated PHIL parsing and internal solver setup overhead, and eliminate expensive copy.deepcopy calls on the parameter scope.

--- a/src/dials/algorithms/indexing/__init__.py
+++ b/src/dials/algorithms/indexing/__init__.py
@@ -1,8 +1,26 @@
 from __future__ import annotations
 
+import functools
+
 import dials_algorithms_indexing_ext as ext
 
 sampling_volume_map = ext.sampling_volume_map
+
+
+@functools.cache
+def rstbx_indexing_api_phil_scope():
+    """Parse the rstbx ``indexing_api_defs`` PHIL defaults once and cache the
+    parsed scope.
+
+    Parsing this string is relatively expensive and was previously repeated
+    every time a StillsIndexer or FFT1D strategy was constructed (i.e. once per
+    still). Callers should ``.extract()`` the returned scope to obtain a fresh,
+    independently mutable object.
+    """
+    import iotbx.phil
+    from rstbx.phil.phil_preferences import indexing_api_defs
+
+    return iotbx.phil.parse(input_string=indexing_api_defs)
 
 
 class DialsIndexError(RuntimeError):

--- a/src/dials/algorithms/indexing/basis_vector_search/fft1d.py
+++ b/src/dials/algorithms/indexing/basis_vector_search/fft1d.py
@@ -55,6 +55,12 @@ class FFT1D(Strategy):
                 reflections, using at most 0.029 radians.
         """
         super().__init__(max_cell, params=params, *args, **kwargs)
+        import iotbx.phil
+        from rstbx.phil.phil_preferences import indexing_api_defs
+
+        self._hardcoded_phil = iotbx.phil.parse(
+            input_string=indexing_api_defs
+        ).extract()
 
     def find_basis_vectors(self, reciprocal_lattice_vectors):
         """Find a list of likely basis vectors.
@@ -67,12 +73,7 @@ class FFT1D(Strategy):
             A tuple containing the list of basis vectors and a flex.bool array
             identifying which reflections were used in indexing.
         """
-        import iotbx.phil
-        from rstbx.phil.phil_preferences import indexing_api_defs
-
         used_in_indexing = flex.bool(reciprocal_lattice_vectors.size(), True)
-
-        hardcoded_phil = iotbx.phil.parse(input_string=indexing_api_defs).extract()
 
         # Spot_positions: Centroid positions for spotfinder spots, in pixels
         # Return value: Corrected for parallax, converted to mm
@@ -88,7 +89,7 @@ class FFT1D(Strategy):
         DPS = DPS_primitive_lattice(
             max_cell=self._max_cell,
             recommended_grid_sampling_rad=self._params.characteristic_grid,
-            horizon_phil=hardcoded_phil,
+            horizon_phil=self._hardcoded_phil,
         )
 
         # transform input into what Nick needs

--- a/src/dials/algorithms/indexing/basis_vector_search/fft1d.py
+++ b/src/dials/algorithms/indexing/basis_vector_search/fft1d.py
@@ -55,12 +55,9 @@ class FFT1D(Strategy):
                 reflections, using at most 0.029 radians.
         """
         super().__init__(max_cell, params=params, *args, **kwargs)
-        import iotbx.phil
-        from rstbx.phil.phil_preferences import indexing_api_defs
+        from dials.algorithms.indexing import rstbx_indexing_api_phil_scope
 
-        self._hardcoded_phil = iotbx.phil.parse(
-            input_string=indexing_api_defs
-        ).extract()
+        self._hardcoded_phil = rstbx_indexing_api_phil_scope().extract()
 
     def find_basis_vectors(self, reciprocal_lattice_vectors):
         """Find a list of likely basis vectors.

--- a/src/dials/algorithms/indexing/stills_indexer.py
+++ b/src/dials/algorithms/indexing/stills_indexer.py
@@ -100,6 +100,20 @@ class StillsIndexer(Indexer):
         super().__init__(reflections, experiments, params)
         self.warn_if_setting_unused_refinement_protocol_params()
 
+        import iotbx.phil
+        from rstbx.indexing_api.outlier_procedure import OutlierPlotPDF
+        from rstbx.phil.phil_preferences import indexing_api_defs
+
+        self.hardcoded_phil = iotbx.phil.parse(input_string=indexing_api_defs).extract()
+        # comment this in if PDF graph is desired:
+        # self.hardcoded_phil.indexing.outlier_detection.pdf = "outlier.pdf"
+        # new code for outlier rejection inline here
+        if self.hardcoded_phil.indexing.outlier_detection.pdf is not None:
+            self.hardcoded_phil.__inject__(
+                "writer",
+                OutlierPlotPDF(self.hardcoded_phil.indexing.outlier_detection.pdf),
+            )
+
     def index(self):
         # most of this is the same as dials.algorithms.indexing.indexer.indexer_base.index(), with some stills
         # specific modifications (don't re-index after choose best orientation matrix, but use the indexing from
@@ -495,7 +509,7 @@ class StillsIndexer(Indexer):
 
         candidates = []
 
-        params = copy.deepcopy(self.all_params)
+        params = self.all_params
 
         for icm, cm in enumerate(candidate_orientation_matrices):
             if icm >= self.params.basis_vector_combinations.max_refine:
@@ -726,34 +740,19 @@ class StillsIndexer(Indexer):
             m.miller_index = item["miller_index"]
             matches.append(m)
 
-        import iotbx.phil
-        from rstbx.phil.phil_preferences import indexing_api_defs
-
-        hardcoded_phil = iotbx.phil.parse(input_string=indexing_api_defs).extract()
-
-        from rstbx.indexing_api.outlier_procedure import OutlierPlotPDF
-
-        # comment this in if PDF graph is desired:
-        # hardcoded_phil.indexing.outlier_detection.pdf = "outlier.pdf"
-        # new code for outlier rejection inline here
-        if hardcoded_phil.indexing.outlier_detection.pdf is not None:
-            hardcoded_phil.__inject__(
-                "writer", OutlierPlotPDF(hardcoded_phil.indexing.outlier_detection.pdf)
-            )
-
         # execute Sauter and Poon (2010) algorithm
         from rstbx.indexing_api import outlier_detection
 
         od = outlier_detection.find_outliers_from_matches(
             matches,
             verbose=self.all_params.refinement.reflections.outlier.sauter_poon.verbose,
-            horizon_phil=hardcoded_phil,
+            horizon_phil=self.hardcoded_phil,
         )
 
-        if hardcoded_phil.indexing.outlier_detection.pdf is not None:
-            od.make_graphs(canvas=hardcoded_phil.writer.R.c, left_margin=0.5)
-            hardcoded_phil.writer.R.c.showPage()
-            hardcoded_phil.writer.R.c.save()
+        if self.hardcoded_phil.indexing.outlier_detection.pdf is not None:
+            od.make_graphs(canvas=self.hardcoded_phil.writer.R.c, left_margin=0.5)
+            self.hardcoded_phil.writer.R.c.showPage()
+            self.hardcoded_phil.writer.R.c.save()
 
         return od.get_cache_status()
 

--- a/src/dials/algorithms/indexing/stills_indexer.py
+++ b/src/dials/algorithms/indexing/stills_indexer.py
@@ -100,11 +100,11 @@ class StillsIndexer(Indexer):
         super().__init__(reflections, experiments, params)
         self.warn_if_setting_unused_refinement_protocol_params()
 
-        import iotbx.phil
         from rstbx.indexing_api.outlier_procedure import OutlierPlotPDF
-        from rstbx.phil.phil_preferences import indexing_api_defs
 
-        self.hardcoded_phil = iotbx.phil.parse(input_string=indexing_api_defs).extract()
+        from dials.algorithms.indexing import rstbx_indexing_api_phil_scope
+
+        self.hardcoded_phil = rstbx_indexing_api_phil_scope().extract()
         # comment this in if PDF graph is desired:
         # self.hardcoded_phil.indexing.outlier_detection.pdf = "outlier.pdf"
         # new code for outlier rejection inline here

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -929,6 +929,15 @@ class Processor:
 
             self.setup_filenames(composite_tag)
 
+        self.idxr_known_crystal_models = None
+        self.idxr = None
+        if self.params.indexing.stills.method_list:
+            self.idxr_method_list = dict.fromkeys(
+                self.params.indexing.stills.method_list
+            )
+        else:
+            self.idxr_method_list = None
+
     def setup_filenames(self, tag):
         # before processing, set output paths according to the templates
         if (
@@ -1193,15 +1202,48 @@ The detector is reporting a gain of {panel.get_gain():f} but you have also suppl
     def index(self, experiments, reflections):
         from dials.algorithms.indexing.indexer import Indexer
 
+        def update_indexer(
+            indexer, experiments, reflections, known_crystal_models=None
+        ):
+            # Mimics the per-frame initialization done by Indexer.from_parameters()
+            # without paying for full object construction on every still.
+            for experiment in experiments:
+                experiment.imageset.set_scan(None)
+                experiment.imageset.set_goniometer(None)
+                experiment.scan = None
+                experiment.goniometer = None
+            indexer.known_orientations = known_crystal_models
+            indexer.experiments = experiments
+            indexer.reflections = reflections
+            if "flags" in reflections:
+                strong_sel = indexer.reflections.get_flags(
+                    indexer.reflections.flags.strong
+                )
+                if strong_sel.count(True) > 0:
+                    indexer.reflections = indexer.reflections.select(strong_sel)
+            if "flags" not in indexer.reflections or strong_sel.count(True) == 0:
+                # backwards compatibility for testing
+                indexer.reflections.set_flags(
+                    flex.size_t_range(len(indexer.reflections)),
+                    indexer.reflections.flags.strong,
+                )
+            indexer.setup_indexing()
+            return indexer
+
         st = time.time()
 
         logger.info("*" * 80)
         logger.info("Indexing Strong Spots")
         logger.info("*" * 80)
 
-        params = copy.deepcopy(self.params)
         # don't do scan-varying refinement during indexing
-        params.refinement.parameterisation.scan_varying = False
+        scan_varying = self.params.refinement.parameterisation.scan_varying
+        self.params.refinement.parameterisation.scan_varying = False
+        # max_refine=5 for stills was previously applied inside Indexer.from_parameters
+        # when the value was libtbx.Auto. Hoisted here so it is visible and restored.
+        # Note: this overrides any user-supplied max_refine value for stills.
+        max_refine = self.params.indexing.basis_vector_combinations.max_refine
+        self.params.indexing.basis_vector_combinations.max_refine = 5
 
         if hasattr(self, "known_crystal_models"):
             known_crystal_models = self.known_crystal_models
@@ -1235,13 +1277,21 @@ The detector is reporting a gain of {panel.get_gain():f} but you have also suppl
         indexing_succeeded = False
         if known_crystal_models:
             try:
-                idxr = Indexer.from_parameters(
-                    reflections,
-                    experiments,
-                    known_crystal_models=known_crystal_models,
-                    params=params,
-                )
-                idxr.index()
+                if self.idxr_known_crystal_models is None:
+                    self.idxr_known_crystal_models = Indexer.from_parameters(
+                        reflections,
+                        experiments,
+                        known_crystal_models=known_crystal_models,
+                        params=self.params,
+                    )
+                else:
+                    self.idxr_known_crystal_models = update_indexer(
+                        self.idxr_known_crystal_models,
+                        experiments,
+                        reflections,
+                        known_crystal_models=known_crystal_models,
+                    )
+                self.idxr_known_crystal_models.index()
                 logger.info("indexed from known orientation")
                 indexing_succeeded = True
             except Exception:
@@ -1269,24 +1319,36 @@ The detector is reporting a gain of {panel.get_gain():f} but you have also suppl
                         flex.random_permutation(len(all_reflections))
                     )[: int(len(all_reflections) * i / 100)]
                 try:
-                    if params.indexing.stills.method_list is None:
-                        idxr = Indexer.from_parameters(
-                            reflections,
-                            experiments,
-                            params=params,
-                        )
-                        idxr.index()
+                    if self.params.indexing.stills.method_list is None:
+                        if self.idxr is None:
+                            self.idxr = Indexer.from_parameters(
+                                reflections,
+                                experiments,
+                                params=self.params,
+                            )
+                        else:
+                            self.idxr = update_indexer(
+                                self.idxr, experiments, reflections
+                            )
+                        self.idxr.index()
                     else:
                         ml_indexing_error = None
-                        for method in params.indexing.stills.method_list:
-                            params.indexing.method = method
-                            try:
-                                idxr = Indexer.from_parameters(
+                        for method in self.params.indexing.stills.method_list:
+                            self.params.indexing.method = method
+                            if self.idxr_method_list[method] is None:
+                                self.idxr_method_list[method] = Indexer.from_parameters(
                                     reflections,
                                     experiments,
-                                    params=params,
+                                    params=self.params,
                                 )
-                                idxr.index()
+                            else:
+                                self.idxr_method_list[method] = update_indexer(
+                                    self.idxr_method_list[method],
+                                    experiments,
+                                    reflections,
+                                )
+                            try:
+                                self.idxr_method_list[method].index()
                             except Exception as e_ml:
                                 logger.info("Couldn't index using method %s", method)
                                 ml_indexing_error = e_ml
@@ -1304,8 +1366,16 @@ The detector is reporting a gain of {panel.get_gain():f} but you have also suppl
             if subset_indexing_error:
                 raise subset_indexing_error
 
-        indexed = idxr.refined_reflections
-        experiments = idxr.refined_experiments
+        if known_crystal_models and indexing_succeeded:
+            indexed = self.idxr_known_crystal_models.refined_reflections
+            experiments = self.idxr_known_crystal_models.refined_experiments
+        elif self.params.indexing.stills.method_list is None:
+            indexed = self.idxr.refined_reflections
+            experiments = self.idxr.refined_experiments
+        else:
+            # "method" is retained from the subsampling for loop.
+            indexed = self.idxr_method_list[method].refined_reflections
+            experiments = self.idxr_method_list[method].refined_experiments
 
         if known_crystal_models is not None:
             filtered_sel = flex.bool(len(indexed), True)
@@ -1330,6 +1400,9 @@ The detector is reporting a gain of {panel.get_gain():f} but you have also suppl
 
         logger.info("")
         logger.info("Time Taken = %f seconds", time.time() - st)
+        # Restore params fields mutated for stills indexing.
+        self.params.refinement.parameterisation.scan_varying = scan_varying
+        self.params.indexing.basis_vector_combinations.max_refine = max_refine
         return experiments, indexed
 
     def refine(self, experiments, centroids):


### PR DESCRIPTION
Processor.index() was called once per still. Each call constructed a fresh Indexer via Indexer.from_parameters(), which involves PHIL scope extraction, reflection-table setup, and internal solver setup. For large MPI jobs (tens of stills per rank) this overhead dominates.

Indexer caching:
- update_indexer() (nested function inside index()) re-populates experiments/reflections and calls setup_indexing() without the full construction cost of Indexer.from_parameters().
- self.idxr, self.idxr_known_crystal_models, self.idxr_method_list cache one Indexer per code path; each is lazily created on the first still and updated on subsequent ones.

Params mutation refactor:
- The prior code called copy.deepcopy(self.params) once per still to isolate the scan_varying=False override applied during indexing. deepcopy of a large PHIL scope is expensive; replaced with explicit save/restore of scan_varying and max_refine (the only two fields modified). The max_refine=5 override for stills was previously applied inside Indexer.from_parameters (when the value was libtbx.Auto); it is now hoisted to the call site and explicitly restored. Note: this unconditionally sets max_refine=5 for stills regardless of any user-supplied value.

PHIL caching (stills_indexer, fft1d):
- StillsIndexer and FFT1D each called iotbx.phil.parse(indexing_api_defs) on every still. The result is constant for a given indexer instance. Moved to __init__ and stored as self.hardcoded_phil.
- StillsIndexer.index_reflections(): remove copy.deepcopy(all_params); the copy was used only to read immutable fields.