### PR TITLE
Batch data points in dials.reciprocal_lattice_viewer

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Speed up dials.reciprocal_lattice_viewer for large datasets

--- a/src/dials/util/reciprocal_lattice/viewer.py
+++ b/src/dials/util/reciprocal_lattice/viewer.py
@@ -554,8 +554,21 @@ class RLVWindow(wx_viewer.show_points_and_lines_mixin):
             gl.glLineWidth(1)
             if self.colors is None:
                 self.colors = flex.vec3_double(len(self.points), (1, 1, 1))
+            # Batch all crosses into a single glBegin/glEnd block.  Over indirect
+            # GLX each begin/end pair is a protocol boundary; one block for all
+            # 6N vertices is orders of magnitude faster than N separate blocks.
+            f = 0.01 * self.settings.marker_size
+            gl.glBegin(gl.GL_LINES)
             for point, color in zip(self.points, self.colors):
-                self.draw_cross_at(point, color=color)
+                x, y, z = point
+                gl.glColor3f(*color)
+                gl.glVertex3f(x - f, y, z)
+                gl.glVertex3f(x + f, y, z)
+                gl.glVertex3f(x, y - f, z)
+                gl.glVertex3f(x, y + f, z)
+                gl.glVertex3f(x, y, z - f)
+                gl.glVertex3f(x, y, z + f)
+            gl.glEnd()
             self.points_display_list.end()
         self.points_display_list.call()
 


### PR DESCRIPTION
Fixes `dials.reciprocal_lattice_viewer` on the Mesa graphics library

Background: on a Rocky Linux 9.7 installation with NVidia graphics cards, `dials.reciprocal_lattice_viewer` doesn't work due to a weird assertion:

```
  File "/dev/shm/aaron/modules/dials/src/dials/util/wx_viewer.py", line 151, in __init__
    self.context = wx.glcanvas.GLContext(self)
                   ~~~~~~~~~~~~~~~~~~~~~^^^^^^
wx._core.wxAssertionError: Please report this error at https://github.com/dials/dials/issues or to dials-user-group@jiscmail.ac.uk: C++ assertion ""vi"" failed at ./src/unix/glx11.cpp(493) in wxGLContext(): invalid visual for OpenGL
```

This occurs over X using XQuartz 2.85 on MacOS 15.4.  After Claude based investigation, it produced a couple environment variables to set which allows the viewer to start:

```
  export __GLX_VENDOR_LIBRARY_NAME=mesa
  export LIBGL_ALWAYS_INDIRECT=1
```

Its reasoning:  "the server's libglvnd defaults to the NVIDIA GLX driver (because of the GPUs), which can't speak to XQuartz. Forcing Mesa fixes that."

However, the viewer doesn't display without this patch, which batches the GL calls.

Marked as draft because I suspect we'd want to change `draw_cross_at` to `draw_crosses_at` to pick up this change in other places, but feedback requested.

AI-assisted (Claude Opus 4.8)