### PR TITLE
exclude_images: allow * to mean every dataset

### DIFF
--- a/newsfragments/2560.feature
+++ b/newsfragments/2560.feature
@@ -1,0 +1,1 @@
+``exclude_images``: allow ``*`` in place of the experiment number, to exclude the same image range from every dataset, e.g. ``exclude_images=*:21:100``.

--- a/src/dials/util/exclude_images.py
+++ b/src/dials/util/exclude_images.py
@@ -23,10 +23,12 @@ phil_scope = iotbx.phil.parse(
     .multiple = True
     .help = "Input in the format exp:start:end"
             "Exclude a range of images (start, stop) from the dataset with"
-            "experiment identifier exp  (inclusive of frames start, stop)."
+            "experiment identifier exp  (inclusive of images start, stop)."
             "Multiple ranges can be given in one go, e.g."
             "exclude_images=0:150:200,1:200:250"
             "exclude_images='0:150:200 1:200:250'"
+            "The experiment may be given as * to apply the same range to"
+            "every dataset, e.g. exclude_images=*:21:100"
     .short_caption = "Exclude images"
     .expert_level = 1
 
@@ -96,11 +98,38 @@ def get_selection_for_valid_image_ranges(reflection_table, experiment):
     return flex.bool(reflection_table.size(), True)  # else say all valid
 
 
+_SYNTAX_HELP = """
+Ranges are given as start:stop, using colons: note that this differs from
+image_range=start,stop as used by dials.import and dials.slice_sequence,
+because here a comma separates one range from the next, e.g.
+exclude_images=0:100:150,1:120:200. Multiple ranges may also be separated by
+spaces, or given as repeated exclude_images= parameters. The experiment may be
+given as * to apply the same range to every dataset, e.g. exclude_images=*:21:100
+"""
+
+
+def _all_identifiers(experiments, reflections):
+    """Return the identifiers of every dataset, for expanding a * wildcard.
+
+    Prefer the experiments, as those are what the image ranges will be set on;
+    fall back on the identifiers recorded in the reflection tables.
+    """
+    if experiments:
+        return [exp.identifier for exp in experiments]
+    identifiers = []
+    for table in reflections or []:
+        for expid in table.experiment_identifiers().values():
+            if expid not in identifiers:
+                identifiers.append(expid)
+    return identifiers
+
+
 def _parse_exclude_images_commands(commands, experiments, reflections):
     """Parse a list of list of command line options.
 
     e.g. commands = [['1:101:200'], ['0:201:300']]
     or commands = [[101:200]] allowable for a single experiment.
+    The experiment may be given as * to mean every dataset, e.g. [['*:101:200']]
     builds and returns a list of tuples (exp_id, (start, stop))
 
 
@@ -120,6 +149,7 @@ def _parse_exclude_images_commands(commands, experiments, reflections):
                 if len(experiments) > 1:
                     raise ValueError(
                         "Exclude images must be in the form experimentnumber:start:stop for multiple experiments"
+                        + _SYNTAX_HELP
                     )
                 else:
                     ranges_to_remove.append(
@@ -129,8 +159,12 @@ def _parse_exclude_images_commands(commands, experiments, reflections):
                 if len(vals) != 3:
                     raise ValueError(
                         "Exclude images must be input in the form experimentnumber:start:stop, or start:stop for a single experiment"
-                        + " Multiple ranges can be specified by comma or space separated values e.g 0:100:150,1:120:200"
+                        + _SYNTAX_HELP
                     )
+                if vals[0] == "*":
+                    for expid in _all_identifiers(experiments, reflections):
+                        ranges_to_remove.append((expid, (int(vals[1]), int(vals[2]))))
+                    continue
                 dataset_id = int(vals[0])
                 if reflections:
                     for table in reflections:

--- a/tests/util/test_exclude_images.py
+++ b/tests/util/test_exclude_images.py
@@ -65,6 +65,47 @@ def test_parse_exclude_images_commands():
         _ = _parse_exclude_images_commands([["1:101:a"]], [], tables)
 
 
+def test_parse_exclude_images_commands_wildcard():
+    """Test that * expands to every dataset"""
+    experiments = ExperimentList(
+        [
+            make_scan_experiment(expid="0"),
+            make_scan_experiment(expid="1"),
+            make_scan_experiment(expid="2"),
+        ]
+    )
+    ranges = _parse_exclude_images_commands([["*:21:100"]], experiments, None)
+    assert ranges == [("0", (21, 100)), ("1", (21, 100)), ("2", (21, 100))]
+
+    # mixing a wildcard with an explicit dataset is allowed
+    ranges = _parse_exclude_images_commands([["*:21:100,1:1:5"]], experiments, None)
+    assert ranges == [
+        ("0", (21, 100)),
+        ("1", (21, 100)),
+        ("2", (21, 100)),
+        ("1", (1, 5)),
+    ]
+
+    # with no experiments, fall back on the reflection table identifiers
+    r0 = flex.reflection_table()
+    r0.experiment_identifiers()[0] = "0"
+    r1 = flex.reflection_table()
+    r1.experiment_identifiers()[1] = "1"
+    ranges = _parse_exclude_images_commands([["*:21:100"]], [], [r0, r1])
+    assert ranges == [("0", (21, 100)), ("1", (21, 100))]
+
+
+def test_exclude_image_ranges_wildcard():
+    """Test that a wildcard exclusion is applied to every scan"""
+    experiments = ExperimentList(
+        [make_scan_experiment(expid="0"), make_scan_experiment(expid="1")]
+    )
+    experiments = exclude_image_ranges_from_scans(None, experiments, [["*:21:100"]])
+    ranges = get_valid_image_ranges(experiments)
+    assert list(ranges[0]) == [(1, 20)]
+    assert list(ranges[1]) == [(1, 20)]
+
+
 def test_expand_exclude_multiples():
     """Test for namesake function"""
     explist = ExperimentList(


### PR DESCRIPTION
Excluding the same image range from every dataset currently means spelling out one range per experiment:

  dials.scale symmetrized.* exclude_images=0:21:100,1:21:100,2:21:100,...

which for modest-to-large N is a job for a script, not a person. Accept * in place of the experiment number, so the above becomes

  dials.scale symmetrized.* exclude_images=*:21:100

The wildcard expands to the identifier of every experiment (falling back on the identifiers recorded in the reflection tables if no experiments are given), and may be mixed with explicit per-dataset ranges. As the expansion is in _parse_exclude_images_commands this works anywhere exclude_images is honoured - dials.scale, dials.integrate, dials.find_spots.

While here, extend the error message raised on a malformed range to spell out that ranges use start:stop while commas separate one range from the next. This is the point at which users hit the difference from image_range=start,stop noted in #1363; the two cannot be made to agree, since a comma already means something else here.

Fixes #2560
Refs #1363