### PR TITLE
repair `search_beam_position` failures when some sweeps cannot be indexed

### DIFF
--- a/newsfragments/3212.bugfix
+++ b/newsfragments/3212.bugfix
@@ -1,0 +1,1 @@
+Fix a crash when dials.search_beam_position cannot index some sweeps.

--- a/src/dials/algorithms/beam_position/labelit_method.py
+++ b/src/dials/algorithms/beam_position/labelit_method.py
@@ -67,6 +67,7 @@ def optimize_origin_offset_local_scope(
                     experiment,
                 )
                 for i, experiment in enumerate(experiments)
+                if solution_lists[i] is not None
             )
 
         scores = flex.double(
@@ -119,6 +120,9 @@ def optimize_origin_offset_local_scope(
                 trial_origin_offset += self.wide_search_offset
             target = 0
             for i, experiment in enumerate(experiments):
+                if solution_lists[i] is None:
+                    continue
+
                 target -= _get_origin_offset_score(
                     trial_origin_offset,
                     solution_lists[i],
@@ -139,6 +143,8 @@ def optimize_origin_offset_local_scope(
                 new_origin_offset = x * plot_px_sz * beamr1 + y * plot_px_sz * beamr2
                 score = 0
                 for i, experiment in enumerate(experiments):
+                    if solution_lists[i] is None:
+                        continue
                     score += _get_origin_offset_score(
                         new_origin_offset,
                         solution_lists[i],
@@ -321,6 +327,7 @@ def discover_better_experimental_model(
     # The detector/beam of the first experiment is used to define the basis
     # for the optimisation, so assert that the beam intersects with
     # the detector
+    # FIXME: this assumption is unnecessary and the code should be generalized
     detector = experiments[0].detector
     beam = experiments[0].beam
     beam_panel = detector.get_panel_intersection(beam.get_s0())
@@ -371,6 +378,9 @@ def discover_better_experimental_model(
             if result.get("solutions"):
                 solution_lists.append(result["solutions"])
                 amax_list.append(result["amax"])
+            else:
+                solution_lists.append(None)
+                amax_list.append(None)
 
     if not solution_lists:
         raise Sorry("No solutions found")

--- a/src/dials/algorithms/beam_position/labelit_method.py
+++ b/src/dials/algorithms/beam_position/labelit_method.py
@@ -382,7 +382,7 @@ def discover_better_experimental_model(
                 solution_lists.append(None)
                 amax_list.append(None)
 
-    if not solution_lists:
+    if all(x is None for x in solution_lists):
         raise Sorry("No solutions found")
 
     new_experiments = optimize_origin_offset_local_scope(


### PR DESCRIPTION
When running `dials.search_beam_position` on multi-sweep datasets, the program **fails unless all sweeps can be indexed independently**. This is problematic when one or more sweeps contain too few spots or many ice rings and cannot be indexed independently.

## How to reproduce

```bash
dials.import `dials.data get -q Rigaku_HyPix_Arc`/CHNOS_*.rodhypix
dials.find_spots imported.expt 

# intentionally makes one sweep unindexable to mimic a difficult case
dials.modify_experiments imported.expt select_experiments=1 distance=10000

# trigger the bug
dials.search_beam_position modified.expt strong.refl
```

## Error before this patch

```
Found 0 solutions with max unit cell 54.94 Angstroms. # This causes the crash
Found 21 solutions with max unit cell 54.94 Angstroms.
Found 22 solutions with max unit cell 54.94 Angstroms.
Found 21 solutions with max unit cell 54.94 Angstroms.

...

  File "/prog/dials-dev/modules/dials/src/dials/command_line/search_beam_position.py", line 328, in run
    experiments = discover_better_experimental_model(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/prog/dials-dev/modules/dials/src/dials/algorithms/beam_position/labelit_method.py", line 378, in discover_better_experimental_model
    new_experiments = optimize_origin_offset_local_scope(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/prog/dials-dev/modules/dials/src/dials/algorithms/beam_position/labelit_method.py", line 72, in optimize_origin_offset_local_scope
    scores = flex.double(
             ^^^^^^^^^^^^
  File "/prog/dials-dev/modules/dials/src/dials/algorithms/beam_position/labelit_method.py", line 73, in <genexpr>
    get_experiment_score_for_coord(x, y)
  File "/prog/dials-dev/modules/dials/src/dials/algorithms/beam_position/labelit_method.py", line 61, in get_experiment_score_for_coord
    return sum(
           ^^^^
  File "/prog/dials-dev/modules/dials/src/dials/algorithms/beam_position/labelit_method.py", line 64, in <genexpr>
    solution_lists[i],
    ~~~~~~~~~~~~~~^^^
IndexError: Please report this error at https://github.com/dials/dials/issues or to dials-user-group@jiscmail.ac.uk: list index out of range
```

## After this patch

The program is more robust to offending sweep(s).

```
Found 0 solutions with max unit cell 54.94 Angstroms.
Found 21 solutions with max unit cell 54.94 Angstroms.
Found 22 solutions with max unit cell 54.94 Angstroms.
Found 21 solutions with max unit cell 54.94 Angstroms.
Old beam centre: 16.14, 37.83 mm (161.4, 378.3 px)
New beam centre: 15.68, 37.70 mm (156.8, 377.0 px)
Shift: 0.46, 0.13 mm (4.6, 1.3 px)
```

Note that with the original geometry `imported.expt`, one gets:

```
Found 21 solutions with max unit cell 54.94 Angstroms.
Found 21 solutions with max unit cell 54.94 Angstroms.
Found 22 solutions with max unit cell 54.94 Angstroms.
Found 21 solutions with max unit cell 54.94 Angstroms.
Old beam centre: 16.14, 37.83 mm (161.4, 378.3 px)
New beam centre: 15.61, 37.62 mm (156.1, 376.2 px)
Shift: 0.53, 0.21 mm (5.3, 2.1 px)
```