### PR TITLE
Cache extension entry-point lookups

### DIFF
--- a/newsfragments/XXXX.misc
+++ b/newsfragments/XXXX.misc
@@ -1,0 +1,1 @@
+Cache extension entry-point lookups: ``dials.extensions._Extension.load`` re-scanned the entry-point metadata of every installed distribution on each call, which for ``dials.stills_process`` happened several times per image

--- a/src/dials/extensions/__init__.py
+++ b/src/dials/extensions/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import importlib.metadata
 
 
@@ -19,6 +20,7 @@ class _Extension:
         ]
 
     @classmethod
+    @functools.cache
     def load(cls, name):
         """Get the requested extension class by name.
 


### PR DESCRIPTION
---

`_Extension.load` resolves an extension class by walking the installed entry-point metadata,
with no memoisation:

```python
    @classmethod
    def load(cls, name):
        for entry_point in importlib.metadata.entry_points(group=cls.entry_point):
            ...
```

On Python 3.11 `entry_points(group=…)` takes the `SelectableGroups` path: it builds the entry
points of **every** installed distribution and filters afterwards, doing a real
`read_text()` of each `entry_points.txt`. With 174 distributions installed that is **4.3 ms
per call** here, and it is filesystem-bound rather than CPU-bound — on a Lustre-backed HPC
filesystem, which is where `dials.stills_process` actually runs at scale, the same call
measured 16.5 ms.

`dials.stills_process` pays this several times per image: `SpotFinderFactory.from_parameters`,
`create_integrator` and `ProfileModelFactory.create` each resolve an extension per still, so
the cost spans spot-finding, indexing and integration alike.

The fix is `functools.cache`:

```python
    @classmethod
    @functools.cache
    def load(cls, name):
```

4.3 ms → 0.09 µs on the repeat calls. `@classmethod` has to stay the outer decorator —
chaining a descriptor through `classmethod` was deprecated in 3.11 and removed in 3.13.
`functools.cache` rather than `lru_cache` matches the existing precedent in
`dials/algorithms/indexing/__init__.py`, which was the resolution of #3158.

## Effect

Cumulative time in `importlib.metadata.entry_points`, seconds per input image, summed over a
64-rank MPI run **on a workstation with the data and the conda environment on local NVMe**.
The next section is the reason that qualifier matters:

| dataset | images/rank | before | after | |
|---|---|---|---|---|
| cytochrome (256 panels) | 22.6 | 0.0403 | 0.0071 | **−82 %** |
| lysozyme (1 panel) | 78.1 | 0.0213 | 0.0021 | **−90 %** |
| fourth case (1 panel) | 77.9 | 0.0157 | 0.0016 | **−90 %** |
| PSII (32 panels) | 2.9 | 0.0486 | 0.0443 | −9 % |

The number of calls falls from 4,850–8,850 per run to **756**, and 756 is the same figure on
two datasets of very different length: what is left is the **first walk in each process**,
about twelve lookups per rank, which is the number of distinct `(cls, name)` pairs a run
touches. That residual is fixed, so the saving grows with how many images each rank handles —
18 % of the original cost remains at 22.6 images per rank and 10 % at 78.

**The PSII row is that residual, not a small win.** The PSII dataset used here is a 186-image
subset, which over 64 ranks is 2.9 images per rank, so 91 % of the walking it does is the
first-walk-per-process that no cache can remove. On the full-length version of that dataset
the same residual is spread over roughly 130× more images.

On this machine the whole-job saving is 15–39 ms of CPU per image, 0.4–2.0 % of the run, at
or below the run-to-run spread of these measurements — so on local disk the case for the change
rests on the profile above rather than on a wall-clock delta. It is also not confined to
`dials.stills_process`: `dials.integrate`, `dials.find_spots`, `dials.ssx_integrate`, the
image viewer and xia2 all take the same path.

## How much this is worth depends on the filesystem

The work being cached is **174 small metadata file reads per call**, not computation. That
makes the cost a property of the filesystem the conda environment sits on, and the numbers
above are the *favourable* case. The same code was profiled earlier on NERSC Perlmutter, with
the environment on Lustre:

| | local NVMe | Lustre (Perlmutter) | |
|---|---|---|---|
| one `Background.load("simple")` | 4.3 ms | 16.5 ms | 3.8× |
| `_Extension.load`, cytochrome/reference, s per image | 0.036 | 0.179 | 5.0× |

Cytochrome is the only like-for-like comparison — the same 1448 images on both machines — and
it is **5× more expensive on Lustre**. On the full-length PSII dataset (24,494 images, 128
ranks) the figure there was **0.629 s per image** — on that machine this was the single
largest item in the whole profiling campaign that produced this change.

The mechanism is metadata contention, and it is visible *within* Lustre as well as against
local disk: per `entry_points.txt` read, 0.36 ms on the lysozyme job against **2.05 ms on the
PSII job at 128 ranks**, 5.7× for identical code and identical files. Every rank on the node
independently re-reads all 174 files, for every image, while every other rank does the same.

So this scales with **rank count and job length**, not with panel count or image size — and it
gets worse in exactly the direction production XFEL processing moves. On a laptop or a
local-disk workstation it is a fraction of a percent and you would be right to call it minor.
On a Lustre- or GPFS-backed cluster at scale it is not, and that is the deployment this command
is written for.

## Scope

**Reviewers of #3158 asked whether that class of fix should be broader, so, measured:** of all
`entry_points` calls in a profiled stills run, **97.5 % come from `_Extension.load`**. The other
per-image-looking sites — `Indexer.from_parameters`, `LatticeSearch`, `BasisVectorSearch` —
stopped being per-image when #3158 landed its indexer caching, and now run about twice per
process. This is the one remaining per-image walk.

`extensions()`, two functions above `load`, does the identical walk and is **deliberately left
uncached**: its callers (`phil_scope()`, `dev.dials.show_extensions`) are import-time rather
than per-image, and unlike `load` it returns a mutable list that a cache would share between
callers.