### PR TITLE
use twin laws for lattice angle calculation

### DIFF
--- a/src/dials/algorithms/indexing/basis_vector_search/combinations.py
+++ b/src/dials/algorithms/indexing/basis_vector_search/combinations.py
@@ -198,7 +198,8 @@ def filter_similar_orientations(
         cell = gemmi.UnitCell(*cryst.get_unit_cell().parameters())
         sg = gemmi.SpaceGroup(cryst.get_space_group().type().lookup_symbol())
         gemmi_ops = gemmi.find_twin_laws(cell, sg, max_obliq=max_obliq, all_ops=True)
-        sgtbx_ops = [rt_mx(op.triplet()) for op in gemmi_ops]
+        sgtbx_ops = [rt_mx("x,y,z")]
+        sgtbx_ops.extend([rt_mx(op.triplet()) for op in gemmi_ops])
 
         for cryst_a in other_crystal_models:
             R_ab, axis, angle, cb_op_ab = difference_rotation_matrix_axis_angle(

--- a/src/dials/algorithms/indexing/basis_vector_search/combinations.py
+++ b/src/dials/algorithms/indexing/basis_vector_search/combinations.py
@@ -4,8 +4,10 @@ import logging
 import math
 from itertools import combinations as iter_combinations
 
+import gemmi
 import numpy as np
 
+from cctbx.sgtbx import rt_mx
 from cctbx.sgtbx.bravais_types import bravais_lattice
 from cctbx.uctbx.reduction_base import iteration_limit_exceeded
 from dxtbx.model import Crystal
@@ -188,13 +190,19 @@ def filter_known_symmetry(
 
 
 def filter_similar_orientations(
-    crystal_models, other_crystal_models, minimum_angular_separation=5
+    crystal_models, other_crystal_models, minimum_angular_separation=5, max_obliq=3.0
 ):
     for cryst in crystal_models:
         orientation_too_similar = False
+
+        cell = gemmi.UnitCell(*cryst.get_unit_cell().parameters())
+        sg = gemmi.SpaceGroup(cryst.get_space_group().type().lookup_symbol())
+        gemmi_ops = gemmi.find_twin_laws(cell, sg, max_obliq=max_obliq, all_ops=True)
+        sgtbx_ops = [rt_mx(op.triplet()) for op in gemmi_ops]
+
         for cryst_a in other_crystal_models:
             R_ab, axis, angle, cb_op_ab = difference_rotation_matrix_axis_angle(
-                cryst_a, cryst
+                cryst_a, cryst, ops=sgtbx_ops
             )
             if abs(angle) < minimum_angular_separation:  # degrees
                 orientation_too_similar = True

--- a/src/dials/algorithms/indexing/compare_orientation_matrices.py
+++ b/src/dials/algorithms/indexing/compare_orientation_matrices.py
@@ -6,7 +6,9 @@ from scitbx import matrix
 from scitbx.math import r3_rotation_axis_and_angle_from_matrix
 
 
-def difference_rotation_matrix_axis_angle(crystal_a, crystal_b, target_angle=0):
+def difference_rotation_matrix_axis_angle(
+    crystal_a, crystal_b, target_angle=0, ops=None
+):
     from cctbx import sgtbx
 
     # assert crystal_a.get_space_group() == crystal_b.get_space_group()
@@ -16,7 +18,10 @@ def difference_rotation_matrix_axis_angle(crystal_a, crystal_b, target_angle=0):
     best_axis = None
     best_angle = 1e8
     # iterate over space group ops to find smallest differences
-    for i_op, op in enumerate(space_group.build_derived_laue_group().all_ops()):
+    if ops is None:
+        ops = space_group.build_derived_laue_group().all_ops()
+
+    for i_op, op in enumerate(ops):
         if op.r().determinant() < 0:
             continue
         elif not op.t().is_zero():


### PR DESCRIPTION
Attempt to resolve #3110 . Use the twin laws from the lattice and space group rather than the operators from the laue group to calculate the minimum angle between lattices. This accounts for indexing ambiguity, psuedo-merohedral twinning, and cases where the spacegroup is unknown during indexing and set to P1. 

@graeme-winter -- can you check to see whether this helps on your test data set from #3110?