### PR TITLE
Vectorize RealSpaceGridSearch.score_vectors() and candidate_orientati…

### DIFF
--- a/newsfragments/3159.misc
+++ b/newsfragments/3159.misc
@@ -1,0 +1,1 @@
+Vectorize real-space grid search scoring and candidate orientation matrix filtering using numpy to reduce per-still indexing overhead. Also fixes an incorrect radians/degrees comparison in one candidate orientation filter.

--- a/newsfragments/XXXX.bugfix
+++ b/newsfragments/XXXX.bugfix
@@ -1,0 +1,1 @@
+Vectorize real-space grid search scoring and candidate orientation matrix filtering using numpy to reduce per-still indexing overhead. Also fixes an incorrect radians/degrees comparison in one candidate orientation filter.

--- a/newsfragments/XXXX.bugfix
+++ b/newsfragments/XXXX.bugfix
@@ -1,1 +1,0 @@
-Vectorize real-space grid search scoring and candidate orientation matrix filtering using numpy to reduce per-still indexing overhead. Also fixes an incorrect radians/degrees comparison in one candidate orientation filter.

--- a/src/dials/algorithms/indexing/basis_vector_search/combinations.py
+++ b/src/dials/algorithms/indexing/basis_vector_search/combinations.py
@@ -5,6 +5,7 @@ import math
 from itertools import combinations as iter_combinations
 
 import numpy as np
+
 from cctbx.sgtbx.bravais_types import bravais_lattice
 from cctbx.uctbx.reduction_base import iteration_limit_exceeded
 from dxtbx.model import Crystal

--- a/src/dials/algorithms/indexing/basis_vector_search/combinations.py
+++ b/src/dials/algorithms/indexing/basis_vector_search/combinations.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import logging
 import math
+from itertools import combinations as iter_combinations
 
+import numpy as np
 from cctbx.sgtbx.bravais_types import bravais_lattice
 from cctbx.uctbx.reduction_base import iteration_limit_exceeded
 from dxtbx.model import Crystal
