### PR TITLE
Simplify groups_cache() and avoid space_group_type construction

### DIFF
--- a/newsfragments/3160.misc
+++ b/newsfragments/3160.misc
@@ -1,0 +1,1 @@
+Simplify the symmetry groups cache to key directly on the space_group object, avoiding redundant space_group_type construction on each lookup.

--- a/newsfragments/XXXX.misc
+++ b/newsfragments/XXXX.misc
@@ -1,1 +1,0 @@
-Simplify the symmetry groups cache to key directly on the space_group object, avoiding redundant space_group_type construction on each lookup.

--- a/newsfragments/XXXX.misc
+++ b/newsfragments/XXXX.misc
@@ -1,0 +1,1 @@
+Simplify the symmetry groups cache to key directly on the space_group object, avoiding redundant space_group_type construction on each lookup.

--- a/src/dials/algorithms/indexing/symmetry.py
+++ b/src/dials/algorithms/indexing/symmetry.py
@@ -24,25 +24,17 @@ def metric_supergroup(group):
 
 
 def groups_cache(fn):
-    class MultiClassCache:
-        "A set of caches for different bravais types"
-
-        instances = {}
-
-        def __new__(cls, classname):
-            if classname not in cls.instances:
-                cls.instances[classname] = {}
-            return cls.instances[classname]
+    _cache = {}
 
     def wrapped_calc(group_info: sgtbx.space_group_info, bravais_t: str):
-        cache = MultiClassCache(bravais_t)
-        info_str = group_info.type().lookup_symbol()
+        group = group_info.group()
+        key = (bravais_t, group)
         try:
-            result = cache[info_str]
+            return _cache[key]
         except KeyError:
             result = fn(group_info, bravais_t)
-            cache[info_str] = result
-        return result
+            _cache[key] = result
+            return result
 
     return wrapped_calc
 


### PR DESCRIPTION
The old implementation keyed the cache on
  group_info.type().lookup_symbol()
which constructs a space_group_type object on every lookup just to get a string key. The new implementation keys on
  (bravais_t, group_info.group())
where group_info.group() returns an sgtbx.space_group, which is hashable via its C++ operator==. The nested MultiClassCache descriptor is replaced by a single flat dict closed over in the decorator, removing a layer of indirection.