### PR TITLE
Make sync_geometry hierarchy-topology-safe.

### DIFF
--- a/newsfragments/3195.misc
+++ b/newsfragments/3195.misc
@@ -1,0 +1,1 @@
+Raise in sync_geometry if the reference geometry has a different hierarchy than the source.

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -388,39 +388,31 @@ def do_import(filename, load_models=True):
     return all_experiments
 
 
-def _collect_leaf_panels(node):
-    """Depth-first list of leaf panel nodes under (and including) `node`."""
-    if node.is_panel():
-        return [node]
-    panels = []
-    for child in node:
-        panels.extend(_collect_leaf_panels(child))
-    return panels
-
-
 def sync_geometry(src, dest):
-    """Transfer refined geometry from `src` onto `dest`, hierarchy-topology-safe.
+    """Copy the refined local geometry from `src` onto `dest` node-by-node.
 
-    Copies each leaf panel's *global* frame (set_frame, which recomputes the local
-    frame against whatever parent the dest panel has) in depth-first leaf order, so
-    `src` and `dest` need NOT share tree depth or grouping -- only the same number of
-    leaf panels in the same order. This avoids the silent mis-pairing a structural
-    (local-frame, zip-by-child) copy produces when the two topologies differ.
+    This faithfully reproduces the `src` hierarchy (including intermediate group
+    nodes and leaf-panel local frames) onto `dest`, which requires the two trees
+    to have the same shape. A `ValueError` is raised if the shapes differ, rather
+    than silently mis-pairing nodes (which the previous `zip`-by-child copy did).
     """
-    src_panels = _collect_leaf_panels(src)
-    dest_panels = _collect_leaf_panels(dest)
-    if len(src_panels) != len(dest_panels):
+    if src.is_panel() != dest.is_panel():
         raise ValueError(
-            "sync_geometry: reference detector has %d leaf panels but target has %d; "
-            "cannot transfer geometry between detectors with different panel counts."
-            % (len(src_panels), len(dest_panels))
+            "sync_geometry: reference and target detector hierarchies have "
+            "different shapes (panel/group mismatch); cannot transfer geometry."
         )
-    for src_panel, dest_panel in zip(src_panels, dest_panels):
-        dest_panel.set_frame(
-            src_panel.get_fast_axis(),
-            src_panel.get_slow_axis(),
-            src_panel.get_origin(),
+    if not src.is_panel() and len(src) != len(dest):
+        raise ValueError(
+            "sync_geometry: reference node has %d children but target has %d; "
+            "the detector hierarchies have different shapes and geometry cannot "
+            "be transferred." % (len(src), len(dest))
         )
+    dest.set_local_frame(
+        src.get_local_fast_axis(), src.get_local_slow_axis(), src.get_local_origin()
+    )
+    if not src.is_panel():
+        for src_child, dest_child in zip(src, dest):
+            sync_geometry(src_child, dest_child)
 
 
 class Script:

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -388,13 +388,39 @@ def do_import(filename, load_models=True):
     return all_experiments
 
 
+def _collect_leaf_panels(node):
+    """Depth-first list of leaf panel nodes under (and including) `node`."""
+    if node.is_panel():
+        return [node]
+    panels = []
+    for child in node:
+        panels.extend(_collect_leaf_panels(child))
+    return panels
+
+
 def sync_geometry(src, dest):
-    dest.set_local_frame(
-        src.get_local_fast_axis(), src.get_local_slow_axis(), src.get_local_origin()
-    )
-    if not src.is_panel():
-        for src_child, dest_child in zip(src, dest):
-            sync_geometry(src_child, dest_child)
+    """Transfer refined geometry from `src` onto `dest`, hierarchy-topology-safe.
+
+    Copies each leaf panel's *global* frame (set_frame, which recomputes the local
+    frame against whatever parent the dest panel has) in depth-first leaf order, so
+    `src` and `dest` need NOT share tree depth or grouping -- only the same number of
+    leaf panels in the same order. This avoids the silent mis-pairing a structural
+    (local-frame, zip-by-child) copy produces when the two topologies differ.
+    """
+    src_panels = _collect_leaf_panels(src)
+    dest_panels = _collect_leaf_panels(dest)
+    if len(src_panels) != len(dest_panels):
+        raise ValueError(
+            "sync_geometry: reference detector has %d leaf panels but target has %d; "
+            "cannot transfer geometry between detectors with different panel counts."
+            % (len(src_panels), len(dest_panels))
+        )
+    for src_panel, dest_panel in zip(src_panels, dest_panels):
+        dest_panel.set_frame(
+            src_panel.get_fast_axis(),
+            src_panel.get_slow_axis(),
+            src_panel.get_origin(),
+        )
 
 
 class Script:


### PR DESCRIPTION
I had an issue where I was constructing a detector with a different hierarchy than the applied reference geometry. sync_geometry failed silently and wasted several hours of beamtime. This hardening is meant to safe guard against this in the future.

Replace the local-frame, zip-by-child copy (which silently mis-pairs nodes when src/dest tree depths differ) with a positional leaf-panel global-frame transfer via set_frame, plus a ValueError guard on panel-count mismatch.