### PR TITLE
Tutorials: set joint_indexing explicitly for multi-sequence data

### DIFF
--- a/doc/sphinx/documentation/tutorials/intensity_based_clustering.rst
+++ b/doc/sphinx/documentation/tutorials/intensity_based_clustering.rst
@@ -88,7 +88,7 @@ Once you are in the same location as your ``data`` folder, import all images int
 
     dials.import data/*gz
     dials.find_spots imported.expt
-    dials.index imported.expt strong.refl joint=False
+    dials.index imported.expt strong.refl joint_indexing=False
     dials.refine indexed.expt indexed.refl
     dials.integrate refined.expt refined.refl
     dials.cosym integrated.expt integrated.refl

--- a/doc/sphinx/documentation/tutorials/small_molecule_tutorial.rst
+++ b/doc/sphinx/documentation/tutorials/small_molecule_tutorial.rst
@@ -61,7 +61,16 @@ Here the lattices overlap in the reciprocal lattice view above, the indexing sho
 
 .. code-block:: bash
 
-   dials.index imported.expt strong.refl
+   dials.index imported.expt strong.refl joint_indexing=True
+
+Since there is more than one sequence in ``imported.expt``, ``dials.index`` will
+not guess whether the sequences come from one sample or from several, and will
+stop with an error if you do not say.
+Here all four sequences were measured from the same crystal, so
+``joint_indexing=True`` is correct and gives a single crystal model shared by all
+four sequences.
+If instead the sequences came from *different* samples you would pass
+``joint_indexing=False``, and each sequence would be indexed independently.
 
 Without any additional input, the indexing will determine the most appropriate primitive (i.e. triclinic) lattice parameters and orientation which describe the observed reciprocal lattice positions.
 
@@ -78,7 +87,7 @@ Once this has run you can manually rerun indexing with:
 
 .. code-block:: bash
 
-   dials.index imported.expt strong.refl space_group=P222
+   dials.index imported.expt strong.refl space_group=P222 joint_indexing=True
 
 to assign the lattice, or manually reindex the data to match setting #5 (though in this case that is a no-op) - or as mentioned above proceed with the lattice unconstrained.
 

--- a/newsfragments/3222.doc
+++ b/newsfragments/3222.doc
@@ -1,0 +1,1 @@
+Tutorials: correct the ``dials.index`` commands for data containing more than one rotation sequence, which now require ``joint_indexing`` to be set explicitly, and fix the misspelt ``joint=False`` in the intensity-based clustering tutorial.

--- a/src/dials/command_line/index.py
+++ b/src/dials/command_line/index.py
@@ -46,6 +46,12 @@ If the unit_cell and space_group parameters are set, then the program will
 only accept solutions which are consistent with these parameters. Space group
 constraints will be enforced in refinement as appropriate.
 
+If the input contains more than one rotation sequence then joint_indexing must
+be set explicitly: joint_indexing=True to index all sequences together with a
+single shared crystal model (e.g. multi-axis data from one sample), or
+joint_indexing=False to index each sequence independently (e.g. data from
+several different samples).
+
 Examples::
 
   dials.index imported.expt strong.refl
@@ -53,6 +59,8 @@ Examples::
   dials.index imported.expt strong.refl unit_cell=37,79,79,90,90,90 space_group=P43212
 
   dials.index imported.expt strong.refl indexing.method=fft1d
+
+  dials.index imported.expt strong.refl joint_indexing=True
 """
 
 


### PR DESCRIPTION
dials.index no longer guesses joint_indexing when handed more than one rotation sequence: it stops and asks. Two tutorials still gave commands that will now fail:

  - small_molecule_tutorial imports four sequences from one crystal and then runs dials.index with no joint_indexing setting. Add joint_indexing=True, plus a short note on how to choose.
  - intensity_based_clustering passes joint=False, which is not a parameter dials.index has ever had. Correct it to joint_indexing=False, which is what is meant for 36 datasets from three different species.

Also record the requirement in the dials.index help message, so the answer is available at the point the error is raised.

Reported by @irisdyoung.

Fixes #3222