### PR TITLE
Break tied peak_coordinates selection toward the shoebox centroid

### DIFF
--- a/newsfragments/3014.bugfix
+++ b/newsfragments/3014.bugfix
@@ -1,0 +1,1 @@
+``Shoebox.peak_coordinates``: when several pixels share the maximum value, break the tie by selecting the pixel nearest the shoebox centroid rather than the first one in z, y, x order. This stops well-placed reflections being rejected by the peak-centroid distance filter.

--- a/src/dials/array_family/boost_python/flex_shoebox.cc
+++ b/src/dials/array_family/boost_python/flex_shoebox.cc
@@ -473,15 +473,99 @@ namespace dials { namespace af { namespace boost_python {
   }
 
   /**
+   * Break a tie between equally-bright pixels by choosing the one nearest the
+   * shoebox centroid, rather than relying on pixel ordering (see
+   * https://github.com/dials/dials/issues/3014). Falls back to first_max (the
+   * first pixel at the maximum, in z, y, x order) when the centroid is
+   * degenerate / non-finite, e.g. for an all-zero shoebox.
+   */
+  template <typename FloatType>
+  std::size_t peak_index_nearest_centroid(
+    const Shoebox<FloatType>& shoebox,
+    const af::const_ref<FloatType, af::c_grid<3> >& data,
+    FloatType max_value,
+    std::size_t first_max) {
+    // Intensity-weighted centroid of the shoebox, in global pixel coordinates.
+    vec3<double> c = shoebox.centroid_all().px.position;
+    if (!std::isfinite(c[0]) || !std::isfinite(c[1]) || !std::isfinite(c[2])) {
+      return first_max;
+    }
+
+    af::c_grid<3> accessor = data.accessor();
+    std::size_t chosen = first_max;
+    double best = -1.0;  // negative sentinel: no candidate measured yet
+
+    // No tied pixel can precede the first maximum, so start the scan there.
+    for (std::size_t j = first_max; j < data.size(); ++j) {
+      // Only the pixels tied at the maximum value are candidates.
+      if (data[j] != max_value) {
+        continue;
+      }
+
+      // Pixel centre in global (x, y, z); the accessor is z, y, x ordered,
+      // hence cd[2]/cd[1]/cd[0] map to x/y/z.
+      tiny<std::size_t, 3> cd = accessor.index_nd(j);
+      vec3<double> p((double)shoebox.bbox[0] + cd[2] + 0.5,
+                     (double)shoebox.bbox[2] + cd[1] + 0.5,
+                     (double)shoebox.bbox[4] + cd[0] + 0.5);
+
+      // Squared distance to the centroid (squared avoids a per-pixel sqrt).
+      double d2 = (p - c).length_sq();
+
+      // Keep the closest candidate; the strict comparison means an equal
+      // distance does not displace an earlier pixel, so ties stay deterministic.
+      if (best >= 0.0 && d2 >= best) {
+        continue;
+      }
+      best = d2;
+      chosen = j;
+    }
+    return chosen;
+  }
+
+  /**
    * Get the maximum index of each shoebox
    */
   template <typename FloatType>
   shared<vec3<double> > peak_coordinates(ref<Shoebox<FloatType> > a) {
     shared<vec3<double> > result(a.size(), af::init_functor_null<vec3<double> >());
     for (std::size_t i = 0; i < a.size(); ++i) {
-      std::size_t index = af::max_index(a[i].data.const_ref());
-      af::c_grid<3> accessor = a[i].data.accessor();
-      tiny<std::size_t, 3> coord = accessor.index_nd(index);
+      af::const_ref<FloatType, af::c_grid<3> > data = a[i].data.const_ref();
+      // The loop below seeds from data[0], so requires a non-empty
+      // array. This restores the empty-array guard that af::max_index
+      // enforced internally throwing on size 0
+      DIALS_ASSERT(data.size() > 0);
+
+      // Single pass to find the maximum value, the first index
+      // attaining it (preserving the historic z, y, x ordering for the
+      // common, untied case) and how many pixels share that maximum
+      // value. This is the same scan af::max_index performed (update
+      // only on a strictly greater value, so the first maximum is
+      // kept), with the sole addition of counting ties in n_max so we
+      // know whether the centroid tie-break below is needed.
+      FloatType max_value = data[0];
+      std::size_t max_index = 0;
+      std::size_t n_max = 1;
+      for (std::size_t j = 1; j < data.size(); ++j) {
+        if (data[j] > max_value) {
+          max_value = data[j];
+          max_index = j;
+          n_max = 1;
+        } else if (data[j] == max_value) {
+          ++n_max;
+        }
+      }
+
+      af::c_grid<3> accessor = data.accessor();
+
+      // The centroid tie-break is only computed in the rare tied case, keeping
+      // the common single-peak path cheap.
+      std::size_t chosen = max_index;
+      if (n_max > 1) {
+        chosen = peak_index_nearest_centroid(a[i], data, max_value, max_index);
+      }
+
+      tiny<std::size_t, 3> coord = accessor.index_nd(chosen);
       result[i][0] = (FloatType)a[i].bbox[0] + (FloatType)coord[2] + 0.5;
       result[i][1] = (FloatType)a[i].bbox[2] + (FloatType)coord[1] + 0.5;
       result[i][2] = (FloatType)a[i].bbox[4] + (FloatType)coord[0] + 0.5;

--- a/tests/array_family/test_flex_shoebox.py
+++ b/tests/array_family/test_flex_shoebox.py
@@ -122,6 +122,53 @@ def test_count_mask_values():
     assert shoebox.count_mask_values(value) == num
 
 
+def test_peak_coordinates_unique_maximum():
+    from dials.array_family import flex
+    from dials.model.data import Shoebox
+
+    # A shoebox with a single, unique brightest pixel: the peak must be that
+    # pixel's global coordinate (bbox origin + index + 0.5). This covers the
+    # cheap, untied path which must behave exactly as before.
+    bbox = (10, 14, 20, 24, 30, 34)
+    shoebox = flex.shoebox(1)
+    shoebox[0] = Shoebox(bbox)
+    shoebox[0].allocate_data()
+    data = shoebox[0].data  # shape (z, y, x)
+    data[1, 2, 3] = 100
+
+    peak = shoebox.peak_coordinates()
+    assert peak[0] == (10 + 3 + 0.5, 20 + 2 + 0.5, 30 + 1 + 0.5)
+
+
+def test_peak_coordinates_ties_resolved_by_centroid():
+    from dials.array_family import flex
+    from dials.model.data import Shoebox
+
+    # Two pixels share the maximum value. Place the intensity mass (and hence the
+    # centroid) near one of them; the tie must be broken in favour of the pixel
+    # nearest the centroid rather than the z, y, x-first pixel. On the previous
+    # (max_index only) implementation this returned the far corner instead.
+    # See https://github.com/dials/dials/issues/3014.
+    bbox = (0, 6, 0, 6, 0, 1)  # single frame, 6x6 in y, x
+    shoebox = flex.shoebox(1)
+    shoebox[0] = Shoebox(bbox)
+    shoebox[0].allocate_data()
+    data = shoebox[0].data  # shape (z=1, y=6, x=6)
+
+    # Build a blob of intensity in the high-y, high-x corner so the centroid sits
+    # there. Two equal maxima: one at the near corner (in the blob) and one at
+    # the far (low-y, low-x) corner which is first in z, y, x order.
+    for y in range(3, 6):
+        for x in range(3, 6):
+            data[0, y, x] = 5
+    data[0, 0, 0] = 10  # far, z/y/x-first maximum
+    data[0, 5, 5] = 10  # near the centroid
+
+    peak = shoebox.peak_coordinates()
+    # Expect the near-centroid pixel (x=5, y=5), not the (0, 0) corner.
+    assert peak[0] == (5 + 0.5, 5 + 0.5, 0 + 0.5)
+
+
 def test_bounding_boxes():
     from dials.array_family import flex
     from dials.model.data import Shoebox


### PR DESCRIPTION
This PR changes how `Shoebox.peak_coordinates()` resolves ties between
equally-bright pixels. It previously used `af::max_index`, which returns
the first pixel in z, y, x order at the maximum value, so when several
pixels shared that maximum the geometrically-first one always won. That
biases the reported peak away from the spot centroid, and a
poorly-placed peak can push the peak-centroid distance over the
threshold in `PeakCentroidDistanceFilter` and drop an otherwise-valid
reflection. The tie is now broken toward the pixel nearest the shoebox
centroid.

The z, y, x rule is the same deterministic tie-break used by the
fast-feedback-service 3D connected-component analysis, and whether it is
the right choice was initially raised in
DiamondLightSource/fast-feedback-service#58 and discussed in
dials/dials#3014 This moves DIALS to the nearest-to-centroid option
discussed and agreed there.

Closes #3014.

### Changes:

- Find the maximum value, its first index, and the tie count in a single
  pass over the shoebox data. The untied case (almost every reflection)
  is unchanged and costs the same as the old `af::max_index` scan; a
  `DIALS_ASSERT` restores the empty-array guard `af::max_index` enforced
  internally.
- Only when there is a tie compute the shoebox `centroid_all()` and pick
  the tied pixel nearest it. The tie-break lives in
  `peak_index_nearest_centroid`, which compares squared distances (no
  per-candidate `sqrt`), keeps the first pixel on equal distances so the
  result stays deterministic, and falls back to the first maximum when
  the centroid is non-finite (e.g. an all-zero shoebox).
- Add two `test_flex_shoebox` tests: an untied regression that pins the
  existing fast-path behaviour, and the tie case that fails on the old
  implementation.