### PR TITLE
Add psana timestamps to the experiment identifiers

### DIFF
--- a/newsfragments/3165.feature
+++ b/newsfragments/3165.feature
@@ -1,0 +1,1 @@
+Add support for custom sorting of LCLS data in dials.stills_process

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -17,14 +17,13 @@ from dxtbx.model.experiment_list import (
     ExperimentList,
     ExperimentListFactory,
 )
+from dxtbx.util import ersatz_uuid4
 from libtbx.phil import parse
 from libtbx.utils import Abort, Sorry
 
 import dials.util
 from dials.array_family import flex
 from dials.util import log
-
-from dxtbx.util import ersatz_uuid4
 
 logger = logging.getLogger("dials.command_line.stills_process")
 
@@ -1046,14 +1045,14 @@ class Processor:
         self.debug_start(tag)
 
         for experiment in experiments:
-           if experiment.identifier == "":
-               experiment.identifier = ersatz_uuid4()
-               fmt = experiment.imageset.get_format_class().get_instance(
-                   experiment.imageset.paths()[0]
-               )
-               if self.params.output.psana_identifiers:
-                   ts = fmt.get_psana_timestamp(experiment.imageset.indices()[0])
-                   experiment.identifier = ts + "_" + experiment.identifier
+            if experiment.identifier == "":
+                experiment.identifier = ersatz_uuid4()
+            if self.params.output.psana_identifiers:
+                fmt = experiment.imageset.get_format_class().get_instance(
+                    experiment.imageset.paths()[0]
+                )
+                ts = fmt.get_psana_timestamp(experiment.imageset.indices()[0])
+                experiment.identifier = ts + "_" + experiment.identifier
 
         if self.params.output.experiments_filename:
             if self.params.output.composite_output:

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -165,7 +165,8 @@ def _control_phil_str():
     psana_identifiers = False
       .type = bool
       .expert_level = 3
-      .help = Add psana timestamps to the experiment identifiers
+      .help = Add psana timestamps to the experiment identifiers. This allows \
+              sorting of LCLS XFEL data for certain experiments.
   }
 
   mp {

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -24,6 +24,8 @@ import dials.util
 from dials.array_family import flex
 from dials.util import log
 
+from dxtbx.util import ersatz_uuid4
+
 logger = logging.getLogger("dials.command_line.stills_process")
 
 help_message = """
@@ -1042,6 +1044,16 @@ class Processor:
             self.setup_filenames(tag)
         self.tag = tag
         self.debug_start(tag)
+
+        for experiment in experiments:
+           if experiment.identifier == "":
+               experiment.identifier = ersatz_uuid4()
+               fmt = experiment.imageset.get_format_class().get_instance(
+                   experiment.imageset.paths()[0]
+               )
+               if self.params.output.psana_identifiers:
+                   ts = fmt.get_psana_timestamp(experiment.imageset.indices()[0])
+                   experiment.identifier = ts + "_" + experiment.identifier
 
         if self.params.output.experiments_filename:
             if self.params.output.composite_output:

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -161,6 +161,10 @@ def _control_phil_str():
       .type = str
       .expert_level = 3
       .help = Filename for legacy cxi.merge integration pickle files. Example: int-%d-%s.pickle
+    psana_identifiers = False
+      .type = bool
+      .expert_level = 3
+      .help = Add psana timestamps to the experiment identifiers
   }
 
   mp {
@@ -1334,6 +1338,16 @@ The detector is reporting a gain of {panel.get_gain():f} but you have also suppl
                 % (len(filtered), len(indexed))
             )
             indexed = filtered
+
+        if self.params.output.psana_identifiers:
+            identifiers = indexed.experiment_identifiers()
+            for expt_id, expt in enumerate(experiments):
+                fmt = expt.imageset.get_format_class().get_instance(
+                    expt.imageset.paths()[0]
+                )
+                ts = fmt.get_psana_timestamp(expt.imageset.indices()[0])
+                expt.identifier = ts + "_" + expt.identifier
+                identifiers[expt_id] = expt.identifier
 
         logger.info("")
         logger.info("Time Taken = %f seconds", time.time() - st)


### PR DESCRIPTION
This allows downstream sorting when many samples are collected at once.  The sample number is encoded in the psana timestamp produced by FormatXTC and that is added to the experiment identifier here.