### PR TITLE
reflection_table: add as_pandas_dataframe()

### DIFF
--- a/newsfragments/1914.feature
+++ b/newsfragments/1914.feature
@@ -1,0 +1,1 @@
+``flex.reflection_table``: add ``as_pandas_dataframe()``, returning the table as a ``pandas.DataFrame``, with multiple valued columns such as ``miller_index`` and ``bbox`` unpacked element by element.

--- a/src/dials/array_family/flex_ext.py
+++ b/src/dials/array_family/flex_ext.py
@@ -22,6 +22,7 @@ import boost_adaptbx.boost.python
 import cctbx.array_family.flex
 import cctbx.miller
 import libtbx.smart_open
+from dxtbx import flumpy
 from dxtbx.model import ExperimentType
 from scitbx import matrix
 
@@ -433,6 +434,64 @@ class _:
             cctbx.miller.array_info(source="DIALS", source_type="reflection_tables")
         )
         return i_obs
+
+    def as_pandas_dataframe(self, columns=None):
+        """
+        Return the reflection table as a pandas DataFrame.
+
+        Columns holding a single value per reflection map to a single
+        DataFrame column of the same name. Columns holding several values per
+        reflection (e.g. miller_index, xyzobs.px.value, bbox) are unpacked
+        into one DataFrame column per element, named by appending an index to
+        the reflection table column name, so miller_index becomes
+        miller_index_0, miller_index_1 and miller_index_2.
+
+        Columns which have no array representation, in practice shoebox, are
+        omitted.
+
+        :param columns: An optional list of reflection table column names to
+                        convert; the default is to convert every column.
+        :return: A pandas DataFrame of the requested columns
+        """
+
+        if columns is None:
+            columns = list(self.keys())
+        else:
+            missing = [c for c in columns if c not in self]
+            if missing:
+                raise KeyError(f"Reflection table has no column(s) {missing}")
+
+        data = {}
+        omitted = []
+
+        for key in columns:
+            column = self[key]
+            try:
+                array = flumpy.to_numpy(column)
+            except (TypeError, ValueError):
+                # types flumpy does not know about, e.g. int6 (bbox), which
+                # can still be split into their elements; and shoebox, which
+                # cannot
+                if hasattr(column, "parts"):
+                    for j, part in enumerate(column.parts()):
+                        data[f"{key}_{j}"] = flumpy.to_numpy(part)
+                else:
+                    omitted.append(key)
+                continue
+            if array.ndim == 1:
+                data[key] = array
+            else:
+                array = array.reshape(array.shape[0], -1)
+                for j in range(array.shape[1]):
+                    data[f"{key}_{j}"] = array[:, j]
+
+        if omitted:
+            logger.debug(
+                "Columns omitted from DataFrame (no array representation): %s",
+                ", ".join(omitted),
+            )
+
+        return pd.DataFrame(data)
 
     def copy(self):
         """

--- a/tests/array_family/test_reflection_table.py
+++ b/tests/array_family/test_reflection_table.py
@@ -1657,3 +1657,61 @@ def test_concat():
     table1 = flex.reflection_table()
     table2 = flex.reflection_table()
     table1 = flex.reflection_table.concat([table1, table2])
+
+
+def test_as_pandas_dataframe():
+    nn = 10
+
+    table = flex.reflection_table()
+    table["miller_index"] = flex.miller_index(
+        flex.int(range(nn)), flex.int(range(nn)), flex.int(range(nn))
+    )
+    table["id"] = flex.int(nn, 0)
+    table["intensity.sum.value"] = flex.double(range(nn))
+    table["xyzobs.px.value"] = flex.vec3_double([(n, n + 1, n + 2) for n in range(nn)])
+    table["bbox"] = flex.int6(*(flex.int(nn, j) for j in range(6)))
+
+    df = table.as_pandas_dataframe()
+
+    assert len(df) == nn
+
+    # single valued columns keep their name
+    assert list(df["id"]) == [0] * nn
+    assert list(df["intensity.sum.value"]) == list(range(nn))
+
+    # multiple valued columns are unpacked, element by element
+    assert list(df["miller_index_0"]) == list(range(nn))
+    assert list(df["miller_index_2"]) == list(range(nn))
+    assert list(df["xyzobs.px.value_1"]) == [n + 1 for n in range(nn)]
+
+    # including those flumpy does not handle directly
+    assert list(df["bbox_0"]) == [0] * nn
+    assert list(df["bbox_5"]) == [5] * nn
+
+    assert "miller_index" not in df
+    assert "bbox" not in df
+
+
+def test_as_pandas_dataframe_selected_columns():
+    nn = 10
+
+    table = flex.reflection_table()
+    table["id"] = flex.int(nn, 0)
+    table["intensity.sum.value"] = flex.double(range(nn))
+
+    df = table.as_pandas_dataframe(columns=["intensity.sum.value"])
+
+    assert list(df.columns) == ["intensity.sum.value"]
+
+    with pytest.raises(KeyError):
+        table.as_pandas_dataframe(columns=["not.a.column"])
+
+
+def test_as_pandas_dataframe_omits_shoebox():
+    table = flex.reflection_table()
+    table["id"] = flex.int(2, 0)
+    table["shoebox"] = flex.shoebox(2)
+
+    df = table.as_pandas_dataframe()
+
+    assert list(df.columns) == ["id"]


### PR DESCRIPTION
Getting reflection data into pandas is a common enough thing to want to do - for ad hoc analysis, plotting, joining against other data - that everyone ends up writing the same loop over the columns. Add it once, as a method on the reflection table.

Columns with one value per reflection map to a DataFrame column of the same name. Columns with several values per reflection are unpacked into one DataFrame column per element, named by appending the element index, so miller_index becomes miller_index_0, miller_index_1, miller_index_2. This includes int6 (i.e. bbox), which flumpy does not handle directly but which can be split with parts(). shoebox has no array representation and is omitted.

An optional columns argument allows a subset to be converted, which matters for large tables where the DataFrame is a copy.

Fixes #1914