-from scitbx.array_family import flex
+from scitbx import matrix as scitbx_matrix
 
 from dials.algorithms.indexing import DialsIndexError
 from dials.algorithms.indexing.compare_orientation_matrices import (
@@ -27,46 +29,76 @@ def candidate_orientation_matrices(basis_vectors, max_combinations=None):
     # https://github.com/dials/dials/issues/72
     n = min(n, 100)
     basis_vectors = basis_vectors[:n]
-    combinations = flex.vec3_int(flex.nested_loop((n, n, n)))
-    combinations = combinations.select(
-        flex.sort_permutation(combinations.as_vec3_double().norms())
-    )
 
-    # select only those combinations where j > i and k > j
-    i, j, k = combinations.as_vec3_double().parts()
-    sel = flex.bool(len(combinations), True)
-    sel &= j > i
-    sel &= k > j
-    combinations = combinations.select(sel)
+    # Build sorted (i<j<k) index array. itertools.combinations already enforces
+    # i<j<k, replacing the flex filter. Sort by squared index-norm to match the
+    # original ordering (smallest-indexed vectors — best candidates — first).
+    idxs = np.array(list(iter_combinations(range(n), 3)), dtype=np.int32)
+    norms_sq = (idxs**2).sum(axis=1)
+    idxs = idxs[np.argsort(norms_sq, kind="stable")]
 
-    if max_combinations is not None and max_combinations < len(combinations):
-        combinations = combinations[:max_combinations]
+    if max_combinations is not None and max_combinations < len(idxs):
+        idxs = idxs[:max_combinations]
 
     half_pi = 0.5 * math.pi
     min_angle = 20 / 180 * math.pi  # 20 degrees, arbitrary cutoff
-    for i, j, k in combinations:
-        a = basis_vectors[i]
-        b = basis_vectors[j]
-        angle = a.angle(b)
-        if angle < min_angle or (math.pi - angle) < min_angle:
-            continue
-        a_cross_b = a.cross(b)
-        gamma = a.angle(b)
-        if gamma < half_pi:
-            # all angles obtuse if possible please
-            b = -b
-            a_cross_b = -a_cross_b
-        c = basis_vectors[k]
-        if abs(half_pi - a_cross_b.angle(c)) < min_angle:
-            continue
-        alpha = b.angle(c, deg=True)
-        if alpha < half_pi:
-            c = -c
-        if a_cross_b.dot(c) < 0:
-            # we want right-handed basis set, therefore invert all vectors
-            a = -a
-            b = -b
-            c = -c
+
+    # Convert basis vectors to a (n, 3) numpy array.
+    bv = np.array([v.elems for v in basis_vectors])
+
+    # Extract all (a, b, c) vector triplets.
+    a_arr = bv[idxs[:, 0]]  # (N, 3)
+    b_arr = bv[idxs[:, 1]]  # (N, 3)
+    c_arr = bv[idxs[:, 2]]  # (N, 3)
+
+    # Precompute squared norms for all vectors in each triplet.
+    a_ns = np.einsum("ij,ij->i", a_arr, a_arr)
+    b_ns = np.einsum("ij,ij->i", b_arr, b_arr)
+    c_ns = np.einsum("ij,ij->i", c_arr, c_arr)
+
+    # Filter 1: angle(a, b) not too close to 0° or 180°.
+    ab_dot = np.einsum("ij,ij->i", a_arr, b_arr)
+    angle_ab = np.arccos(np.clip(ab_dot / np.sqrt(a_ns * b_ns), -1.0, 1.0))
+    m1 = (angle_ab >= min_angle) & ((np.pi - angle_ab) >= min_angle)
+    a_arr, b_arr, c_arr = a_arr[m1], b_arr[m1], c_arr[m1]
+    b_ns, c_ns, angle_ab = b_ns[m1], c_ns[m1], angle_ab[m1]
+
+    # Flip b (and implicitly a×b) where angle_ab < half_pi so all angles obtuse.
+    flip_b = (angle_ab < half_pi)[:, None]
+    b_arr = np.where(flip_b, -b_arr, b_arr)
+
+    # Compute a × b after the b flip.
+    a_cross_b = np.cross(a_arr, b_arr)  # (M1, 3)
+    acb_ns = np.einsum("ij,ij->i", a_cross_b, a_cross_b)
+
+    # Filter 2: angle(a×b, c) not too close to 90° (would give degenerate cell).
+    acb_c_dot = np.einsum("ij,ij->i", a_cross_b, c_arr)
+    angle_acb_c = np.arccos(np.clip(acb_c_dot / np.sqrt(acb_ns * c_ns), -1.0, 1.0))
+    m2 = np.abs(half_pi - angle_acb_c) >= min_angle
+    a_arr, b_arr, c_arr = a_arr[m2], b_arr[m2], c_arr[m2]
+    a_cross_b, b_ns, c_ns = a_cross_b[m2], b_ns[m2], c_ns[m2]
+
+    # Flip c where angle(b, c) < half_pi so all angles obtuse.
+    # alpha is in radians — consistent with half_pi (fixes a deg=True bug in the
+    # original code where alpha was computed in degrees but compared to half_pi).
+    bc_dot = np.einsum("ij,ij->i", b_arr, c_arr)
+    alpha = np.arccos(np.clip(bc_dot / np.sqrt(b_ns * c_ns), -1.0, 1.0))
+    flip_c = (alpha < half_pi)[:, None]
+    c_arr = np.where(flip_c, -c_arr, c_arr)
+
+    # Ensure right-handed basis: invert all vectors if a×b · c < 0.
+    acb_dot_c = np.einsum("ij,ij->i", a_cross_b, c_arr)
+    flip_all = (acb_dot_c < 0)[:, None]
+    a_arr = np.where(flip_all, -a_arr, a_arr)
+    b_arr = np.where(flip_all, -b_arr, b_arr)
+    c_arr = np.where(flip_all, -c_arr, c_arr)
+
+    # Crystal creation and Niggli reduction are C++ and cannot be batched.
+    # The loop runs only over the fraction of combinations that passed the filters.
+    for a_row, b_row, c_row in zip(a_arr, b_arr, c_arr):
+        a = scitbx_matrix.col(a_row.tolist())
+        b = scitbx_matrix.col(b_row.tolist())
+        c = scitbx_matrix.col(c_row.tolist())
         model = Crystal(a, b, c, space_group_symbol="P 1")
         uc = model.get_unit_cell()
         try:

--- a/src/dials/algorithms/indexing/basis_vector_search/combinations.py
+++ b/src/dials/algorithms/indexing/basis_vector_search/combinations.py
@@ -26,6 +26,8 @@ def candidate_orientation_matrices(basis_vectors, max_combinations=None):
     # nearer the beginning of the input list will appear before combinations
     # comprising vectors towards the end of the list
     n = len(basis_vectors)
+    if n < 3:
+        return []
     # hardcoded limit on number of vectors, fixes issue #72
     # https://github.com/dials/dials/issues/72
     n = min(n, 100)

--- a/src/dials/algorithms/indexing/basis_vector_search/real_space_grid_search.py
+++ b/src/dials/algorithms/indexing/basis_vector_search/real_space_grid_search.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 import math
 
+import numpy as np
+
 from libtbx import phil
 from rstbx.array_family import (
     flex,  # required to load scitbx::af::shared<rstbx::Direction> to_python converter
@@ -72,6 +74,16 @@ class RealSpaceGridSearch(Strategy):
                 "Target unit cell must be provided for real_space_grid_search"
             )
         self._target_unit_cell = target_unit_cell
+        # Precompute search vector array and flex object once — both are constant for
+        # this instance (depend only on target_unit_cell and characteristic_grid).
+        SST = SimpleSamplerTool(self._params.characteristic_grid)
+        SST.construct_hemisphere_grid(SST.incr)
+        directions = np.array(
+            [d.dvec for d in SST.angles], dtype=np.float64
+        )  # (N_dir, 3)
+        unique_dims = sorted(set(target_unit_cell.parameters()[:3]))
+        self._sv_array = np.vstack([directions * l for l in unique_dims])  # (N_sv, 3)
+        self._sv_flex = flex.vec3_double(list(map(tuple, self._sv_array)))
 
     @property
     def search_directions(self):
@@ -117,13 +129,11 @@ class RealSpaceGridSearch(Strategy):
         Returns:
             A tuple containing the list of search vectors and their scores.
         """
-        vectors = flex.vec3_double()
-        scores = flex.double()
-        for i, v in enumerate(self.search_vectors):
-            f = self.compute_functional(v.elems, reciprocal_lattice_vectors)
-            vectors.append(v.elems)
-            scores.append(f)
-        return vectors, scores
+        rlv_array = np.array(reciprocal_lattice_vectors, dtype=np.float64)  # (N_rlv, 3)
+        dots = 2 * math.pi * (self._sv_array @ rlv_array.T)  # (N_sv, N_rlv)
+        scores_np = np.cos(dots).sum(axis=1)  # (N_sv,)
+        scores = flex.double(scores_np.tolist())
+        return self._sv_flex, scores
 
     def find_basis_vectors(self, reciprocal_lattice_vectors):
         """Find a list of likely basis vectors.


### PR DESCRIPTION
…on_matrices()

RealSpaceGridSearch.score_vectors():
- The prior implementation looped over every search vector calling compute_functional() one at a time (O(N_sv) Python calls per still).
- New: precompute the (N_sv, 3) search vector array once in __init__ (constant for a given target cell). score_vectors() becomes a single matrix multiply: scores = cos(2pi * sv_array @ rlv.T).sum(axis=1).
- The companion flex.vec3_double of the same vectors is also precomputed once and returned directly, avoiding per-call conversion.
- Import switches from scitbx.array_family.flex to scitbx.matrix for constructing the per-triplet col() vectors passed to Crystal(); flex is still used indirectly via the return value.

candidate_orientation_matrices():
- The prior code built an n^3 flex.vec3_int of all (i, j, k) index triples, sorted by vector norm, then applied three sequential Python filters.
- New: itertools.combinations generates i<j<k triplets directly, avoiding the n^3 allocation. Triplets are sorted by squared index-norm (np.argsort(norms_sq, kind="stable")) to preserve the original ordering -- important because downstream code breaks after max_refine candidates. All three filter passes (angle(a,b), angle(a x b, c), right-handedness) are applied as numpy boolean masks over the full candidate batch before entering the C++ Crystal/Niggli-reduction loop, which runs only over the fraction that passes all filters.
- Bug fix: the original code computed alpha = b.angle(c, deg=True) but then compared it to half_pi (radians), causing some valid candidates to be flipped incorrectly. The numpy path uses radians throughout.