### PR TITLE
dials.integrate: say "Images" rather than "Frames"

### DIFF
--- a/newsfragments/1394.misc
+++ b/newsfragments/1394.misc
@@ -1,0 +1,1 @@
+``dials.integrate``: report per-block ranges as ``Images:`` rather than ``Frames:``, since "image" is the term used everywhere else in DIALS and understood by users.

--- a/src/dials/algorithms/integration/integrator.py
+++ b/src/dials/algorithms/integration/integrator.py
@@ -651,7 +651,7 @@ class ProfileModellerExecutor(Executor):
         logger.debug("")
         logger.debug(" Beginning modelling job %d", job.index)
         logger.info("")
-        logger.info(" Frames: %d -> %d", frame0 + 1, frame1)
+        logger.info(" Images: %d -> %d", frame0 + 1, frame1)
         logger.info("")
         logger.info(" Number of reflections")
         logger.info("  Partial:     %d", npart)
@@ -665,7 +665,7 @@ class ProfileModellerExecutor(Executor):
             logger.debug(
                 " The following histogram shows the number of reflections predicted"
             )
-            logger.debug(" to have all or part of their intensity on each frame.")
+            logger.debug(" to have all or part of their intensity on each image.")
             logger.debug("")
             logger.debug(frame_hist(reflections["bbox"], prefix=" ", symbol="*"))
             logger.debug("")
@@ -754,7 +754,7 @@ class ProfileValidatorExecutor(Executor):
         logger.debug("")
         logger.debug(" Beginning modelling job %d", job.index)
         logger.info("")
-        logger.info(" Frames: %d -> %d", frame0, frame1)
+        logger.info(" Images: %d -> %d", frame0, frame1)
         logger.info("")
         logger.info(" Number of reflections")
         logger.info("  Partial:     %d", npart)
@@ -768,7 +768,7 @@ class ProfileValidatorExecutor(Executor):
             logger.debug(
                 " The following histogram shows the number of reflections predicted"
             )
-            logger.debug(" to have all or part of their intensity on each frame.")
+            logger.debug(" to have all or part of their intensity on each image.")
             logger.debug("")
             logger.debug(frame_hist(reflections["bbox"], prefix=" ", symbol="*"))
             logger.debug("")
@@ -864,7 +864,7 @@ class IntegratorExecutor(Executor):
         logger.debug("")
         logger.debug(" Beginning integration job %d", job.index)
         logger.info("")
-        logger.info(" Frames: %d -> %d", frame0, frame1)
+        logger.info(" Images: %d -> %d", frame0, frame1)
         logger.info("")
         logger.info(" Number of reflections")
         logger.info("  Partial:     %d", npart)
@@ -879,7 +879,7 @@ class IntegratorExecutor(Executor):
             logger.debug(
                 " The following histogram shows the number of reflections predicted"
             )
-            logger.debug(" to have all or part of their intensity on each frame.")
+            logger.debug(" to have all or part of their intensity on each image.")
             logger.debug("")
             logger.debug(frame_hist(reflections["bbox"], prefix=" ", symbol="*"))
             logger.debug("")

--- a/src/dials/algorithms/integration/parallel_integrator.py
+++ b/src/dials/algorithms/integration/parallel_integrator.py
@@ -436,7 +436,7 @@ class IntegrationJob:
         # Write some output
         logger.info(" Beginning integration job %d", self.index)
         logger.info("")
-        logger.info(" Frames: %d -> %d", frame0, frame1)
+        logger.info(" Images: %d -> %d", frame0, frame1)
         logger.info("")
         logger.info(" Number of reflections")
         logger.info("  Partial:     %d", npart)
@@ -451,7 +451,7 @@ class IntegrationJob:
             logger.info(
                 " The following histogram shows the number of reflections predicted"
             )
-            logger.info(" to have all or part of their intensity on each frame.")
+            logger.info(" to have all or part of their intensity on each image.")
             logger.info("")
             logger.info(
                 frame_hist(
@@ -882,7 +882,7 @@ class ReferenceCalculatorJob:
         # Write some output
         logger.info(" Beginning integration job %d", self.index)
         logger.info("")
-        logger.info(" Frames: %d -> %d", frame0, frame1)
+        logger.info(" Images: %d -> %d", frame0, frame1)
         logger.info("")
         logger.info(" Number of reflections")
         logger.info("  Partial:     %d", npart)
@@ -897,7 +897,7 @@ class ReferenceCalculatorJob:
             logger.info(
                 " The following histogram shows the number of reflections predicted"
             )
-            logger.info(" to have all or part of their intensity on each frame.")
+            logger.info(" to have all or part of their intensity on each image.")
             logger.info("")
             logger.info(
                 frame_hist(


### PR DESCRIPTION
The per-block summary printed by dials.integrate reported

  Frames: 7452 -> 7488

but "frame" is not the term used elsewhere in DIALS, nor the term users recognise: what is being counted here is images. Rename the user-facing occurrences in the integrator summaries, along with the accompanying histogram description, leaving internal variable names (frame0, frame1) untouched so this remains a purely cosmetic change.

Fixes #1394