### PR TITLE
tof_integration.h refactor

### DIFF
--- a/newsfragments/3237.misc
+++ b/newsfragments/3237.misc
@@ -1,0 +1,1 @@
+Rename tof profile1d and profile3d methods to profile_1d_ibix and profile_3d_gutmann, respectively.

--- a/newsfragments/xxx.misc
+++ b/newsfragments/xxx.misc
@@ -1,1 +1,0 @@
-Refactor tof_integration.h to simplify branching logic and make it easier to add additional integration methods/corrections.

--- a/newsfragments/xxx.misc
+++ b/newsfragments/xxx.misc
@@ -1,0 +1,1 @@
+Refactor tof_integration.h to simplify branching logic and make it easier to add additional integration methods/corrections.

--- a/src/dials/algorithms/integration/tof/boost_python/tof_integration_ext.cc
+++ b/src/dials/algorithms/integration/tof/boost_python/tof_integration_ext.cc
@@ -11,6 +11,24 @@ namespace dials { namespace algorithms { namespace boost_python {
 
   using namespace boost::python;
 
+  std::shared_ptr<ProfileFitter> make_profile_fitter(
+    object profile_1d_ibix_params_obj,
+    object profile_3d_gutmann_params_obj) {
+    // Only one profile fitting method allowed
+    DIALS_ASSERT(!(!profile_1d_ibix_params_obj.is_none()
+                   && !profile_3d_gutmann_params_obj.is_none()));
+
+    if (!profile_1d_ibix_params_obj.is_none()) {
+      return std::make_shared<Profile1DIBIXFitter>(
+        extract<TOFProfile1DIBIXParams>(profile_1d_ibix_params_obj));
+    }
+    if (!profile_3d_gutmann_params_obj.is_none()) {
+      return std::make_shared<Profile3DGutmannFitter>(
+        extract<TOFProfile3DGutmannParams>(profile_3d_gutmann_params_obj));
+    }
+    return nullptr;
+  }
+
   void integrate_reflection_table_wrapper(dials::af::reflection_table& reflection_table,
                                           dxtbx::model::Experiment& experiment,
                                           dxtbx::ImageSequence& data,
@@ -20,61 +38,134 @@ namespace dials { namespace algorithms { namespace boost_python {
                                           int n_threads,
                                           object profile_1d_ibix_params_obj,
                                           object profile_3d_gutmann_params_obj) {
-    boost::optional<TOFProfile1DIBIXParams> profile_1d_ibix_params;
-    boost::optional<TOFProfile3DGutmannParams> profile_3d_gutmann_params;
-
-    if (!profile_1d_ibix_params_obj.is_none()) {
-      profile_1d_ibix_params =
-        extract<TOFProfile1DIBIXParams>(profile_1d_ibix_params_obj);
-    }
-
-    if (!profile_3d_gutmann_params_obj.is_none()) {
-      profile_3d_gutmann_params =
-        extract<TOFProfile3DGutmannParams>(profile_3d_gutmann_params_obj);
-    }
-
-    if (absorption_params_obj.is_none() && incident_params_obj.is_none()) {
-      integrate_reflection_table(reflection_table,
-                                 experiment,
-                                 data,
-                                 apply_lorentz,
-                                 n_threads,
-                                 profile_1d_ibix_params,
-                                 profile_3d_gutmann_params);
-
-      return;
-    }
+    boost::optional<dials_scaling::TOFIncidentSpectrumParams> incident_params;
+    boost::optional<dials_scaling::TOFAbsorptionParams> absorption_params;
 
     if (!incident_params_obj.is_none()) {
-      dials_scaling::TOFIncidentSpectrumParams incident_params =
+      incident_params =
         extract<dials_scaling::TOFIncidentSpectrumParams>(incident_params_obj);
-
-      if (!absorption_params_obj.is_none()) {
-        dials_scaling::TOFAbsorptionParams absorption_params =
-          extract<dials_scaling::TOFAbsorptionParams>(absorption_params_obj);
-
-        integrate_reflection_table(reflection_table,
-                                   experiment,
-                                   data,
-                                   incident_params,
-                                   absorption_params,
-                                   apply_lorentz,
-                                   n_threads,
-                                   profile_1d_ibix_params,
-                                   profile_3d_gutmann_params);
-      }
-
-      else {
-        integrate_reflection_table(reflection_table,
-                                   experiment,
-                                   data,
-                                   incident_params,
-                                   apply_lorentz,
-                                   n_threads,
-                                   profile_1d_ibix_params,
-                                   profile_3d_gutmann_params);
-      }
     }
+    if (!absorption_params_obj.is_none()) {
+      absorption_params =
+        extract<dials_scaling::TOFAbsorptionParams>(absorption_params_obj);
+    }
+
+    std::shared_ptr<ProfileFitter> profile_fitter =
+      make_profile_fitter(profile_1d_ibix_params_obj, profile_3d_gutmann_params_obj);
+
+    integrate_reflection_table(reflection_table,
+                               experiment,
+                               data,
+                               incident_params,
+                               absorption_params,
+                               apply_lorentz,
+                               n_threads,
+                               profile_fitter);
+  }
+
+  void extract_correction_params(
+    object incident_params_obj,
+    object absorption_params_obj,
+    boost::optional<dials_scaling::TOFIncidentSpectrumParams>& incident_params,
+    boost::optional<dials_scaling::TOFAbsorptionParams>& absorption_params) {
+    if (!incident_params_obj.is_none()) {
+      incident_params =
+        extract<dials_scaling::TOFIncidentSpectrumParams>(incident_params_obj);
+    }
+    if (!absorption_params_obj.is_none()) {
+      absorption_params =
+        extract<dials_scaling::TOFAbsorptionParams>(absorption_params_obj);
+    }
+  }
+
+  boost::python::tuple calculate_line_profile_for_reflection_wrapper(
+    dials::af::reflection_table& reflection,
+    dxtbx::model::Experiment& experiment,
+    dxtbx::ImageSequence& data,
+    object incident_params_obj,
+    object absorption_params_obj,
+    scitbx::af::shared<double> raw_projected_intensity_out,
+    scitbx::af::shared<double> projected_intensity_out,
+    scitbx::af::shared<double> projected_background_out,
+    scitbx::af::shared<double> tof_z_out,
+    const bool& apply_lorentz_correction) {
+    boost::optional<dials_scaling::TOFIncidentSpectrumParams> incident_params;
+    boost::optional<dials_scaling::TOFAbsorptionParams> absorption_params;
+    extract_correction_params(
+      incident_params_obj, absorption_params_obj, incident_params, absorption_params);
+
+    return calculate_line_profile_for_reflection(reflection,
+                                                 experiment,
+                                                 data,
+                                                 incident_params,
+                                                 absorption_params,
+                                                 raw_projected_intensity_out,
+                                                 projected_intensity_out,
+                                                 projected_background_out,
+                                                 tof_z_out,
+                                                 apply_lorentz_correction);
+  }
+
+  boost::python::tuple calculate_line_profile_for_reflection_1d_wrapper(
+    dials::af::reflection_table& reflection,
+    dxtbx::model::Experiment& experiment,
+    dxtbx::ImageSequence& data,
+    object incident_params_obj,
+    object absorption_params_obj,
+    scitbx::af::shared<double> raw_projected_intensity_out,
+    scitbx::af::shared<double> projected_intensity_out,
+    scitbx::af::shared<double> projected_background_out,
+    scitbx::af::shared<double> tof_z_out,
+    scitbx::af::shared<double> line_profile_out,
+    const bool& apply_lorentz_correction,
+    TOFProfile1DIBIXParams& profile_params_1d_ibix) {
+    boost::optional<dials_scaling::TOFIncidentSpectrumParams> incident_params;
+    boost::optional<dials_scaling::TOFAbsorptionParams> absorption_params;
+    extract_correction_params(
+      incident_params_obj, absorption_params_obj, incident_params, absorption_params);
+
+    return calculate_line_profile_for_reflection(reflection,
+                                                 experiment,
+                                                 data,
+                                                 incident_params,
+                                                 absorption_params,
+                                                 raw_projected_intensity_out,
+                                                 projected_intensity_out,
+                                                 projected_background_out,
+                                                 tof_z_out,
+                                                 line_profile_out,
+                                                 apply_lorentz_correction,
+                                                 profile_params_1d_ibix);
+  }
+
+  boost::python::tuple calculate_line_profile_for_reflection_3d_wrapper(
+    dials::af::reflection_table& reflection,
+    dxtbx::model::Experiment& experiment,
+    dxtbx::ImageSequence& data,
+    object incident_params_obj,
+    object absorption_params_obj,
+    scitbx::af::shared<double> raw_projected_intensity_out,
+    scitbx::af::shared<double> projected_intensity_out,
+    scitbx::af::shared<double> projected_background_out,
+    scitbx::af::shared<double> tof_z_out,
+    const bool& apply_lorentz_correction,
+    TOFProfile3DGutmannParams& profile_params_3d_gutmann) {
+    boost::optional<dials_scaling::TOFIncidentSpectrumParams> incident_params;
+    boost::optional<dials_scaling::TOFAbsorptionParams> absorption_params;
+    extract_correction_params(
+      incident_params_obj, absorption_params_obj, incident_params, absorption_params);
+
+    return calculate_line_profile_for_reflection_3d(reflection,
+                                                    experiment,
+                                                    data,
+                                                    incident_params,
+                                                    absorption_params,
+                                                    raw_projected_intensity_out,
+                                                    projected_intensity_out,
+                                                    projected_background_out,
+                                                    tof_z_out,
+                                                    apply_lorentz_correction,
+                                                    profile_params_3d_gutmann);
   }
 
   BOOST_PYTHON_MODULE(dials_algorithms_tof_integration_ext) {
@@ -135,95 +226,46 @@ namespace dials { namespace algorithms { namespace boost_python {
          arg("profile_1d_ibix_params") = object()));
 
     def("calculate_line_profile_for_reflection",
-        static_cast<boost::python::tuple (*)(dials::af::reflection_table&,
-                                             dxtbx::model::Experiment&,
-                                             dxtbx::ImageSequence&,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             const bool&)>(
-          &calculate_line_profile_for_reflection));
+        &calculate_line_profile_for_reflection_wrapper,
+        (arg("reflection"),
+         arg("experiment"),
+         arg("data"),
+         arg("incident_params") = object(),
+         arg("absorption_params") = object(),
+         arg("raw_projected_intensity_out"),
+         arg("projected_intensity_out"),
+         arg("projected_background_out"),
+         arg("tof_z_out"),
+         arg("apply_lorentz_correction")));
+
+    def("calculate_line_profile_for_reflection",
+        &calculate_line_profile_for_reflection_1d_wrapper,
+        (arg("reflection"),
+         arg("experiment"),
+         arg("data"),
+         arg("incident_params"),
+         arg("absorption_params"),
+         arg("raw_projected_intensity_out"),
+         arg("projected_intensity_out"),
+         arg("projected_background_out"),
+         arg("tof_z_out"),
+         arg("line_profile_out"),
+         arg("apply_lorentz_correction"),
+         arg("profile_params_1d_ibix")));
 
     def("calculate_line_profile_for_reflection_3d",
-        static_cast<boost::python::tuple (*)(dials::af::reflection_table&,
-                                             dxtbx::model::Experiment&,
-                                             dxtbx::ImageSequence&,
-                                             scitbx::af::shared<vec3<double> >,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             const bool&,
-                                             TOFProfile3DGutmannParams&)>(
-          &calculate_line_profile_for_reflection_3d));
-
-    def("calculate_line_profile_for_reflection",
-        static_cast<boost::python::tuple (*)(dials::af::reflection_table&,
-                                             dxtbx::model::Experiment&,
-                                             dxtbx::ImageSequence&,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             scitbx::af::shared<double>,
-                                             const bool&,
-                                             TOFProfile1DIBIXParams&)>(
-          &calculate_line_profile_for_reflection));
-
-    def("calculate_line_profile_for_reflection",
-        static_cast<boost::python::tuple (*)(
-          dials::af::reflection_table&,
-          dxtbx::model::Experiment&,
-          dxtbx::ImageSequence&,
-          const dials_scaling::TOFIncidentSpectrumParams&,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          const bool&)>(&calculate_line_profile_for_reflection));
-
-    def("calculate_line_profile_for_reflection",
-        static_cast<boost::python::tuple (*)(
-          dials::af::reflection_table&,
-          dxtbx::model::Experiment&,
-          dxtbx::ImageSequence&,
-          const dials_scaling::TOFIncidentSpectrumParams&,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          const bool&,
-          TOFProfile1DIBIXParams&)>(&calculate_line_profile_for_reflection));
-
-    def("calculate_line_profile_for_reflection",
-        static_cast<boost::python::tuple (*)(
-          dials::af::reflection_table&,
-          dxtbx::model::Experiment&,
-          dxtbx::ImageSequence&,
-          const dials_scaling::TOFIncidentSpectrumParams&,
-          const dials_scaling::TOFAbsorptionParams&,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          const bool&)>(&calculate_line_profile_for_reflection));
-
-    def("calculate_line_profile_for_reflection",
-        static_cast<boost::python::tuple (*)(
-          dials::af::reflection_table&,
-          dxtbx::model::Experiment&,
-          dxtbx::ImageSequence&,
-          const dials_scaling::TOFIncidentSpectrumParams&,
-          const dials_scaling::TOFAbsorptionParams&,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          scitbx::af::shared<double>,
-          const bool&,
-          TOFProfile1DIBIXParams&)>(&calculate_line_profile_for_reflection));
+        &calculate_line_profile_for_reflection_3d_wrapper,
+        (arg("reflection"),
+         arg("experiment"),
+         arg("data"),
+         arg("incident_params"),
+         arg("absorption_params"),
+         arg("raw_projected_intensity_out"),
+         arg("projected_intensity_out"),
+         arg("projected_background_out"),
+         arg("tof_z_out"),
+         arg("apply_lorentz_correction"),
+         arg("profile_params_3d_gutmann")));
   }
 
 }}}  // namespace dials::algorithms::boost_python

--- a/src/dials/algorithms/integration/tof/tof_integration.h
+++ b/src/dials/algorithms/integration/tof/tof_integration.h
@@ -1,6 +1,8 @@
 #ifndef DIALS_ALGORITHMS_INTEGRATION_TOF_INTEGRATION_H
 #define DIALS_ALGORITHMS_INTEGRATION_TOF_INTEGRATION_H
 
+#include <memory>
+#include <boost/optional.hpp>
 #include <dxtbx/imageset.h>
 #include <dxtbx/format/image.h>
 #include <dxtbx/array_family/flex_table.h>
@@ -46,371 +48,120 @@ namespace dials { namespace algorithms {
   using scitbx::constants::pi;
   using scitbx::constants::Planck;
 
-  void integrate_reflection_table(
-    dials::af::reflection_table& reflection_table,
-    Experiment& experiment,
-    ImageSequence& data,
-    const bool& apply_lorentz_correction,
-    int n_threads,
-    boost::optional<TOFProfile1DIBIXParams> profile_params_1d_ibix = boost::none,
-    boost::optional<TOFProfile3DGutmannParams> profile_params_3d_gutmann =
-      boost::none) {
-    /*
-     * Updates reflection_table with intensities and variances with
-     * optional Lorentz correction
-     */
+  // Holds information common to different shoeboxes
+  struct TOFGeometryContext {
+    Detector detector;
+    vec3<double> unit_s0;
+    double sample_to_source_distance;
+    scitbx::af::shared<double> img_tof;
+    vec2<std::size_t> image_size;
+    int n_panels;
 
-    // Only one profile fitting method allowed
-    DIALS_ASSERT(!(profile_params_1d_ibix && profile_params_3d_gutmann));
+    TOFGeometryContext(Experiment& experiment, ImageSequence& data)
+        : detector(*experiment.get_detector()) {
+      Scan scan = *experiment.get_scan();
 
-    std::size_t n_reflections = reflection_table.size();
+      std::shared_ptr<dxtbx::model::BeamBase> beam_ptr = experiment.get_beam();
+      std::shared_ptr<PolychromaticBeam> beam =
+        std::dynamic_pointer_cast<PolychromaticBeam>(beam_ptr);
+      DIALS_ASSERT(beam != nullptr);
+      unit_s0 = beam->get_unit_s0();
+      sample_to_source_distance = beam->get_sample_to_source_distance();
 
-    Detector detector = *experiment.get_detector();
-    Scan scan = *experiment.get_scan();
+      img_tof = scan.get_property<double>("time_of_flight");
 
-    // Required beam params
-    std::shared_ptr<dxtbx::model::BeamBase> beam_ptr = experiment.get_beam();
-    std::shared_ptr<PolychromaticBeam> beam =
-      std::dynamic_pointer_cast<PolychromaticBeam>(beam_ptr);
-    DIALS_ASSERT(beam != nullptr);
-    vec3<double> unit_s0 = beam->get_unit_s0();
-    double sample_to_source_distance = beam->get_sample_to_source_distance();
+      n_panels = detector.size();
+      int num_images = data.size();
+      image_size = detector[0].get_image_size();
+      DIALS_ASSERT(num_images == img_tof.size());
+    }
+  };
 
-    // Required scan params
-    scitbx::af::shared<double> img_tof = scan.get_property<double>("time_of_flight");
+  // First pass over a shoebox counts foreground/background pixels
+  struct ShoeboxPixelCount {
+    bool success = true;
+    int n_signal = 0;
+    int n_background = 0;
+    scitbx::af::shared<double> incident_spectrum;
+    scitbx::af::shared<double> empty_spectrum;
+    scitbx::af::shared<std::size_t> n_contrib;
+  };
 
-    // Required detector params
-    int n_panels = detector.size();
-    int num_images = data.size();
-    vec2<std::size_t> image_size = detector[0].get_image_size();
-    DIALS_ASSERT(num_images == img_tof.size());
-
-    dials::af::shared<Shoebox<>> shoeboxes = reflection_table["shoebox"];
-    dials::af::shared<std::size_t> refl_flags =
-      reflection_table.get<std::size_t>("flags");
-    dials::af::const_ref<int6> bboxes = reflection_table["bbox"];
-
-    // Arrays to store ouput of integration
-    dials::af::shared<bool> succeeded(reflection_table.size());
-    dials::af::shared<double> intensities(reflection_table.size());
-    dials::af::shared<double> variances(reflection_table.size());
-    dials::af::shared<bool> succeeded_prf;
-    dials::af::shared<double> intensities_prf;
-    dials::af::shared<double> variances_prf;
-
-    if (profile_params_1d_ibix || profile_params_3d_gutmann) {
-      succeeded_prf.resize(reflection_table.size());
-      intensities_prf.resize(reflection_table.size());
-      variances_prf.resize(reflection_table.size());
+  inline ShoeboxPixelCount scan_shoebox_pixels(
+    const Shoebox<>& shoebox,
+    const int6& bbox,
+    const vec2<std::size_t>& image_size,
+    const Shoebox<>* incident_shoebox = nullptr,
+    const Shoebox<>* empty_shoebox = nullptr) {
+    ShoeboxPixelCount result;
+    bool has_incident = incident_shoebox != nullptr;
+    if (has_incident) {
+      result.incident_spectrum = scitbx::af::shared<double>(shoebox.zsize(), 0.0);
+      result.empty_spectrum = scitbx::af::shared<double>(shoebox.zsize(), 0.0);
+      result.n_contrib = scitbx::af::shared<std::size_t>(shoebox.zsize(), 0);
     }
 
     int bg_code = Valid | Background | BackgroundUsed;
 
-    auto worker = [&](std::size_t start, std::size_t end) {
-      for (std::size_t i = start; i < end; ++i) {
-        if (refl_flags[i] & dials::af::DontIntegrate) {
+    // Shoebox data are ordered (z, y, x)
+    for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
+      if (!result.success) {
+        break;
+      }
+      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
+        int panel_y = bbox[2] + y;
+        if (panel_y > image_size[1] || panel_y < 0) {
           continue;
         }
-        Shoebox<> shoebox = shoeboxes[i];
-        int6 bbox = bboxes[i];
-        int panel = shoebox.panel;
-
-        bool success = true;
-        int n_background = 0;
-        int n_signal = 0;
-        double intensity = 0.0;
-        double variance = 0.0;
-
-        // First pass to get, n_signal, n_background
-        // Shoebox data are ordered (z, y, x)
-        for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-          if (!success) {
-            break;
+        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
+          int panel_x = bbox[0] + x;
+          if (panel_x > image_size[0] || panel_x < 0) {
+            continue;
           }
-          for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-            int panel_y = bbox[2] + y;
-            if (panel_y > image_size[1] || panel_y < 0) {
-              continue;
+
+          if (has_incident) {
+            result.incident_spectrum[z] += incident_shoebox->data(z, y, x);
+            result.empty_spectrum[z] += empty_shoebox->data(z, y, x);
+            result.n_contrib[z]++;
+          }
+
+          int mask = shoebox.mask(z, y, x);
+          if ((mask & Foreground) == Foreground) {
+            if ((mask & Valid) == Valid && (mask & Overlapped) == 0) {
+              result.n_signal++;
+            } else {
+              result.success = false;
             }
-            for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-              int panel_x = bbox[0] + x;
-              if (panel_x > image_size[0] || panel_x < 0) {
-                continue;
-              }
-
-              int mask = shoebox.mask(z, y, x);
-              if ((mask & Foreground) == Foreground) {
-                if ((mask & Valid) == Valid && (mask & Overlapped) == 0) {
-                  n_signal++;
-                } else {
-                  success = false;
-                }
-              } else if ((mask & bg_code) == bg_code) {
-                n_background++;
-              }
-            }
+          } else if ((mask & bg_code) == bg_code) {
+            result.n_background++;
           }
-        }
-
-        // 1D profile fitting params
-        scitbx::af::shared<double> tof_z(shoebox.zsize(), 0.0);
-        scitbx::af::shared<double> projected_intensity(shoebox.zsize(), 0.0);
-
-        // 3D profile fitting params done in xyz
-        auto acc = shoebox.data.accessor();
-        af::c_grid<3> transposed_acc(acc[2], acc[1], acc[0]);
-        scitbx::af::versa<double, af::c_grid<3>> intensity_3d(transposed_acc);
-        scitbx::af::versa<double, af::c_grid<3>> background_var_3d(transposed_acc);
-        scitbx::af::versa<vec3<double>, af::c_grid<3>> coords_3d(transposed_acc);
-
-        // Second pass to perform actual integration
-        for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-          double intensity_z = 0;
-
-          if (!success) {
-            break;
-          }
-
-          int frame_z = bbox[4] + z;
-          double tof = img_tof[frame_z];
-          tof_z[z] = tof;           // (μs)
-          tof *= std::pow(10, -6);  // (s)
-
-          for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-            int panel_y = bbox[2] + y;
-
-            // Bounds check
-            if (panel_y > image_size[1] || panel_y < 0) {
-              continue;
-            }
-
-            for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-              int panel_x = bbox[0] + x;
-
-              // Bounds check
-              if (panel_x > image_size[0] || panel_x < 0) {
-                continue;
-              }
-
-              // Raw counts
-              double raw_S = shoebox.data(z, y, x);
-              double raw_B = shoebox.background(z, y, x);
-              int mask = shoebox.mask(z, y, x);
-
-              // Variances
-              double var_S = std::abs(raw_S);
-              double var_B = std::abs(var_B);
-              if (n_background > 0) {
-                var_B *= (1.0 + double(n_signal) / double(n_background));
-              }
-
-              double L;
-
-              // Lorentz correction
-              if (apply_lorentz_correction) {
-                scitbx::vec3<double> s1 = detector[panel].get_pixel_lab_coord(
-                  scitbx::vec2<double>(panel_x, panel_y));
-                double distance = s1.length() + sample_to_source_distance;
-                distance *= std::pow(10, -3);  // (m)
-                double wl = ((Planck * tof) / (m_n * (distance))) * std::pow(10, 10);
-                double two_theta = detector[panel].get_two_theta_at_pixel(
-                  unit_s0, scitbx::vec2<double>(panel_x, panel_y));
-                double sin_two_theta_sq = std::pow(sin(two_theta * .5), 2);
-                L = sin_two_theta_sq / std::pow(wl, 4);
-              }
-
-              // Account for some data having different sized bin widths
-              double bin_width_correction = img_tof[frame_z] - img_tof[frame_z - 1];
-
-              // Net signal
-              double I0 = raw_S - raw_B;
-              double var_I0 = var_S + var_B;
-
-              double I = I0 / bin_width_correction;
-              double B = raw_B / bin_width_correction;
-              double var_I = var_I0 / (bin_width_correction * bin_width_correction);
-              var_B /= (bin_width_correction * bin_width_correction);
-
-              if (apply_lorentz_correction) {
-                I *= L;
-                B *= L;
-                var_I *= (L * L);
-                var_B *= (L * L);
-              }
-
-              intensity_z += I;
-
-              if (profile_params_3d_gutmann) {
-                intensity_3d(x, y, z) = I;
-                background_var_3d(x, y, z) = var_B;
-                double x_c = x + shoebox.xoffset() + 0.5;
-                double y_c = y + shoebox.yoffset() + 0.5;
-                double z_c = z + shoebox.zoffset() + 0.5;
-                coords_3d(x, y, z) = vec3<double>(x_c, y_c, z_c);
-              }
-
-              // Accumulate summation values if pixel in foreground and valid
-              if ((mask & Foreground) == Foreground && (mask & Valid) == Valid
-                  && (mask & Overlapped) == 0) {
-                intensity += I;
-                variance += var_I;
-              } else if ((mask & Foreground) == Foreground) {
-                success = false;
-                break;
-              }
-            }
-          }
-
-          if (profile_params_1d_ibix) {  // Doing 1D profile fitting
-            projected_intensity[z] = intensity_z;
-          }
-        }
-
-        // Overall values for shoebox summation
-        succeeded[i] = success;
-        intensities[i] = intensity;
-        variances[i] = variance;
-
-        if (profile_params_1d_ibix && success) {
-          bool profile_success = false;
-          double I_prf;
-          profile_success = fit_profile_1d_ibix(projected_intensity.const_ref(),
-                                                tof_z.const_ref(),
-                                                *profile_params_1d_ibix,
-                                                I_prf);
-          if (profile_success) {
-            intensities_prf[i] = I_prf;
-            variances_prf[i] = variance;  // Use summation variance as approximation
-          }
-          succeeded_prf[i] = profile_success;
-
-        } else if (profile_params_3d_gutmann && success) {
-          bool profile_success = false;
-
-          double I_prf, var_prf;
-          profile_success = fit_profile_3d_gutmann(coords_3d.const_ref(),
-                                                   intensity_3d,
-                                                   background_var_3d,
-                                                   *profile_params_3d_gutmann,
-                                                   I_prf);
-          if (profile_success) {
-            intensities_prf[i] = I_prf;
-            variances_prf[i] = variance;  // Use summation variance as approximation
-          }
-          succeeded_prf[i] = profile_success;
-        }
-      }
-    };
-
-    dials::util::ThreadPool pool(n_threads);
-    std::size_t chunk_size = (n_reflections + n_threads - 1) / n_threads;
-
-    for (int t = 0; t < n_threads; ++t) {
-      std::size_t start = t * chunk_size;
-      std::size_t end = std::min(start + chunk_size, n_reflections);
-      if (start >= end) break;
-
-      pool.post([=]() { worker(start, end); });
-    }
-
-    pool.wait();
-
-    reflection_table["intensity.sum.value"] = intensities;
-    reflection_table["intensity.sum.variance"] = variances;
-
-    if (profile_params_1d_ibix || profile_params_3d_gutmann) {
-      reflection_table["intensity.prf.value"] = intensities_prf;
-      reflection_table["intensity.prf.variance"] = variances_prf;
-    }
-
-    // Update flags
-    dials::af::ref<std::size_t> flags =
-      reflection_table.get<std::size_t>("flags").ref();
-    for (std::size_t i = 0; i < flags.size(); ++i) {
-      if (succeeded[i]) {
-        flags[i] &= ~dials::af::FailedDuringSummation;
-        flags[i] |= dials::af::IntegratedSum;
-      } else {
-        flags[i] &= ~dials::af::IntegratedSum;
-        flags[i] |= dials::af::FailedDuringSummation;
-      }
-      if (profile_params_1d_ibix || profile_params_3d_gutmann) {
-        if (succeeded_prf[i]) {
-          flags[i] &= ~dials::af::FailedDuringProfileFitting;
-          flags[i] |= dials::af::IntegratedPrf;
-        } else {
-          flags[i] &= ~dials::af::IntegratedPrf;
-          flags[i] |= dials::af::FailedDuringProfileFitting;
         }
       }
     }
+    return result;
   }
 
-  void integrate_reflection_table(
+  // Loads imagesequence data into reflection shoeboxes
+  inline dials::af::reflection_table load_shoebox_image_data(
     dials::af::reflection_table& reflection_table,
-    Experiment& experiment,
-    ImageSequence& data,
-    const dials_scaling::TOFIncidentSpectrumParams& incident_params,
-    const bool& apply_lorentz_correction,
-    int n_threads,
-    boost::optional<TOFProfile1DIBIXParams> profile_params_1d_ibix = boost::none,
-    boost::optional<TOFProfile3DGutmannParams> profile_params_3d_gutmann =
-      boost::none) {
-    /*
-     * Updates reflection_table with intensities and variances corrected by
-     * incident and empty runs, and an optional Lorentz correction
-     */
-
-    // Only one profile fitting method allowed
-    DIALS_ASSERT(!(profile_params_1d_ibix && profile_params_3d_gutmann));
-
-    std::size_t n_reflections = reflection_table.size();
-    Detector detector = *experiment.get_detector();
-    Scan scan = *experiment.get_scan();
-
-    // Required beam params
-    std::shared_ptr<dxtbx::model::BeamBase> beam_ptr = experiment.get_beam();
-    std::shared_ptr<PolychromaticBeam> beam =
-      std::dynamic_pointer_cast<PolychromaticBeam>(beam_ptr);
-    DIALS_ASSERT(beam != nullptr);
-    vec3<double> unit_s0 = beam->get_unit_s0();
-    double sample_to_source_distance = beam->get_sample_to_source_distance();
-
-    // Required scan params
-    scitbx::af::shared<double> img_tof = scan.get_property<double>("time_of_flight");
-
-    // Required detector params
-    int n_panels = detector.size();
-    int num_images = data.size();
-    vec2<std::size_t> image_size = detector[0].get_image_size();
-    DIALS_ASSERT(num_images == img_tof.size());
-
-    // Copy reflections for incident and empty runs
+    std::shared_ptr<ImageSequence> reference_data,
+    int n_panels,
+    int num_images) {
     boost::python::dict d;
-    dials::af::reflection_table i_reflection_table =
-      dxtbx::af::flex_table_suite::deepcopy(reflection_table, d);
-    dials::af::reflection_table e_reflection_table =
+    dials::af::reflection_table ref_table =
       dxtbx::af::flex_table_suite::deepcopy(reflection_table, d);
 
-    dials::af::ref<Shoebox<>> i_shoeboxes = i_reflection_table["shoebox"];
-    dials::af::ref<Shoebox<>> e_shoeboxes = e_reflection_table["shoebox"];
-    for (std::size_t i = 0; i < i_reflection_table.size(); ++i) {
-      i_shoeboxes[i].deallocate();
-      e_shoeboxes[i].deallocate();
+    dials::af::ref<Shoebox<>> ref_shoeboxes = ref_table["shoebox"];
+    for (std::size_t i = 0; i < ref_table.size(); ++i) {
+      ref_shoeboxes[i].deallocate();
     }
 
-    ShoeboxProcessor incident_shoebox_processor(
-      i_reflection_table, n_panels, 0, num_images, false);
+    ShoeboxProcessor processor(ref_table, n_panels, 0, num_images, false);
 
-    ShoeboxProcessor empty_shoebox_processor(
-      e_reflection_table, n_panels, 0, num_images, false);
-
-    // Get shoeboxes for incident data
-    for (std::size_t img_num = 0; img_num < num_images; ++img_num) {
-      dxtbx::format::Image<double> img =
-        incident_params.incident_data->get_corrected_data(img_num);
-      dxtbx::format::Image<bool> mask =
-        incident_params.incident_data->get_mask(img_num);
+    for (std::size_t img_num = 0; img_num < static_cast<std::size_t>(num_images);
+         ++img_num) {
+      dxtbx::format::Image<double> img = reference_data->get_corrected_data(img_num);
+      dxtbx::format::Image<bool> mask = reference_data->get_mask(img_num);
 
       dials::af::shared<scitbx::af::versa<double, scitbx::af::c_grid<2>>> output_data(
         n_panels);
@@ -421,419 +172,386 @@ namespace dials { namespace algorithms {
         output_data[i] = img.tile(i).data();
         output_mask[i] = mask.tile(i).data();
       }
-      incident_shoebox_processor.next_data_only(
+      processor.next_data_only(
         dials::model::Image<double>(output_data.const_ref(), output_mask.const_ref()));
     }
 
-    // Get shoeboxes for empty data
-    for (std::size_t img_num = 0; img_num < num_images; ++img_num) {
-      dxtbx::format::Image<double> img =
-        incident_params.empty_data->get_corrected_data(img_num);
-      dxtbx::format::Image<bool> mask = incident_params.empty_data->get_mask(img_num);
-
-      dials::af::shared<scitbx::af::versa<double, scitbx::af::c_grid<2>>> output_data(
-        n_panels);
-      dials::af::shared<scitbx::af::versa<bool, scitbx::af::c_grid<2>>> output_mask(
-        n_panels);
-
-      for (std::size_t i = 0; i < output_data.size(); ++i) {
-        output_data[i] = img.tile(i).data();
-        output_mask[i] = mask.tile(i).data();
-      }
-      empty_shoebox_processor.next_data_only(
-        dials::model::Image<double>(output_data.const_ref(), output_mask.const_ref()));
-    }
-
-    dials::af::shared<Shoebox<>> shoeboxes = reflection_table["shoebox"];
-    dials::af::shared<std::size_t> refl_flags =
-      reflection_table.get<std::size_t>("flags");
-    dials::af::const_ref<int6> bboxes = reflection_table["bbox"];
-
-    // Arrays to store ouput of integration
-    dials::af::shared<bool> succeeded(reflection_table.size());
-    dials::af::shared<double> intensities(reflection_table.size());
-    dials::af::shared<double> variances(reflection_table.size());
-    dials::af::shared<bool> succeeded_prf;
-    dials::af::shared<double> intensities_prf;
-    dials::af::shared<double> variances_prf;
-
-    if (profile_params_1d_ibix || profile_params_3d_gutmann) {
-      succeeded_prf.resize(reflection_table.size());
-      intensities_prf.resize(reflection_table.size());
-      variances_prf.resize(reflection_table.size());
-    }
-
-    int bg_code = Valid | Background | BackgroundUsed;
-
-    auto worker = [&](std::size_t start, std::size_t end) {
-      for (std::size_t i = start; i < end; ++i) {
-        if (refl_flags[i] & dials::af::DontIntegrate) {
-          continue;
-        }
-        Shoebox<> shoebox = shoeboxes[i];
-        Shoebox<> i_shoebox = i_shoeboxes[i];
-        Shoebox<> e_shoebox = e_shoeboxes[i];
-        int6 bbox = bboxes[i];
-        int panel = shoebox.panel;
-
-        bool success = true;
-        int n_background = 0;
-        int n_signal = 0;
-        double intensity = 0.0;
-        double variance = 0.0;
-
-        // First pass to get, n_signal, n_background, incident spectrum, empty spectrum
-        // Shoebox data are ordered (z, y, x)
-        scitbx::af::shared<double> incident_spectrum(shoebox.zsize(), 0.0);
-        scitbx::af::shared<double> empty_spectrum(shoebox.zsize(), 0.0);
-        scitbx::af::shared<std::size_t> n_contrib(shoebox.zsize(), 0);
-
-        for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-          if (!success) {
-            break;
-          }
-          for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-            int panel_y = bbox[2] + y;
-            if (panel_y > image_size[1] || panel_y < 0) {
-              continue;
-            }
-            for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-              int panel_x = bbox[0] + x;
-              if (panel_x > image_size[0] || panel_x < 0) {
-                continue;
-              }
-
-              incident_spectrum[z] += i_shoebox.data(z, y, x);
-              empty_spectrum[z] += e_shoebox.data(z, y, x);
-              n_contrib[z]++;
-
-              int mask = shoebox.mask(z, y, x);
-              if ((mask & Foreground) == Foreground) {
-                if ((mask & Valid) == Valid && (mask & Overlapped) == 0) {
-                  n_signal++;
-                } else {
-                  success = false;
-                }
-              } else if ((mask & bg_code) == bg_code) {
-                n_background++;
-              }
-            }
-          }
-        }
-
-        // Smooth incident and empty to avoid dividing by a noisy signal
-        scitbx::af::shared<double> smoothed_empty =
-          dials_scaling::savitzky_golay(empty_spectrum, 7, 2);
-        scitbx::af::shared<double> smoothed_incident =
-          dials_scaling::savitzky_golay(incident_spectrum, 7, 2);
-
-        // 1D profile fitting params
-        scitbx::af::shared<double> tof_z(shoebox.zsize(), 0.0);
-        scitbx::af::shared<double> projected_intensity(shoebox.zsize(), 0.0);
-
-        // 3D profile fitting params done in xyz
-        auto acc = shoebox.data.accessor();
-        af::c_grid<3> transposed_acc(acc[2], acc[1], acc[0]);
-        scitbx::af::versa<double, af::c_grid<3>> intensity_3d(transposed_acc);
-        scitbx::af::versa<double, af::c_grid<3>> background_var_3d(transposed_acc);
-        scitbx::af::versa<vec3<double>, af::c_grid<3>> coords_3d(transposed_acc);
-
-        // Second pass to perform actual integration
-        for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-          double intensity_z = 0;
-
-          if (!success) {
-            break;
-          }
-
-          int frame_z = bbox[4] + z;
-          double tof = img_tof[frame_z];
-          tof_z[z] = tof;
-          tof *= std::pow(10, -6);  // (s)
-
-          for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-            int panel_y = bbox[2] + y;
-            // Bounds check
-            if (panel_y > image_size[1] || panel_y < 0) {
-              continue;
-            }
-            for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-              int panel_x = bbox[0] + x;
-              // Bounds check
-              if (panel_x > image_size[0] || panel_x < 0) {
-                continue;
-              }
-
-              // Raw counts
-              double raw_S = shoebox.data(z, y, x);
-              double raw_B = shoebox.background(z, y, x);
-              double n = n_contrib[z];
-              double raw_J = smoothed_incident[z] / n;
-              double raw_E = smoothed_empty[z] / n;
-              int mask = shoebox.mask(z, y, x);
-
-              // Normalize by proton charge
-              double sample_pc = incident_params.sample_proton_charge;
-              double incident_pc = incident_params.incident_proton_charge;
-              double empty_pc = incident_params.empty_proton_charge;
-              double S = raw_S / sample_pc;
-              double B = raw_B / sample_pc;
-              double J = raw_J / incident_pc;
-              double E = raw_E / empty_pc;
-
-              // Variances
-              double var_S = std::abs(raw_S) / (sample_pc * sample_pc);
-              double var_B = std::abs(raw_B) / (sample_pc * sample_pc);
-              if (n_background > 0) {
-                var_B *= (1.0 + double(n_signal) / double(n_background));
-              }
-              double var_J =
-                (std::abs(raw_J) * n) / (incident_pc * incident_pc * n * n);
-              double var_E = (std::abs(raw_E) * n) / (empty_pc * empty_pc * n * n);
-
-              // Lorentz correction
-              double L;
-              if (apply_lorentz_correction) {
-                scitbx::vec3<double> s1 = detector[panel].get_pixel_lab_coord(
-                  scitbx::vec2<double>(panel_x, panel_y));
-                double distance = s1.length() + sample_to_source_distance;
-                distance *= std::pow(10, -3);  // (m)
-                double wl = ((Planck * tof) / (m_n * (distance))) * std::pow(10, 10);
-                double two_theta = detector[panel].get_two_theta_at_pixel(
-                  unit_s0, scitbx::vec2<double>(panel_x, panel_y));
-                double sin_two_theta_sq = std::pow(sin(two_theta * .5), 2);
-                L = sin_two_theta_sq / std::pow(wl, 4);
-              }
-
-              // Net signal
-              double I0 = S - B - E;
-              double var_I0 = var_S + var_B + var_E;
-
-              // Apply Lorentz correction and normalise by incident spectrum
-              // (bin_width correction not needed as this cancels with incident spectrum
-              // division)
-              double I, var_I;
-              if (apply_lorentz_correction) {
-                I = L * I0 / J;
-                B *= L / J;
-                // Var( L*I0/J ) = (L/J)^2 Var(I0) + (L*I0/J^2)^2 Var(J)
-                var_I = (L * L / (J * J)) * var_I0
-                        + (L * L * I0 * I0 / (J * J * J * J)) * var_J;
-                var_B =
-                  (L * L / (J * J)) * var_B + (L * L * B * B / (J * J * J * J)) * var_J;
-              } else {
-                I = I0 / J;
-                B /= J;
-                // Var( I0/J ) = (1/J)^2 Var(I0) + (I0/J^2)^2 Var(J)
-                var_I = (1 / (J * J)) * var_I0 + (I0 * I0 / (J * J * J * J)) * var_J;
-                var_B = (1 / (J * J)) * var_B + (B * B / (J * J * J * J)) * var_J;
-              }
-
-              intensity_z += I;
-
-              if (profile_params_3d_gutmann) {
-                intensity_3d(x, y, z) = I;
-                background_var_3d(x, y, z) = var_B;
-                double x_c = x + shoebox.xoffset() + 0.5;
-                double y_c = y + shoebox.yoffset() + 0.5;
-                double z_c = z + shoebox.zoffset() + 0.5;
-                coords_3d(x, y, z) = vec3<double>(x_c, y_c, z_c);
-              }
-
-              // Accumulate summation values if pixel in foreground and valid
-              if ((mask & Foreground) == Foreground && (mask & Valid) == Valid
-                  && (mask & Overlapped) == 0) {
-                intensity += I;
-                variance += var_I;
-              } else if ((mask & Foreground) == Foreground) {
-                success = false;
-                break;
-              }
-            }
-          }
-          if (profile_params_1d_ibix) {
-            projected_intensity[z] = intensity_z;
-          }
-        }
-
-        // Overall values for shoebox summation
-        succeeded[i] = success;
-        intensities[i] = intensity;
-        variances[i] = variance;
-
-        if (profile_params_1d_ibix) {
-          bool profile_success = false;
-          double I_prf;
-          profile_success = fit_profile_1d_ibix(projected_intensity.const_ref(),
-                                                tof_z.const_ref(),
-                                                *profile_params_1d_ibix,
-                                                I_prf);
-          if (profile_success) {
-            intensities_prf[i] = I_prf;
-            variances_prf[i] = variance;  // Use summation variance as approximation
-          }
-          succeeded_prf[i] = profile_success;
-        } else if (profile_params_3d_gutmann) {
-          bool profile_success = false;
-
-          double I_prf, var_prf;
-          profile_success = fit_profile_3d_gutmann(coords_3d.const_ref(),
-                                                   intensity_3d,
-                                                   background_var_3d,
-                                                   *profile_params_3d_gutmann,
-                                                   I_prf);
-          if (profile_success) {
-            intensities_prf[i] = I_prf;
-            variances_prf[i] = variance;  // Use summation variance as approximation
-          }
-          succeeded_prf[i] = profile_success;
-        }
-      }
-    };
-
-    dials::util::ThreadPool pool(n_threads);
-    std::size_t chunk_size = (n_reflections + n_threads - 1) / n_threads;
-
-    for (int t = 0; t < n_threads; ++t) {
-      std::size_t start = t * chunk_size;
-      std::size_t end = std::min(start + chunk_size, n_reflections);
-      if (start >= end) break;
-
-      pool.post([=]() { worker(start, end); });
-    }
-
-    pool.wait();
-
-    reflection_table["intensity.sum.value"] = intensities;
-    reflection_table["intensity.sum.variance"] = variances;
-
-    if (profile_params_1d_ibix || profile_params_3d_gutmann) {
-      reflection_table["intensity.prf.value"] = intensities_prf;
-      reflection_table["intensity.prf.variance"] = variances_prf;
-    }
-
-    // Update flags
-    dials::af::ref<std::size_t> flags =
-      reflection_table.get<std::size_t>("flags").ref();
-    for (std::size_t i = 0; i < flags.size(); ++i) {
-      if (succeeded[i]) {
-        flags[i] &= ~dials::af::FailedDuringSummation;
-        flags[i] |= dials::af::IntegratedSum;
-      } else {
-        flags[i] &= ~dials::af::IntegratedSum;
-        flags[i] |= dials::af::FailedDuringSummation;
-      }
-      if (profile_params_1d_ibix || profile_params_3d_gutmann) {
-        if (succeeded_prf[i]) {
-          flags[i] &= ~dials::af::FailedDuringProfileFitting;
-          flags[i] |= dials::af::IntegratedPrf;
-        } else {
-          flags[i] &= ~dials::af::IntegratedPrf;
-          flags[i] |= dials::af::FailedDuringProfileFitting;
-        }
-      }
-    }
+    return ref_table;
   }
 
-  void integrate_reflection_table(
+  struct PixelCorrection {
+    double I = 0;
+    double B = 0;
+    double var_I = 0;
+    double var_B = 0;
+    double I_raw = 0;
+  };
+
+  class PixelCorrector {
+  public:
+    PixelCorrector(const TOFGeometryContext& geometry,
+                   bool apply_lorentz_correction,
+                   int n_signal,
+                   int n_background,
+                   const dials_scaling::TOFIncidentSpectrumParams* incident_params,
+                   const dials_scaling::TOFAbsorptionParams* absorption_params,
+                   const scitbx::af::shared<double>* smoothed_incident,
+                   const scitbx::af::shared<double>* smoothed_empty,
+                   const scitbx::af::shared<std::size_t>* n_contrib)
+        : geometry_(geometry),
+          apply_lorentz_correction_(apply_lorentz_correction),
+          n_signal_(n_signal),
+          n_background_(n_background),
+          incident_params_(incident_params),
+          absorption_params_(absorption_params),
+          smoothed_incident_(smoothed_incident),
+          smoothed_empty_(smoothed_empty),
+          n_contrib_(n_contrib) {}
+
+    // Returns false if the pixel cannot be corrected and should be skipped
+    bool correct(int panel,
+                 int panel_x,
+                 int panel_y,
+                 int frame_z,
+                 std::size_t z,
+                 double tof_us,
+                 double raw_S,
+                 double raw_B,
+                 PixelCorrection& out) const {
+      double tof_s = tof_us * std::pow(10, -6);
+
+      double var_S = std::abs(raw_S);
+      double var_B = std::abs(raw_B);
+      if (n_background_ > 0) {
+        var_B *= (1.0 + double(n_signal_) / double(n_background_));
+      }
+
+      bool has_incident = incident_params_ != nullptr;
+      bool has_absorption = absorption_params_ != nullptr;
+
+      // wl/two_theta are needed for the Lorentz correction and for the
+      // absorption correction, so compute them once if either is active.
+      double wl = 0.0, two_theta = 0.0, L = 1.0;
+      if (apply_lorentz_correction_ || has_absorption) {
+        scitbx::vec3<double> s1 = geometry_.detector[panel].get_pixel_lab_coord(
+          scitbx::vec2<double>(panel_x, panel_y));
+        double distance =
+          (s1.length() + geometry_.sample_to_source_distance) * std::pow(10, -3);
+        wl = ((Planck * tof_s) / (m_n * distance)) * std::pow(10, 10);
+        two_theta = geometry_.detector[panel].get_two_theta_at_pixel(
+          geometry_.unit_s0, scitbx::vec2<double>(panel_x, panel_y));
+        if (apply_lorentz_correction_) {
+          double sin_two_theta_sq = std::pow(sin(two_theta * .5), 2);
+          L = sin_two_theta_sq / std::pow(wl, 4);
+        }
+      }
+
+      // Spherical absorption correction
+      double T = 1.0;
+      int two_theta_idx = 0;
+      if (has_absorption) {
+        double two_theta_deg = two_theta * (180.0 / pi);
+        two_theta_idx = static_cast<int>(two_theta_deg / 10);
+        double sample_muR =
+          (absorption_params_->sample_linear_scattering_c
+           + (absorption_params_->sample_linear_absorption_c / 1.8) * wl)
+          * absorption_params_->sample_radius;
+        T = dials_scaling::tof_pixel_spherical_absorption_correction(
+          sample_muR, two_theta, two_theta_idx);
+        if (T < 1e-7) {
+          return false;
+        }
+      }
+
+      double I0, var_I0, I_raw, B, var_B_pre;
+      double J = 1.0, var_J = 0.0;
+
+      // Bin-width normalisation is used when there is no incident/empty
+      if (!has_incident) {
+        double bin_width = geometry_.img_tof[frame_z] - geometry_.img_tof[frame_z - 1];
+        I0 = (raw_S - raw_B) / bin_width;
+        var_I0 = (var_S + var_B) / (bin_width * bin_width);
+        I_raw = raw_S / bin_width;
+        B = raw_B / bin_width;
+        var_B_pre = var_B / (bin_width * bin_width);
+      } else {
+        double n = double((*n_contrib_)[z]);
+        double raw_J = (*smoothed_incident_)[z] / n;
+        double raw_E = (*smoothed_empty_)[z] / n;
+
+        double sample_pc = incident_params_->sample_proton_charge;
+        double incident_pc = incident_params_->incident_proton_charge;
+        double empty_pc = incident_params_->empty_proton_charge;
+
+        double S = raw_S / sample_pc;
+        double Bn = raw_B / sample_pc;
+        double Jn = raw_J / incident_pc;
+        double En = raw_E / empty_pc;
+
+        double var_Sn = var_S / (sample_pc * sample_pc);
+        double var_Bn = var_B / (sample_pc * sample_pc);
+        double var_Jn = (std::abs(raw_J) * n) / (incident_pc * incident_pc * n * n);
+        double var_En = (std::abs(raw_E) * n) / (empty_pc * empty_pc * n * n);
+
+        if (has_absorption) {
+          // Spherical absorption correction for the incident spectrum
+          double incident_muR =
+            (absorption_params_->incident_linear_scattering_c
+             + (absorption_params_->incident_linear_absorption_c / 1.8) * wl)
+            * absorption_params_->incident_radius;
+          double J_T = dials_scaling::tof_pixel_spherical_absorption_correction(
+            incident_muR, two_theta, two_theta_idx);
+          if (J_T < 1e-7) {
+            return false;
+          }
+          Jn /= J_T;
+          if (Jn < 1e-7) {
+            return false;
+          }
+          var_Jn /= (J_T * J_T);
+        }
+
+        I0 = S - Bn - En;
+        var_I0 = var_Sn + var_Bn + var_En;
+        I_raw = S;
+        B = Bn;
+        var_B_pre = var_Bn;
+        J = Jn;
+        var_J = var_Jn;
+      }
+
+      // Apply the Lorentz correction and normalise
+      double JT = J * T;
+      out.I = L * I0 / JT;
+      out.B = L * B / JT;
+      out.I_raw = L * I_raw / JT;
+      out.var_I =
+        (L * L / (JT * JT)) * var_I0 + (L * L * I0 * I0 / std::pow(JT, 4)) * var_J;
+      out.var_B =
+        (L * L / (JT * JT)) * var_B_pre + (L * L * B * B / std::pow(JT, 4)) * var_J;
+      return true;
+    }
+
+  private:
+    const TOFGeometryContext& geometry_;
+    bool apply_lorentz_correction_;
+    int n_signal_;
+    int n_background_;
+    const dials_scaling::TOFIncidentSpectrumParams* incident_params_;
+    const dials_scaling::TOFAbsorptionParams* absorption_params_;
+    const scitbx::af::shared<double>* smoothed_incident_;
+    const scitbx::af::shared<double>* smoothed_empty_;
+    const scitbx::af::shared<std::size_t>* n_contrib_;
+  };
+
+  struct ShoeboxIntegrationResult {
+    bool success = true;
+    double intensity = 0.0;
+    double variance = 0.0;
+    scitbx::af::shared<double> tof_z;
+    scitbx::af::shared<double> projected_intensity;
+    scitbx::af::shared<double> raw_projected_intensity;
+    scitbx::af::shared<double> projected_background;
+    scitbx::af::versa<double, af::c_grid<3>> intensity_3d;
+    scitbx::af::versa<double, af::c_grid<3>> background_var_3d;
+    scitbx::af::versa<vec3<double>, af::c_grid<3>> coords_3d;
+  };
+
+  // Second pass over a shoebox
+  // applies the pixel corrector and accumulates summation intensity/variance
+  // plus every array needed by 1D/3D profile fitting
+  inline ShoeboxIntegrationResult integrate_shoebox(const Shoebox<>& shoebox,
+                                                    const int6& bbox,
+                                                    const TOFGeometryContext& geometry,
+                                                    const PixelCorrector& corrector,
+                                                    bool initial_success = true) {
+    ShoeboxIntegrationResult result;
+    result.success = initial_success;
+    result.tof_z = scitbx::af::shared<double>(shoebox.zsize(), 0.0);
+    result.projected_intensity = scitbx::af::shared<double>(shoebox.zsize(), 0.0);
+    result.raw_projected_intensity = scitbx::af::shared<double>(shoebox.zsize(), 0.0);
+    result.projected_background = scitbx::af::shared<double>(shoebox.zsize(), 0.0);
+
+    auto acc = shoebox.data.accessor();
+    af::c_grid<3> transposed_acc(acc[2], acc[1], acc[0]);
+    result.intensity_3d = scitbx::af::versa<double, af::c_grid<3>>(transposed_acc);
+    result.background_var_3d = scitbx::af::versa<double, af::c_grid<3>>(transposed_acc);
+    result.coords_3d = scitbx::af::versa<vec3<double>, af::c_grid<3>>(transposed_acc);
+
+    int panel = shoebox.panel;
+
+    // Shoebox data are ordered (z, y, x)
+    for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
+      double intensity_z = 0;
+      double intensity_raw_z = 0;
+      double background_z = 0;
+
+      if (!result.success) {
+        break;
+      }
+
+      int frame_z = bbox[4] + z;
+      double tof = geometry.img_tof[frame_z];
+      result.tof_z[z] = tof;  // (us)
+
+      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
+        int panel_y = bbox[2] + y;
+        if (panel_y > geometry.image_size[1] || panel_y < 0) {
+          continue;
+        }
+        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
+          int panel_x = bbox[0] + x;
+          if (panel_x > geometry.image_size[0] || panel_x < 0) {
+            continue;
+          }
+
+          double raw_S = shoebox.data(z, y, x);
+          double raw_B = shoebox.background(z, y, x);
+          int mask = shoebox.mask(z, y, x);
+
+          PixelCorrection pixel;
+          if (!corrector.correct(
+                panel, panel_x, panel_y, frame_z, z, tof, raw_S, raw_B, pixel)) {
+            continue;
+          }
+
+          intensity_z += pixel.I;
+          intensity_raw_z += pixel.I_raw;
+          background_z += pixel.B;
+
+          result.intensity_3d(x, y, z) = pixel.I;
+          result.background_var_3d(x, y, z) = pixel.var_B;
+          double x_c = x + shoebox.xoffset() + 0.5;
+          double y_c = y + shoebox.yoffset() + 0.5;
+          double z_c = z + shoebox.zoffset() + 0.5;
+          result.coords_3d(x, y, z) = vec3<double>(x_c, y_c, z_c);
+
+          // Accumulate summation values if pixel in foreground and valid
+          if ((mask & Foreground) == Foreground && (mask & Valid) == Valid
+              && (mask & Overlapped) == 0) {
+            result.intensity += pixel.I;
+            result.variance += pixel.var_I;
+          } else if ((mask & Foreground) == Foreground) {
+            result.success = false;
+            break;
+          }
+        }
+      }
+
+      result.projected_intensity[z] = intensity_z;
+      result.raw_projected_intensity[z] = intensity_raw_z;
+      result.projected_background[z] = background_z;
+    }
+
+    return result;
+  }
+
+  // Profile fitting strategy
+  class ProfileFitter {
+  public:
+    virtual ~ProfileFitter() {}
+    virtual bool fit(const ShoeboxIntegrationResult& shoebox_result,
+                     double& I_prf,
+                     double& var_prf) = 0;
+  };
+
+  class Profile1DIBIXFitter : public ProfileFitter {
+  public:
+    explicit Profile1DIBIXFitter(TOFProfile1DIBIXParams params) : params_(params) {}
+
+    bool fit(const ShoeboxIntegrationResult& shoebox_result,
+             double& I_prf,
+             double& var_prf) override {
+      var_prf = shoebox_result.variance;  // Use summation variance as approximation
+      return fit_profile_1d_ibix(shoebox_result.projected_intensity.const_ref(),
+                                 shoebox_result.tof_z.const_ref(),
+                                 params_,
+                                 I_prf);
+    }
+
+  private:
+    TOFProfile1DIBIXParams params_;
+  };
+
+  class Profile3DGutmannFitter : public ProfileFitter {
+  public:
+    explicit Profile3DGutmannFitter(TOFProfile3DGutmannParams params)
+        : params_(params) {}
+
+    bool fit(const ShoeboxIntegrationResult& shoebox_result,
+             double& I_prf,
+             double& var_prf) override {
+      var_prf = shoebox_result.variance;  // Use summation variance as approximation
+      return fit_profile_3d_gutmann(shoebox_result.coords_3d.const_ref(),
+                                    shoebox_result.intensity_3d,
+                                    shoebox_result.background_var_3d,
+                                    params_,
+                                    I_prf);
+    }
+
+  private:
+    TOFProfile3DGutmannParams params_;
+  };
+
+  // Runs incident/empty scanning/smoothing for one shoebox and builds
+  // the PixelCorrector
+  struct ShoeboxCorrectorInputs {
+    ShoeboxPixelCount scan;
+    scitbx::af::shared<double> smoothed_incident;
+    scitbx::af::shared<double> smoothed_empty;
+  };
+
+  inline ShoeboxCorrectorInputs prepare_shoebox_corrector_inputs(
+    const Shoebox<>& shoebox,
+    const int6& bbox,
+    const vec2<std::size_t>& image_size,
+    const Shoebox<>* incident_shoebox,
+    const Shoebox<>* empty_shoebox) {
+    ShoeboxCorrectorInputs inputs;
+    inputs.scan =
+      scan_shoebox_pixels(shoebox, bbox, image_size, incident_shoebox, empty_shoebox);
+    if (incident_shoebox != nullptr) {
+      // Smooth incident and empty to avoid dividing by a noisy signal
+      inputs.smoothed_empty =
+        dials_scaling::savitzky_golay(inputs.scan.empty_spectrum, 7, 2);
+      inputs.smoothed_incident =
+        dials_scaling::savitzky_golay(inputs.scan.incident_spectrum, 7, 2);
+    }
+    return inputs;
+  }
+
+  // Updates reflection_table with intensities and variances corrected by
+  // any combination of an incident/empty spectrum normalisation, a
+  // spherical absorption correction, and a Lorentz correction.
+  // profile-fitted intensity is also produced if profile_fitter is
+  // given
+  inline void integrate_reflection_table(
     dials::af::reflection_table& reflection_table,
     Experiment& experiment,
     ImageSequence& data,
-    const dials_scaling::TOFIncidentSpectrumParams& incident_params,
-    const dials_scaling::TOFAbsorptionParams& corrections_data,
+    boost::optional<dials_scaling::TOFIncidentSpectrumParams> incident_params,
+    boost::optional<dials_scaling::TOFAbsorptionParams> absorption_params,
     const bool& apply_lorentz_correction,
     int n_threads,
-    boost::optional<TOFProfile1DIBIXParams> profile_params_1d_ibix = boost::none,
-    boost::optional<TOFProfile3DGutmannParams> profile_params_3d_gutmann =
-      boost::none) {
-    /*
-     * Updates reflection_table with intensities and variances corrected by
-     * incident and empty runs, a spherical absorption correction,
-     * and an optional Lorentz correction
-     */
-
-    // Only one profile fitting method allowed
-    DIALS_ASSERT(!(profile_params_1d_ibix && profile_params_3d_gutmann));
-
+    std::shared_ptr<ProfileFitter> profile_fitter = nullptr) {
     std::size_t n_reflections = reflection_table.size();
+    TOFGeometryContext geometry(experiment, data);
 
-    Detector detector = *experiment.get_detector();
-    Scan scan = *experiment.get_scan();
+    // incident and empty
+    dials::af::reflection_table i_reflection_table;
+    dials::af::reflection_table e_reflection_table;
+    dials::af::shared<Shoebox<>> i_shoeboxes;
+    dials::af::shared<Shoebox<>> e_shoeboxes;
 
-    // Required beam params
-    std::shared_ptr<dxtbx::model::BeamBase> beam_ptr = experiment.get_beam();
-    std::shared_ptr<PolychromaticBeam> beam =
-      std::dynamic_pointer_cast<PolychromaticBeam>(beam_ptr);
-    DIALS_ASSERT(beam != nullptr);
-    vec3<double> unit_s0 = beam->get_unit_s0();
-    double sample_to_source_distance = beam->get_sample_to_source_distance();
-
-    // Required scan params
-    scitbx::af::shared<double> img_tof = scan.get_property<double>("time_of_flight");
-
-    // Required detector params
-    int n_panels = detector.size();
-    int num_images = data.size();
-    vec2<std::size_t> image_size = detector[0].get_image_size();
-    DIALS_ASSERT(num_images == img_tof.size());
-
-    // Copy reflections for incident and empty runs
-    boost::python::dict d;
-    dials::af::reflection_table i_reflection_table =
-      dxtbx::af::flex_table_suite::deepcopy(reflection_table, d);
-    dials::af::reflection_table e_reflection_table =
-      dxtbx::af::flex_table_suite::deepcopy(reflection_table, d);
-
-    dials::af::ref<Shoebox<>> i_shoeboxes = i_reflection_table["shoebox"];
-    dials::af::ref<Shoebox<>> e_shoeboxes = e_reflection_table["shoebox"];
-    for (std::size_t i = 0; i < i_reflection_table.size(); ++i) {
-      i_shoeboxes[i].deallocate();
-      e_shoeboxes[i].deallocate();
-    }
-
-    ShoeboxProcessor incident_shoebox_processor(
-      i_reflection_table, n_panels, 0, num_images, false);
-
-    ShoeboxProcessor empty_shoebox_processor(
-      e_reflection_table, n_panels, 0, num_images, false);
-
-    // Get shoeboxes for incident data
-    for (std::size_t img_num = 0; img_num < num_images; ++img_num) {
-      dxtbx::format::Image<double> img =
-        incident_params.incident_data->get_corrected_data(img_num);
-      dxtbx::format::Image<bool> mask =
-        incident_params.incident_data->get_mask(img_num);
-
-      dials::af::shared<scitbx::af::versa<double, scitbx::af::c_grid<2>>> output_data(
-        n_panels);
-      dials::af::shared<scitbx::af::versa<bool, scitbx::af::c_grid<2>>> output_mask(
-        n_panels);
-
-      for (std::size_t i = 0; i < output_data.size(); ++i) {
-        output_data[i] = img.tile(i).data();
-        output_mask[i] = mask.tile(i).data();
-      }
-      incident_shoebox_processor.next_data_only(
-        dials::model::Image<double>(output_data.const_ref(), output_mask.const_ref()));
-    }
-
-    // Get shoeboxes for empty data
-    for (std::size_t img_num = 0; img_num < num_images; ++img_num) {
-      dxtbx::format::Image<double> img =
-        incident_params.empty_data->get_corrected_data(img_num);
-      dxtbx::format::Image<bool> mask = incident_params.empty_data->get_mask(img_num);
-
-      dials::af::shared<scitbx::af::versa<double, scitbx::af::c_grid<2>>> output_data(
-        n_panels);
-      dials::af::shared<scitbx::af::versa<bool, scitbx::af::c_grid<2>>> output_mask(
-        n_panels);
-
-      for (std::size_t i = 0; i < output_data.size(); ++i) {
-        output_data[i] = img.tile(i).data();
-        output_mask[i] = mask.tile(i).data();
-      }
-      empty_shoebox_processor.next_data_only(
-        dials::model::Image<double>(output_data.const_ref(), output_mask.const_ref()));
+    if (incident_params) {
+      i_reflection_table = load_shoebox_image_data(reflection_table,
+                                                   incident_params->incident_data,
+                                                   geometry.n_panels,
+                                                   data.size());
+      e_reflection_table = load_shoebox_image_data(
+        reflection_table, incident_params->empty_data, geometry.n_panels, data.size());
+      i_shoeboxes = i_reflection_table["shoebox"];
+      e_shoeboxes = e_reflection_table["shoebox"];
     }
 
     dials::af::shared<Shoebox<>> shoeboxes = reflection_table["shoebox"];
@@ -841,7 +559,7 @@ namespace dials { namespace algorithms {
       reflection_table.get<std::size_t>("flags");
     dials::af::const_ref<int6> bboxes = reflection_table["bbox"];
 
-    // Arrays to store ouput of integration
+    // Arrays to store output of integration
     dials::af::shared<bool> succeeded(reflection_table.size());
     dials::af::shared<double> intensities(reflection_table.size());
     dials::af::shared<double> variances(reflection_table.size());
@@ -849,13 +567,11 @@ namespace dials { namespace algorithms {
     dials::af::shared<double> intensities_prf;
     dials::af::shared<double> variances_prf;
 
-    if (profile_params_1d_ibix || profile_params_3d_gutmann) {
+    if (profile_fitter) {
       succeeded_prf.resize(reflection_table.size());
       intensities_prf.resize(reflection_table.size());
       variances_prf.resize(reflection_table.size());
     }
-
-    int bg_code = Valid | Background | BackgroundUsed;
 
     auto worker = [&](std::size_t start, std::size_t end) {
       for (std::size_t i = start; i < end; ++i) {
@@ -863,255 +579,49 @@ namespace dials { namespace algorithms {
           continue;
         }
         Shoebox<> shoebox = shoeboxes[i];
-        Shoebox<> i_shoebox = i_shoeboxes[i];
-        Shoebox<> e_shoebox = e_shoeboxes[i];
         int6 bbox = bboxes[i];
-        int panel = shoebox.panel;
 
-        bool success = true;
-        int n_background = 0;
-        int n_signal = 0;
-        double intensity = 0.0;
-        double variance = 0.0;
-
-        // First pass to get, n_signal, n_background, incident spectrum, empty spectrum
-        // Shoebox data are ordered (z, y, x)
-        scitbx::af::shared<double> incident_spectrum(shoebox.zsize(), 0.0);
-        scitbx::af::shared<double> empty_spectrum(shoebox.zsize(), 0.0);
-        scitbx::af::shared<std::size_t> n_contrib(shoebox.zsize(), 0);
-
-        for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-          if (!success) {
-            break;
-          }
-          for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-            int panel_y = bbox[2] + y;
-            if (panel_y > image_size[1] || panel_y < 0) {
-              continue;
-            }
-            for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-              int panel_x = bbox[0] + x;
-              if (panel_x > image_size[0] || panel_x < 0) {
-                continue;
-              }
-
-              incident_spectrum[z] += i_shoebox.data(z, y, x);
-              empty_spectrum[z] += e_shoebox.data(z, y, x);
-              n_contrib[z]++;
-
-              int mask = shoebox.mask(z, y, x);
-              if ((mask & Foreground) == Foreground) {
-                if ((mask & Valid) == Valid && (mask & Overlapped) == 0) {
-                  n_signal++;
-                } else {
-                  success = false;
-                }
-              } else if ((mask & bg_code) == bg_code) {
-                n_background++;
-              }
-            }
-          }
+        // incident and empty
+        Shoebox<> i_shoebox, e_shoebox;
+        const Shoebox<>* i_shoebox_ptr = nullptr;
+        const Shoebox<>* e_shoebox_ptr = nullptr;
+        if (incident_params) {
+          i_shoebox = i_shoeboxes[i];
+          e_shoebox = e_shoeboxes[i];
+          i_shoebox_ptr = &i_shoebox;
+          e_shoebox_ptr = &e_shoebox;
         }
 
-        // Smooth incident and empty to avoid dividing by a noisy signal
-        scitbx::af::shared<double> smoothed_empty =
-          dials_scaling::savitzky_golay(empty_spectrum, 7, 2);
-        scitbx::af::shared<double> smoothed_incident =
-          dials_scaling::savitzky_golay(incident_spectrum, 7, 2);
+        ShoeboxCorrectorInputs inputs = prepare_shoebox_corrector_inputs(
+          shoebox, bbox, geometry.image_size, i_shoebox_ptr, e_shoebox_ptr);
 
-        // 1D profile fitting params
-        scitbx::af::shared<double> tof_z(shoebox.zsize(), 0.0);
-        scitbx::af::shared<double> projected_intensity(shoebox.zsize(), 0.0);
+        PixelCorrector corrector(geometry,
+                                 apply_lorentz_correction,
+                                 inputs.scan.n_signal,
+                                 inputs.scan.n_background,
+                                 incident_params.get_ptr(),
+                                 absorption_params.get_ptr(),
+                                 incident_params ? &inputs.smoothed_incident : nullptr,
+                                 incident_params ? &inputs.smoothed_empty : nullptr,
+                                 incident_params ? &inputs.scan.n_contrib : nullptr);
 
-        // 3D profile fitting params done in xyz
-        auto acc = shoebox.data.accessor();
-        af::c_grid<3> transposed_acc(acc[2], acc[1], acc[0]);
-        scitbx::af::versa<double, af::c_grid<3>> intensity_3d(transposed_acc);
-        scitbx::af::versa<double, af::c_grid<3>> background_var_3d(transposed_acc);
-        scitbx::af::versa<vec3<double>, af::c_grid<3>> coords_3d(transposed_acc);
-
-        // Second pass to perform actual integration
-        for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-          double intensity_z = 0;
-
-          if (!success) {
-            break;
-          }
-
-          int frame_z = bbox[4] + z;
-          double tof = img_tof[frame_z];
-          tof_z[z] = tof;
-          tof *= std::pow(10, -6);  // (s)
-
-          for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-            int panel_y = bbox[2] + y;
-            if (panel_y > image_size[1] || panel_y < 0) {
-              continue;
-            }
-            for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-              int panel_x = bbox[0] + x;
-              if (panel_x > image_size[0] || panel_x < 0) {
-                continue;
-              }
-
-              // Raw counts
-              double raw_S = shoebox.data(z, y, x);
-              double raw_B = shoebox.background(z, y, x);
-              double n = n_contrib[z];
-              double raw_J = smoothed_incident[z] / n;
-              double raw_E = smoothed_empty[z] / n;
-              int mask = shoebox.mask(z, y, x);
-
-              // Pixel data will be divided by incident spectrum
-              if (raw_J < 1e-7) {
-                continue;
-              }
-
-              // Normalize by proton charge
-              double sample_pc = incident_params.sample_proton_charge;
-              double incident_pc = incident_params.incident_proton_charge;
-              double empty_pc = incident_params.empty_proton_charge;
-              double S = raw_S / sample_pc;
-              double B = raw_B / sample_pc;
-              double J = raw_J / incident_pc;
-              double E = raw_E / empty_pc;
-
-              // Variances
-              double var_S = std::abs(raw_S) / (sample_pc * sample_pc);
-              double var_B = std::abs(raw_B) / (sample_pc * sample_pc);
-              if (n_background > 0) {
-                var_B *= (1.0 + double(n_signal) / double(n_background));
-              }
-              double var_J =
-                (std::abs(raw_J) * n) / (incident_pc * incident_pc * n * n);
-              double var_E = (std::abs(raw_E) * n) / (empty_pc * empty_pc * n * n);
-
-              // Lorentz correction
-              double two_theta = detector[panel].get_two_theta_at_pixel(
-                unit_s0, scitbx::vec2<double>(panel_x, panel_y));
-              scitbx::vec3<double> s1 = detector[panel].get_pixel_lab_coord(
-                scitbx::vec2<double>(panel_x, panel_y));
-              double distance = s1.length() + sample_to_source_distance;
-              distance *= std::pow(10, -3);  // (m)
-              double wl = ((Planck * tof) / (m_n * (distance))) * std::pow(10, 10);
-              double sin_two_theta_sq = std::pow(sin(two_theta * .5), 2);
-              double L = sin_two_theta_sq / std::pow(wl, 4);
-
-              // Spherical absorption correction
-              // for image data and incident data
-              double two_theta_deg = two_theta * (180 / pi);
-              int two_theta_idx = static_cast<int>(two_theta_deg / 10);
-              double sample_muR =
-                (corrections_data.sample_linear_scattering_c
-                 + (corrections_data.sample_linear_absorption_c / 1.8) * wl)
-                * corrections_data.sample_radius;
-              double T = dials_scaling::tof_pixel_spherical_absorption_correction(
-                sample_muR, two_theta, two_theta_idx);
-
-              // Pixel data will be divided by the absorption correction
-              if (T < 1e-7) {
-                continue;
-              }
-              double incident_muR =
-                (corrections_data.incident_linear_scattering_c
-                 + (corrections_data.incident_linear_absorption_c / 1.8) * wl)
-                * corrections_data.incident_radius;
-              double J_T = dials_scaling::tof_pixel_spherical_absorption_correction(
-                incident_muR, two_theta, two_theta_idx);
-
-              // Pixel data will be divided by absorption correction
-              if (J_T < 1e-7) {
-                continue;
-              }
-
-              // Net signal
-              double I0 = (S - B - E);
-              double var_I0 = var_S + var_B + var_E;
-
-              J /= J_T;
-
-              if (J < 1e-7) {
-                continue;
-              }
-
-              var_J /= (J_T * J_T);
-
-              // Apply Lorentz correction and normalise by incident spectrum
-              double I, var_I;
-              if (apply_lorentz_correction) {
-                I = L * I0 / (J * T);
-                B *= L / (J * T);
-
-                var_I = (L * L / (J * J * T * T)) * var_I0
-                        + (L * L * I0 * I0 / (J * J * J * J * T * T)) * var_J;
-                var_B = (L * L / (J * J * T * T)) * var_B
-                        + (L * L * B * B / (J * J * J * J * T * T)) * var_J;
-              } else {
-                I = I0 / (J * T);
-                B /= J * T;
-                var_I = (1 / (J * J * T * T)) * var_I0
-                        + (I0 * I0 / (J * J * J * J * T * T)) * var_J;
-                var_B = (1 / (J * J * T * T)) * var_B
-                        + (B * B / (J * J * J * J * T * T)) * var_J;
-              }
-
-              intensity_z += I;
-
-              if (profile_params_3d_gutmann) {
-                intensity_3d(x, y, z) = I;
-                background_var_3d(x, y, z) = var_B;
-                double x_c = x + shoebox.xoffset() + 0.5;
-                double y_c = y + shoebox.yoffset() + 0.5;
-                double z_c = z + shoebox.zoffset() + 0.5;
-                coords_3d(x, y, z) = vec3<double>(x_c, y_c, z_c);
-              }
-
-              // Accumulate if pixel in foreground & valid
-              if ((mask & Foreground) == Foreground && (mask & Valid) == Valid
-                  && (mask & Overlapped) == 0) {
-                intensity += I;
-                variance += var_I;
-              } else if ((mask & Foreground) == Foreground) {
-                success = false;
-                break;
-              }
-            }
-          }
-          if (profile_params_1d_ibix) {
-            projected_intensity[z] = intensity_z;
-          }
-        }
+        ShoeboxIntegrationResult shoebox_result =
+          integrate_shoebox(shoebox, bbox, geometry, corrector, inputs.scan.success);
 
         // Overall values for shoebox summation
-        succeeded[i] = success;
-        intensities[i] = intensity;
-        variances[i] = variance;
+        succeeded[i] = shoebox_result.success;
+        intensities[i] = shoebox_result.intensity;
+        variances[i] = shoebox_result.variance;
 
-        if (profile_params_1d_ibix) {
+        if (profile_fitter) {
           bool profile_success = false;
-
-          double I_prf, var_prf;
-          profile_success = fit_profile_1d_ibix(projected_intensity.const_ref(),
-                                                tof_z.const_ref(),
-                                                *profile_params_1d_ibix,
-                                                I_prf);
-          if (profile_success) {
-            intensities_prf[i] = I_prf;
-            variances_prf[i] = variance;  // Use summation variance as approximation
+          double I_prf = 0.0, var_prf = 0.0;
+          if (shoebox_result.success) {
+            profile_success = profile_fitter->fit(shoebox_result, I_prf, var_prf);
           }
-          succeeded_prf[i] = profile_success;
-        } else if (profile_params_3d_gutmann) {
-          bool profile_success = false;
-
-          double I_prf, var_prf;
-          profile_success = fit_profile_3d_gutmann(coords_3d.const_ref(),
-                                                   intensity_3d,
-                                                   background_var_3d,
-                                                   *profile_params_3d_gutmann,
-                                                   I_prf);
           if (profile_success) {
             intensities_prf[i] = I_prf;
-            variances_prf[i] = variance;  // Use summation variance as approximation
+            variances_prf[i] = var_prf;
           }
           succeeded_prf[i] = profile_success;
         }
@@ -1134,7 +644,7 @@ namespace dials { namespace algorithms {
     reflection_table["intensity.sum.value"] = intensities;
     reflection_table["intensity.sum.variance"] = variances;
 
-    if (profile_params_1d_ibix || profile_params_3d_gutmann) {
+    if (profile_fitter) {
       reflection_table["intensity.prf.value"] = intensities_prf;
       reflection_table["intensity.prf.variance"] = variances_prf;
     }
@@ -1150,7 +660,7 @@ namespace dials { namespace algorithms {
         flags[i] &= ~dials::af::IntegratedSum;
         flags[i] |= dials::af::FailedDuringSummation;
       }
-      if (profile_params_1d_ibix || profile_params_3d_gutmann) {
+      if (profile_fitter) {
         if (succeeded_prf[i]) {
           flags[i] &= ~dials::af::FailedDuringProfileFitting;
           flags[i] |= dials::af::IntegratedPrf;
@@ -1162,1124 +672,217 @@ namespace dials { namespace algorithms {
     }
   }
 
-  boost::python::tuple calculate_line_profile_for_reflection(
+  // Single-reflection variant used for diagnostics/plotting
+  // Calculates raw_projected_intensity, projected_intensity, projected_background,
+  // sum_intensity and sum_variance, with the same correction
+  // combinations as integrate_reflection_table
+  inline boost::python::tuple calculate_line_profile_for_reflection(
     dials::af::reflection_table& reflection,
     Experiment& experiment,
     ImageSequence& data,
+    boost::optional<dials_scaling::TOFIncidentSpectrumParams> incident_params,
+    boost::optional<dials_scaling::TOFAbsorptionParams> absorption_params,
     scitbx::af::shared<double> raw_projected_intensity_out,
     scitbx::af::shared<double> projected_intensity_out,
     scitbx::af::shared<double> projected_background_out,
     scitbx::af::shared<double> tof_z_out,
     const bool& apply_lorentz_correction) {
-    /*
-     * Calculates raw_projected_intensity, projected_intensity,
-     * projected_background, sum_intensity, sum_variance
-     */
-
-    // This is a slight hack to make using current interfaces eaiser
+    // This is a slight hack to make using current interfaces easier
     // E.g. the shoebox processor
     DIALS_ASSERT(reflection.size() == 1);
 
-    Detector detector = *experiment.get_detector();
-    Scan scan = *experiment.get_scan();
-
-    // Required beam params
-    std::shared_ptr<dxtbx::model::BeamBase> beam_ptr = experiment.get_beam();
-    std::shared_ptr<PolychromaticBeam> beam =
-      std::dynamic_pointer_cast<PolychromaticBeam>(beam_ptr);
-    DIALS_ASSERT(beam != nullptr);
-    vec3<double> unit_s0 = beam->get_unit_s0();
-    double sample_to_source_distance = beam->get_sample_to_source_distance();
-
-    // Required scan params
-    scitbx::af::shared<double> img_tof = scan.get_property<double>("time_of_flight");
-
-    // Required detector params
-    int num_images = data.size();
-    vec2<std::size_t> image_size = detector[0].get_image_size();
-    DIALS_ASSERT(num_images == img_tof.size());
-
-    // Mask codes
-    int bg_code = Valid | Background | BackgroundUsed;
+    TOFGeometryContext geometry(experiment, data);
 
     dials::af::shared<Shoebox<>> shoeboxes = reflection["shoebox"];
-    dials::model::Shoebox<> shoebox = shoeboxes[0];
+    Shoebox<> shoebox = shoeboxes[0];
+    int6 bbox = shoebox.bbox;
 
     DIALS_ASSERT(raw_projected_intensity_out.size() == shoebox.zsize());
     DIALS_ASSERT(projected_intensity_out.size() == shoebox.zsize());
     DIALS_ASSERT(projected_background_out.size() == shoebox.zsize());
     DIALS_ASSERT(tof_z_out.size() == shoebox.zsize());
 
-    int6 bbox = shoebox.bbox;
-    int panel = shoebox.panel;
-
-    bool success = true;
-    int n_background = 0;
-    int n_signal = 0;
-    double intensity = 0.0;
-    double variance = 0.0;
-
-    // First pass to get, n_signal, n_background
-    // Shoebox data are ordered (z, y, x)
-    for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-      if (!success) {
-        break;
-      }
-      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-        int panel_y = bbox[2] + y;
-        if (panel_y > image_size[1] || panel_y < 0) {
-          continue;
-        }
-        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-          int panel_x = bbox[0] + x;
-          if (panel_x > image_size[0] || panel_x < 0) {
-            continue;
-          }
-
-          int mask = shoebox.mask(z, y, x);
-          if ((mask & Foreground) == Foreground) {
-            if ((mask & Valid) == Valid && (mask & Overlapped) == 0) {
-              n_signal++;
-            } else {
-              success = false;
-            }
-          } else if ((mask & bg_code) == bg_code) {
-            n_background++;
-          }
-        }
-      }
+    dials::af::reflection_table i_reflection_table;
+    dials::af::reflection_table e_reflection_table;
+    Shoebox<> i_shoebox, e_shoebox;
+    const Shoebox<>* i_shoebox_ptr = nullptr;
+    const Shoebox<>* e_shoebox_ptr = nullptr;
+    if (incident_params) {
+      i_reflection_table = load_shoebox_image_data(
+        reflection, incident_params->incident_data, geometry.n_panels, data.size());
+      e_reflection_table = load_shoebox_image_data(
+        reflection, incident_params->empty_data, geometry.n_panels, data.size());
+      dials::af::ref<Shoebox<>> i_shoeboxes = i_reflection_table["shoebox"];
+      dials::af::ref<Shoebox<>> e_shoeboxes = e_reflection_table["shoebox"];
+      i_shoebox = i_shoeboxes[0];
+      e_shoebox = e_shoeboxes[0];
+      i_shoebox_ptr = &i_shoebox;
+      e_shoebox_ptr = &e_shoebox;
     }
 
-    // Second pass to perform actual integration
+    ShoeboxCorrectorInputs inputs = prepare_shoebox_corrector_inputs(
+      shoebox, bbox, geometry.image_size, i_shoebox_ptr, e_shoebox_ptr);
+
+    PixelCorrector corrector(geometry,
+                             apply_lorentz_correction,
+                             inputs.scan.n_signal,
+                             inputs.scan.n_background,
+                             incident_params.get_ptr(),
+                             absorption_params.get_ptr(),
+                             incident_params ? &inputs.smoothed_incident : nullptr,
+                             incident_params ? &inputs.smoothed_empty : nullptr,
+                             incident_params ? &inputs.scan.n_contrib : nullptr);
+
+    ShoeboxIntegrationResult result =
+      integrate_shoebox(shoebox, bbox, geometry, corrector, inputs.scan.success);
+
     for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-      double intensity_z = 0;
-      double intensity_raw_z = 0;
-      double background_z = 0;
-
-      if (!success) {
-        break;
-      }
-
-      int frame_z = bbox[4] + z;
-      double tof = img_tof[frame_z];
-      tof_z_out[z] = tof;
-      tof *= std::pow(10, -6);  // (s)
-
-      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-        int panel_y = bbox[2] + y;
-        if (panel_y > image_size[1] || panel_y < 0) {
-          continue;
-        }
-        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-          int panel_x = bbox[0] + x;
-          if (panel_x > image_size[0] || panel_x < 0) {
-            continue;
-          }
-
-          // Raw counts
-          double raw_S = shoebox.data(z, y, x);
-          double raw_B = shoebox.background(z, y, x);
-
-          int mask = shoebox.mask(z, y, x);
-
-          // Variances
-          double var_S = std::abs(raw_S);
-          double var_B = std::abs(raw_B);
-          if (n_background > 0) {
-            var_B *= (1.0 + double(n_signal) / double(n_background));
-          }
-
-          // Lorentz correction
-          scitbx::vec3<double> s1 =
-            detector[panel].get_pixel_lab_coord(scitbx::vec2<double>(panel_x, panel_y));
-          double distance = s1.length() + sample_to_source_distance;
-          distance *= std::pow(10, -3);  // (m)
-          double wl = ((Planck * tof) / (m_n * (distance))) * std::pow(10, 10);
-          double two_theta = detector[panel].get_two_theta_at_pixel(
-            unit_s0, scitbx::vec2<double>(panel_x, panel_y));
-          double sin_two_theta_sq = std::pow(sin(two_theta * .5), 2);
-          double L = sin_two_theta_sq / std::pow(wl, 4);
-
-          // Acount for some data having different sized bin widths
-          double bin_width_correction = img_tof[frame_z] - img_tof[frame_z - 1];
-
-          // Net signal
-          double I0 = raw_S - raw_B;
-          double var_I0 = var_S + var_B;
-          double I_raw = raw_S;
-
-          double I = I0 / bin_width_correction;
-          double B = raw_B / bin_width_correction;
-          I_raw /= bin_width_correction;
-          double var_I = var_I0 / (bin_width_correction * bin_width_correction);
-
-          if (apply_lorentz_correction) {
-            I *= L;
-            var_I *= (L * L);
-            I_raw *= L;
-            B *= L;
-          }
-
-          intensity_z += I;
-          intensity_raw_z += I_raw;
-          background_z += B;
-
-          // Accumulate if pixel in foreground & valid
-          if ((mask & Foreground) == Foreground && (mask & Valid) == Valid
-              && (mask & Overlapped) == 0) {
-            intensity += I;
-            variance += var_I;
-          } else if ((mask & Foreground) == Foreground) {
-            success = false;
-            break;
-          }
-        }
-      }
-      raw_projected_intensity_out[z] = intensity_raw_z;
-      projected_intensity_out[z] = intensity_z;
-      projected_background_out[z] = background_z;
+      raw_projected_intensity_out[z] = result.raw_projected_intensity[z];
+      projected_intensity_out[z] = result.projected_intensity[z];
+      projected_background_out[z] = result.projected_background[z];
+      tof_z_out[z] = result.tof_z[z];
     }
 
-    return boost::python::make_tuple(intensity, variance, success);
+    return boost::python::make_tuple(result.intensity, result.variance, result.success);
   }
 
-  boost::python::tuple calculate_line_profile_for_reflection_3d(
+  // As above, but also fits a 1D profile and returns the profile-
+  // fitted intensity, the line profile itself (line_profile_out), and the
+  // summation results.
+  inline boost::python::tuple calculate_line_profile_for_reflection(
     dials::af::reflection_table& reflection,
     Experiment& experiment,
     ImageSequence& data,
-    scitbx::af::shared<vec3<double>> coords,
+    boost::optional<dials_scaling::TOFIncidentSpectrumParams> incident_params,
+    boost::optional<dials_scaling::TOFAbsorptionParams> absorption_params,
+    scitbx::af::shared<double> raw_projected_intensity_out,
+    scitbx::af::shared<double> projected_intensity_out,
+    scitbx::af::shared<double> projected_background_out,
+    scitbx::af::shared<double> tof_z_out,
+    scitbx::af::shared<double> line_profile_out,
+    const bool& apply_lorentz_correction,
+    TOFProfile1DIBIXParams& profile_params_1d_ibix) {
+    boost::python::tuple result =
+      calculate_line_profile_for_reflection(reflection,
+                                            experiment,
+                                            data,
+                                            incident_params,
+                                            absorption_params,
+                                            raw_projected_intensity_out,
+                                            projected_intensity_out,
+                                            projected_background_out,
+                                            tof_z_out,
+                                            apply_lorentz_correction);
+
+    double I_sum = boost::python::extract<double>(result[0]);
+    double var_sum = boost::python::extract<double>(result[1]);
+    bool success = boost::python::extract<bool>(result[2]);
+
+    double I_prf = 0;
+    double var_prf = 0;
+    bool profile_success = false;
+
+    if (success) {
+      profile_success = fit_profile_1d_ibix(projected_intensity_out.const_ref(),
+                                            tof_z_out.const_ref(),
+                                            profile_params_1d_ibix,
+                                            I_prf,
+                                            line_profile_out,
+                                            true);
+    }
+    return boost::python::make_tuple(I_prf, var_prf, I_sum, var_sum, profile_success);
+  }
+
+  // As calculate_line_profile_for_reflection, but also fits a 3D
+  // profile and returns the profile-fitted intensity, the fitted 3D
+  // profile, and the summation results.
+  inline boost::python::tuple calculate_line_profile_for_reflection_3d(
+    dials::af::reflection_table& reflection,
+    Experiment& experiment,
+    ImageSequence& data,
+    boost::optional<dials_scaling::TOFIncidentSpectrumParams> incident_params,
+    boost::optional<dials_scaling::TOFAbsorptionParams> absorption_params,
     scitbx::af::shared<double> raw_projected_intensity_out,
     scitbx::af::shared<double> projected_intensity_out,
     scitbx::af::shared<double> projected_background_out,
     scitbx::af::shared<double> tof_z_out,
     const bool& apply_lorentz_correction,
     TOFProfile3DGutmannParams& profile_params_3d_gutmann) {
-    /*
-     * Calculates raw_projected_intensity, projected_intensity,
-     * projected_background, sum_intensity, sum_variance
-     */
-
-    // This is a slight hack to make using current interfaces eaiser
-    // E.g. the shoebox processor
     DIALS_ASSERT(reflection.size() == 1);
 
-    Detector detector = *experiment.get_detector();
-    Scan scan = *experiment.get_scan();
-
-    // Required beam params
-    std::shared_ptr<dxtbx::model::BeamBase> beam_ptr = experiment.get_beam();
-    std::shared_ptr<PolychromaticBeam> beam =
-      std::dynamic_pointer_cast<PolychromaticBeam>(beam_ptr);
-    DIALS_ASSERT(beam != nullptr);
-    vec3<double> unit_s0 = beam->get_unit_s0();
-    double sample_to_source_distance = beam->get_sample_to_source_distance();
-
-    // Required scan params
-    scitbx::af::shared<double> img_tof = scan.get_property<double>("time_of_flight");
-
-    // Required detector params
-    int num_images = data.size();
-    vec2<std::size_t> image_size = detector[0].get_image_size();
-    DIALS_ASSERT(num_images == img_tof.size());
-
-    // Mask codes
-    int bg_code = Valid | Background | BackgroundUsed;
+    TOFGeometryContext geometry(experiment, data);
 
     dials::af::shared<Shoebox<>> shoeboxes = reflection["shoebox"];
-    dials::model::Shoebox<> shoebox = shoeboxes[0];
+    Shoebox<> shoebox = shoeboxes[0];
+    int6 bbox = shoebox.bbox;
 
     DIALS_ASSERT(raw_projected_intensity_out.size() == shoebox.zsize());
     DIALS_ASSERT(projected_intensity_out.size() == shoebox.zsize());
     DIALS_ASSERT(projected_background_out.size() == shoebox.zsize());
     DIALS_ASSERT(tof_z_out.size() == shoebox.zsize());
 
-    int6 bbox = shoebox.bbox;
-    int panel = shoebox.panel;
-
-    bool sum_success = true;
-    int n_background = 0;
-    int n_signal = 0;
-    double I_sum = 0.0;
-    double var_sum = 0.0;
-
-    // First pass to get, n_signal, n_background
-    // Shoebox data are ordered (z, y, x)
-    for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-      if (!sum_success) {
-        break;
-      }
-      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-        int panel_y = bbox[2] + y;
-        if (panel_y > image_size[1] || panel_y < 0) {
-          continue;
-        }
-        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-          int panel_x = bbox[0] + x;
-          if (panel_x > image_size[0] || panel_x < 0) {
-            continue;
-          }
-
-          int mask = shoebox.mask(z, y, x);
-          if ((mask & Foreground) == Foreground) {
-            if ((mask & Valid) == Valid && (mask & Overlapped) == 0) {
-              n_signal++;
-            } else {
-              sum_success = false;
-            }
-          } else if ((mask & bg_code) == bg_code) {
-            n_background++;
-          }
-        }
-      }
+    dials::af::reflection_table i_reflection_table;
+    dials::af::reflection_table e_reflection_table;
+    Shoebox<> i_shoebox, e_shoebox;
+    const Shoebox<>* i_shoebox_ptr = nullptr;
+    const Shoebox<>* e_shoebox_ptr = nullptr;
+    if (incident_params) {
+      i_reflection_table = load_shoebox_image_data(
+        reflection, incident_params->incident_data, geometry.n_panels, data.size());
+      e_reflection_table = load_shoebox_image_data(
+        reflection, incident_params->empty_data, geometry.n_panels, data.size());
+      dials::af::ref<Shoebox<>> i_shoeboxes = i_reflection_table["shoebox"];
+      dials::af::ref<Shoebox<>> e_shoeboxes = e_reflection_table["shoebox"];
+      i_shoebox = i_shoeboxes[0];
+      e_shoebox = e_shoeboxes[0];
+      i_shoebox_ptr = &i_shoebox;
+      e_shoebox_ptr = &e_shoebox;
     }
-    // 3D profile fitting params done in xyz
-    auto acc = shoebox.data.accessor();
-    af::c_grid<3> transposed_acc(acc[2], acc[1], acc[0]);
-    scitbx::af::versa<double, af::c_grid<3>> intensity_3d(transposed_acc);
-    scitbx::af::versa<double, af::c_grid<3>> background_var_3d(transposed_acc);
-    scitbx::af::versa<vec3<double>, af::c_grid<3>> coords_3d(transposed_acc);
-    int coord_count = 0;
 
-    // Second pass to perform actual integration
+    ShoeboxCorrectorInputs inputs = prepare_shoebox_corrector_inputs(
+      shoebox, bbox, geometry.image_size, i_shoebox_ptr, e_shoebox_ptr);
+
+    PixelCorrector corrector(geometry,
+                             apply_lorentz_correction,
+                             inputs.scan.n_signal,
+                             inputs.scan.n_background,
+                             incident_params.get_ptr(),
+                             absorption_params.get_ptr(),
+                             incident_params ? &inputs.smoothed_incident : nullptr,
+                             incident_params ? &inputs.smoothed_empty : nullptr,
+                             incident_params ? &inputs.scan.n_contrib : nullptr);
+
+    ShoeboxIntegrationResult result =
+      integrate_shoebox(shoebox, bbox, geometry, corrector, inputs.scan.success);
+
     for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-      double intensity_z = 0;
-      double intensity_raw_z = 0;
-      double background_z = 0;
-
-      if (!sum_success) {
-        break;
-      }
-
-      int frame_z = bbox[4] + z;
-      double tof = img_tof[frame_z];
-      tof_z_out[z] = tof;
-      tof *= std::pow(10, -6);  // (s)
-
-      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-        int panel_y = bbox[2] + y;
-        if (panel_y > image_size[1] || panel_y < 0) {
-          continue;
-        }
-        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-          int panel_x = bbox[0] + x;
-          if (panel_x > image_size[0] || panel_x < 0) {
-            continue;
-          }
-
-          // Raw counts
-          double raw_S = shoebox.data(z, y, x);
-          double raw_B = shoebox.background(z, y, x);
-
-          int mask = shoebox.mask(z, y, x);
-
-          // Variances
-          double var_S = std::abs(raw_S);
-          double var_B = std::abs(raw_B);
-          if (n_background > 0) {
-            var_B *= (1.0 + double(n_signal) / double(n_background));
-          }
-
-          // Lorentz correction
-          scitbx::vec3<double> s1 =
-            detector[panel].get_pixel_lab_coord(scitbx::vec2<double>(panel_x, panel_y));
-          double distance = s1.length() + sample_to_source_distance;
-          distance *= std::pow(10, -3);  // (m)
-          double wl = ((Planck * tof) / (m_n * (distance))) * std::pow(10, 10);
-          double two_theta = detector[panel].get_two_theta_at_pixel(
-            unit_s0, scitbx::vec2<double>(panel_x, panel_y));
-          double sin_two_theta_sq = std::pow(sin(two_theta * .5), 2);
-          double L = sin_two_theta_sq / std::pow(wl, 4);
-
-          // Acount for some data having different sized bin widths
-          double bin_width_correction = img_tof[frame_z] - img_tof[frame_z - 1];
-
-          // Net signal
-          double I0 = raw_S - raw_B;
-          double var_I0 = var_S + var_B;
-          double I_raw = raw_S;
-          double B = raw_B;
-
-          double I = I0 / bin_width_correction;
-          I_raw /= bin_width_correction;
-          double var_I = var_I0 / (bin_width_correction * bin_width_correction);
-          B /= bin_width_correction;
-          var_B /= (bin_width_correction * bin_width_correction);
-
-          if (apply_lorentz_correction) {
-            I *= L;
-            var_I *= (L * L);
-            var_B *= (L * L);
-            I_raw *= L;
-            B *= L;
-          }
-
-          intensity_z += I;
-          intensity_raw_z += I_raw;
-          background_z += B;
-
-          intensity_3d(x, y, z) = I;
-          background_var_3d(x, y, z) = var_B;
-          coords_3d(x, y, z) = coords[coord_count];
-          coord_count++;
-
-          // Accumulate if pixel in foreground & valid
-          if ((mask & Foreground) == Foreground && (mask & Valid) == Valid
-              && (mask & Overlapped) == 0) {
-            I_sum += I;
-            var_sum += var_I;
-          } else if ((mask & Foreground) == Foreground) {
-            sum_success = false;
-            break;
-          }
-        }
-      }
-      raw_projected_intensity_out[z] = intensity_raw_z;
-      projected_intensity_out[z] = intensity_z;
-      projected_background_out[z] = background_z;
+      raw_projected_intensity_out[z] = result.raw_projected_intensity[z];
+      projected_intensity_out[z] = result.projected_intensity[z];
+      projected_background_out[z] = result.projected_background[z];
+      tof_z_out[z] = result.tof_z[z];
     }
 
     double I_prf = 0;
     double var_prf = 0;
     bool profile_success = false;
     scitbx::af::versa<double, scitbx::af::c_grid<3>> profile_3d_out(
-      intensity_3d.accessor());
+      result.intensity_3d.accessor());
 
-    if (sum_success) {
-      profile_success = fit_profile_3d_gutmann(coords_3d.const_ref(),
-                                               intensity_3d,
-                                               background_var_3d,
+    if (result.success) {
+      profile_success = fit_profile_3d_gutmann(result.coords_3d.const_ref(),
+                                               result.intensity_3d,
+                                               result.background_var_3d,
                                                profile_params_3d_gutmann,
                                                I_prf,
                                                profile_3d_out,
                                                true);
-    } else {
-      profile_success = false;
     }
-    return boost::python::make_tuple(
-      I_prf, var_prf, I_sum, var_sum, profile_success, profile_3d_out);
-  }
-
-  boost::python::tuple calculate_line_profile_for_reflection(
-    dials::af::reflection_table& reflection,
-    Experiment& experiment,
-    ImageSequence& data,
-    scitbx::af::shared<double> raw_projected_intensity_out,
-    scitbx::af::shared<double> projected_intensity_out,
-    scitbx::af::shared<double> projected_background_out,
-    scitbx::af::shared<double> tof_z_out,
-    scitbx::af::shared<double> line_profile_out,
-    const bool& apply_lorentz_correction,
-    TOFProfile1DIBIXParams& profile_params_1d_ibix) {
-    /*
-     * Calculates raw_projected_intensity, projected_intensity, line_profile
-     * projected_background, sum_intensity, sum_variance, prf_intensity, prf_variance
-     */
-
-    boost::python::tuple result =
-      calculate_line_profile_for_reflection(reflection,
-                                            experiment,
-                                            data,
-                                            raw_projected_intensity_out,
-                                            projected_intensity_out,
-                                            projected_background_out,
-                                            tof_z_out,
-                                            apply_lorentz_correction);
-
-    double I_sum = boost::python::extract<double>(result[0]);
-    double var_sum = boost::python::extract<double>(result[1]);
-    bool success = boost::python::extract<bool>(result[2]);
-
-    double I_prf = 0;
-    double var_prf = 0;
-    bool profile_success = false;
-
-    if (success) {
-      profile_success = fit_profile_1d_ibix(projected_intensity_out.const_ref(),
-                                            tof_z_out.const_ref(),
-                                            profile_params_1d_ibix,
-                                            I_prf,
-                                            line_profile_out,
-                                            true);
-
-    } else {
-      profile_success = false;
-    }
-    return boost::python::make_tuple(I_prf, var_prf, I_sum, var_sum, profile_success);
-  }
-
-  boost::python::tuple calculate_line_profile_for_reflection(
-    dials::af::reflection_table& reflection,
-    Experiment& experiment,
-    ImageSequence& data,
-    const dials_scaling::TOFIncidentSpectrumParams& incident_params,
-    scitbx::af::shared<double> raw_projected_intensity_out,
-    scitbx::af::shared<double> projected_intensity_out,
-    scitbx::af::shared<double> projected_background_out,
-    scitbx::af::shared<double> tof_z_out,
-    const bool& apply_lorentz_correction) {
-    /*
-     * Calculates raw_projected_intensity, projected_intensity,
-     * projected_background, sum_intensity, sum_variance
-     */
-
-    // This is a slight hack to make using current interfaces eaiser
-    // E.g. the shoebox processor
-    DIALS_ASSERT(reflection.size() == 1);
-    dials::af::shared<Shoebox<>> shoeboxes = reflection["shoebox"];
-    dials::model::Shoebox<> shoebox = shoeboxes[0];
-
-    Detector detector = *experiment.get_detector();
-    Scan scan = *experiment.get_scan();
-
-    // Required beam params
-    std::shared_ptr<dxtbx::model::BeamBase> beam_ptr = experiment.get_beam();
-    std::shared_ptr<PolychromaticBeam> beam =
-      std::dynamic_pointer_cast<PolychromaticBeam>(beam_ptr);
-    DIALS_ASSERT(beam != nullptr);
-    vec3<double> unit_s0 = beam->get_unit_s0();
-    double sample_to_source_distance = beam->get_sample_to_source_distance();
-
-    // Required scan params
-    scitbx::af::shared<double> img_tof = scan.get_property<double>("time_of_flight");
-
-    // Required detector params
-    int num_images = data.size();
-    vec2<std::size_t> image_size = detector[0].get_image_size();
-    DIALS_ASSERT(num_images == img_tof.size());
-    int n_panels = detector.size();
-
-    int6 bbox = shoebox.bbox;
-    int panel = shoebox.panel;
-
-    // Copy reflections for incident and empty runs
-    boost::python::dict d;
-    dials::af::reflection_table i_reflection_table =
-      dxtbx::af::flex_table_suite::deepcopy(reflection, d);
-    dials::af::reflection_table e_reflection_table =
-      dxtbx::af::flex_table_suite::deepcopy(reflection, d);
-
-    dials::af::ref<Shoebox<>> i_shoeboxes = i_reflection_table["shoebox"];
-    dials::af::ref<Shoebox<>> e_shoeboxes = e_reflection_table["shoebox"];
-    i_shoeboxes[0].deallocate();
-    e_shoeboxes[0].deallocate();
-
-    ShoeboxProcessor incident_shoebox_processor(
-      i_reflection_table, n_panels, 0, num_images, false);
-
-    ShoeboxProcessor empty_shoebox_processor(
-      e_reflection_table, n_panels, 0, num_images, false);
-
-    // Get shoebox for incident data
-    for (std::size_t img_num = 0; img_num < num_images; ++img_num) {
-      dxtbx::format::Image<double> img =
-        incident_params.incident_data->get_corrected_data(img_num);
-      dxtbx::format::Image<bool> mask =
-        incident_params.incident_data->get_mask(img_num);
-
-      dials::af::shared<scitbx::af::versa<double, scitbx::af::c_grid<2>>> output_data(
-        n_panels);
-      dials::af::shared<scitbx::af::versa<bool, scitbx::af::c_grid<2>>> output_mask(
-        n_panels);
-
-      for (std::size_t i = 0; i < output_data.size(); ++i) {
-        output_data[i] = img.tile(i).data();
-        output_mask[i] = mask.tile(i).data();
-      }
-      incident_shoebox_processor.next_data_only(
-        dials::model::Image<double>(output_data.const_ref(), output_mask.const_ref()));
-    }
-
-    // Get shoeboxes for empty data
-    for (std::size_t img_num = 0; img_num < num_images; ++img_num) {
-      dxtbx::format::Image<double> img =
-        incident_params.empty_data->get_corrected_data(img_num);
-      dxtbx::format::Image<bool> mask = incident_params.empty_data->get_mask(img_num);
-
-      dials::af::shared<scitbx::af::versa<double, scitbx::af::c_grid<2>>> output_data(
-        n_panels);
-      dials::af::shared<scitbx::af::versa<bool, scitbx::af::c_grid<2>>> output_mask(
-        n_panels);
-
-      for (std::size_t i = 0; i < output_data.size(); ++i) {
-        output_data[i] = img.tile(i).data();
-        output_mask[i] = mask.tile(i).data();
-      }
-      empty_shoebox_processor.next_data_only(
-        dials::model::Image<double>(output_data.const_ref(), output_mask.const_ref()));
-    }
-
-    // Mask codes
-    int bg_code = Valid | Background | BackgroundUsed;
-
-    bool success = true;
-    int n_background = 0;
-    int n_signal = 0;
-    double intensity = 0.0;
-    double variance = 0.0;
-
-    scitbx::af::shared<double> incident_spectrum(shoebox.zsize(), 0.0);
-    scitbx::af::shared<double> empty_spectrum(shoebox.zsize(), 0.0);
-    scitbx::af::shared<std::size_t> n_contrib(shoebox.zsize(), 0);
-    Shoebox<> i_shoebox = i_shoeboxes[0];
-    Shoebox<> e_shoebox = e_shoeboxes[0];
-
-    // First pass to get, n_signal, n_background
-    // Shoebox data are ordered (z, y, x)
-    for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-      if (!success) {
-        break;
-      }
-      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-        int panel_y = bbox[2] + y;
-        if (panel_y > image_size[1] || panel_y < 0) {
-          continue;
-        }
-        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-          int panel_x = bbox[0] + x;
-          if (panel_x > image_size[0] || panel_x < 0) {
-            continue;
-          }
-
-          incident_spectrum[z] += i_shoebox.data(z, y, x);
-          empty_spectrum[z] += e_shoebox.data(z, y, x);
-          n_contrib[z]++;
-
-          int mask = shoebox.mask(z, y, x);
-          if ((mask & Foreground) == Foreground) {
-            if ((mask & Valid) == Valid && (mask & Overlapped) == 0) {
-              n_signal++;
-            } else {
-              success = false;
-            }
-          } else if ((mask & bg_code) == bg_code) {
-            n_background++;
-          }
-        }
-      }
-    }
-    // Smooth incident and empty to avoid dividing by a noisy signal
-    scitbx::af::shared<double> smoothed_empty =
-      dials_scaling::savitzky_golay(empty_spectrum, 7, 2);
-    scitbx::af::shared<double> smoothed_incident =
-      dials_scaling::savitzky_golay(incident_spectrum, 7, 2);
-
-    DIALS_ASSERT(raw_projected_intensity_out.size() == shoebox.zsize());
-    DIALS_ASSERT(projected_intensity_out.size() == shoebox.zsize());
-    DIALS_ASSERT(projected_background_out.size() == shoebox.zsize());
-    DIALS_ASSERT(tof_z_out.size() == shoebox.zsize());
-
-    // Second pass to perform actual integration
-    for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-      double intensity_z = 0;
-      double intensity_raw_z = 0;
-      double background_z = 0;
-
-      if (!success) {
-        break;
-      }
-
-      int frame_z = bbox[4] + z;
-      double tof = img_tof[frame_z];
-      tof_z_out[z] = tof;
-      tof *= std::pow(10, -6);  // (s)
-
-      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-        int panel_y = bbox[2] + y;
-        if (panel_y > image_size[1] || panel_y < 0) {
-          continue;
-        }
-        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-          int panel_x = bbox[0] + x;
-          if (panel_x > image_size[0] || panel_x < 0) {
-            continue;
-          }
-          // Raw counts
-          double raw_S = shoebox.data(z, y, x);
-          double raw_B = shoebox.background(z, y, x);
-          double n = n_contrib[z];
-          double raw_J = smoothed_incident[z] / n;
-          double raw_E = smoothed_empty[z] / n;
-
-          int mask = shoebox.mask(z, y, x);
-
-          // Normalise by proton charge
-          double sample_pc = incident_params.sample_proton_charge;
-          double incident_pc = incident_params.incident_proton_charge;
-          double empty_pc = incident_params.empty_proton_charge;
-          double S = raw_S / sample_pc;
-          double B = raw_B / sample_pc;
-          double J = raw_J / incident_pc;
-          double E = raw_E / empty_pc;
-
-          // Variances
-          double var_S = std::abs(raw_S) / (sample_pc * sample_pc);
-          double var_B = std::abs(raw_B) / (sample_pc * sample_pc);
-          if (n_background > 0) {
-            var_B *= (1.0 + double(n_signal) / double(n_background));
-          }
-          double var_J = (std::abs(raw_J) * n) / (incident_pc * incident_pc * n * n);
-          double var_E = (std::abs(raw_E) * n) / (empty_pc * empty_pc * n * n);
-
-          // Lorentz correction
-          scitbx::vec3<double> s1 =
-            detector[panel].get_pixel_lab_coord(scitbx::vec2<double>(panel_x, panel_y));
-          double distance = s1.length() + sample_to_source_distance;
-          distance *= std::pow(10, -3);  // (m)
-          double wl = ((Planck * tof) / (m_n * (distance))) * std::pow(10, 10);
-          double two_theta = detector[panel].get_two_theta_at_pixel(
-            unit_s0, scitbx::vec2<double>(panel_x, panel_y));
-          double sin_two_theta_sq = std::pow(sin(two_theta * .5), 2);
-          double L = sin_two_theta_sq / std::pow(wl, 4);
-
-          // Net signal
-          double I0 = S - B - E;
-          double var_I0 = var_S + var_B + var_E;
-          double I_raw = S;
-
-          // Apply Lorentz correction and normalise by incident spectrum
-          double I, var_I;
-          if (apply_lorentz_correction) {
-            I = L * I0 / J;
-            I_raw *= L / J;
-            B *= L / J;
-            // Var( L*I0/J ) = (L/J)^2 Var(I0) + (L*I0/J^2)^2 Var(J)
-            var_I =
-              (L * L / (J * J)) * var_I0 + (L * L * I0 * I0 / (J * J * J * J)) * var_J;
-          } else {
-            I = I0 / J;
-            I_raw /= J;
-            B /= J;
-            // Var( I0/J ) = (1/J)^2 Var(I0) + (I0/J^2)^2 Var(J)
-            var_I = (1 / (J * J)) * var_I0 + (I0 * I0 / (J * J * J * J)) * var_J;
-          }
-
-          intensity_z += I;
-          intensity_raw_z += I_raw;
-          background_z += B;
-
-          // Accumulate if pixel in foreground & valid
-          if ((mask & Foreground) == Foreground && (mask & Valid) == Valid
-              && (mask & Overlapped) == 0) {
-            intensity += I;
-            variance += var_I;
-          } else if ((mask & Foreground) == Foreground) {
-            success = false;
-            break;
-          }
-        }
-      }
-      raw_projected_intensity_out[z] = intensity_raw_z;
-      projected_intensity_out[z] = intensity_z;
-      projected_background_out[z] = background_z;
-    }
-
-    return boost::python::make_tuple(intensity, variance, success);
-  }
-
-  boost::python::tuple calculate_line_profile_for_reflection(
-    dials::af::reflection_table& reflection,
-    Experiment& experiment,
-    ImageSequence& data,
-    const dials_scaling::TOFIncidentSpectrumParams& incident_params,
-    scitbx::af::shared<double> raw_projected_intensity_out,
-    scitbx::af::shared<double> projected_intensity_out,
-    scitbx::af::shared<double> projected_background_out,
-    scitbx::af::shared<double> tof_z_out,
-    scitbx::af::shared<double> line_profile_out,
-    const bool& apply_lorentz_correction,
-    TOFProfile1DIBIXParams& profile_params_1d_ibix) {
-    /*
-     * Calculates raw_projected_intensity, projected_intensity, line_profile
-     * projected_background, sum_intensity, sum_variance, prf_intensity, prf_variance
-     */
-
-    boost::python::tuple result =
-      calculate_line_profile_for_reflection(reflection,
-                                            experiment,
-                                            data,
-                                            incident_params,
-                                            raw_projected_intensity_out,
-                                            projected_intensity_out,
-                                            projected_background_out,
-                                            tof_z_out,
-                                            apply_lorentz_correction);
-
-    double I_sum = boost::python::extract<double>(result[0]);
-    double var_sum = boost::python::extract<double>(result[1]);
-    bool success = boost::python::extract<bool>(result[2]);
-
-    double I_prf = 0;
-    double var_prf = 0;
-    bool profile_success = false;
-    if (success) {
-      profile_success = fit_profile_1d_ibix(projected_intensity_out.const_ref(),
-                                            tof_z_out.const_ref(),
-                                            profile_params_1d_ibix,
-                                            I_prf,
-                                            line_profile_out,
-                                            true);
-
-    } else {
-      profile_success = false;
-    }
-    return boost::python::make_tuple(I_prf, var_prf, I_sum, var_sum, profile_success);
-  }
-
-  boost::python::tuple calculate_line_profile_for_reflection(
-    dials::af::reflection_table& reflection,
-    Experiment& experiment,
-    ImageSequence& data,
-    const dials_scaling::TOFIncidentSpectrumParams& incident_params,
-    const dials_scaling::TOFAbsorptionParams& corrections_data,
-    scitbx::af::shared<double> raw_projected_intensity_out,
-    scitbx::af::shared<double> projected_intensity_out,
-    scitbx::af::shared<double> projected_background_out,
-    scitbx::af::shared<double> tof_z_out,
-    const bool& apply_lorentz_correction) {
-    /*
-     * Calculates raw_projected_intensity, projected_intensity,
-     * projected_background, sum_intensity, sum_variance
-     */
-
-    // This is a slight hack to make using current interfaces eaiser
-    // E.g. the shoebox processor
-    DIALS_ASSERT(reflection.size() == 1);
-    dials::af::shared<Shoebox<>> shoeboxes = reflection["shoebox"];
-    dials::model::Shoebox<> shoebox = shoeboxes[0];
-
-    Detector detector = *experiment.get_detector();
-    Scan scan = *experiment.get_scan();
-
-    // Required beam params
-    std::shared_ptr<dxtbx::model::BeamBase> beam_ptr = experiment.get_beam();
-    std::shared_ptr<PolychromaticBeam> beam =
-      std::dynamic_pointer_cast<PolychromaticBeam>(beam_ptr);
-    DIALS_ASSERT(beam != nullptr);
-    vec3<double> unit_s0 = beam->get_unit_s0();
-    double sample_to_source_distance = beam->get_sample_to_source_distance();
-
-    // Required scan params
-    scitbx::af::shared<double> img_tof = scan.get_property<double>("time_of_flight");
-
-    // Required detector params
-    int num_images = data.size();
-    vec2<std::size_t> image_size = detector[0].get_image_size();
-    DIALS_ASSERT(num_images == img_tof.size());
-    int n_panels = detector.size();
-
-    int6 bbox = shoebox.bbox;
-    int panel = shoebox.panel;
-
-    // Copy reflections for incident and empty runs
-    boost::python::dict d;
-    dials::af::reflection_table i_reflection_table =
-      dxtbx::af::flex_table_suite::deepcopy(reflection, d);
-    dials::af::reflection_table e_reflection_table =
-      dxtbx::af::flex_table_suite::deepcopy(reflection, d);
-
-    dials::af::ref<Shoebox<>> i_shoeboxes = i_reflection_table["shoebox"];
-    dials::af::ref<Shoebox<>> e_shoeboxes = e_reflection_table["shoebox"];
-    i_shoeboxes[0].deallocate();
-    e_shoeboxes[0].deallocate();
-
-    ShoeboxProcessor incident_shoebox_processor(
-      i_reflection_table, n_panels, 0, num_images, false);
-
-    ShoeboxProcessor empty_shoebox_processor(
-      e_reflection_table, n_panels, 0, num_images, false);
-
-    // Get shoebox for incident data
-    for (std::size_t img_num = 0; img_num < num_images; ++img_num) {
-      dxtbx::format::Image<double> img =
-        incident_params.incident_data->get_corrected_data(img_num);
-      dxtbx::format::Image<bool> mask =
-        incident_params.incident_data->get_mask(img_num);
-
-      dials::af::shared<scitbx::af::versa<double, scitbx::af::c_grid<2>>> output_data(
-        n_panels);
-      dials::af::shared<scitbx::af::versa<bool, scitbx::af::c_grid<2>>> output_mask(
-        n_panels);
-
-      for (std::size_t i = 0; i < output_data.size(); ++i) {
-        output_data[i] = img.tile(i).data();
-        output_mask[i] = mask.tile(i).data();
-      }
-      incident_shoebox_processor.next_data_only(
-        dials::model::Image<double>(output_data.const_ref(), output_mask.const_ref()));
-    }
-
-    // Get shoeboxes for empty data
-    for (std::size_t img_num = 0; img_num < num_images; ++img_num) {
-      dxtbx::format::Image<double> img =
-        incident_params.empty_data->get_corrected_data(img_num);
-      dxtbx::format::Image<bool> mask = incident_params.empty_data->get_mask(img_num);
-
-      dials::af::shared<scitbx::af::versa<double, scitbx::af::c_grid<2>>> output_data(
-        n_panels);
-      dials::af::shared<scitbx::af::versa<bool, scitbx::af::c_grid<2>>> output_mask(
-        n_panels);
-
-      for (std::size_t i = 0; i < output_data.size(); ++i) {
-        output_data[i] = img.tile(i).data();
-        output_mask[i] = mask.tile(i).data();
-      }
-      empty_shoebox_processor.next_data_only(
-        dials::model::Image<double>(output_data.const_ref(), output_mask.const_ref()));
-    }
-
-    // Mask codes
-    int bg_code = Valid | Background | BackgroundUsed;
-
-    bool success = true;
-    int n_background = 0;
-    int n_signal = 0;
-    double intensity = 0.0;
-    double variance = 0.0;
-
-    scitbx::af::shared<double> incident_spectrum(shoebox.zsize(), 0.0);
-    scitbx::af::shared<double> empty_spectrum(shoebox.zsize(), 0.0);
-    scitbx::af::shared<std::size_t> n_contrib(shoebox.zsize(), 0);
-    dials::model::Shoebox<> i_shoebox = i_shoeboxes[0];
-    dials::model::Shoebox<> e_shoebox = e_shoeboxes[0];
-
-    // First pass to get, n_signal, n_background
-    // Shoebox data are ordered (z, y, x)
-    for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-      if (!success) {
-        break;
-      }
-      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-        int panel_y = bbox[2] + y;
-        if (panel_y > image_size[1] || panel_y < 0) {
-          continue;
-        }
-        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-          int panel_x = bbox[0] + x;
-          if (panel_x > image_size[0] || panel_x < 0) {
-            continue;
-          }
-
-          incident_spectrum[z] += i_shoebox.data(z, y, x);
-          empty_spectrum[z] += e_shoebox.data(z, y, x);
-          n_contrib[z]++;
-
-          int mask = shoebox.mask(z, y, x);
-          if ((mask & Foreground) == Foreground) {
-            if ((mask & Valid) == Valid && (mask & Overlapped) == 0) {
-              n_signal++;
-            } else {
-              success = false;
-            }
-          } else if ((mask & bg_code) == bg_code) {
-            n_background++;
-          }
-        }
-      }
-    }
-
-    DIALS_ASSERT(raw_projected_intensity_out.size() == shoebox.zsize());
-    DIALS_ASSERT(projected_intensity_out.size() == shoebox.zsize());
-    DIALS_ASSERT(projected_background_out.size() == shoebox.zsize());
-    DIALS_ASSERT(tof_z_out.size() == shoebox.zsize());
-
-    // Smooth incident and empty to avoid dividing by a noisy signal
-    scitbx::af::shared<double> smoothed_empty =
-      dials_scaling::savitzky_golay(empty_spectrum, 7, 2);
-    scitbx::af::shared<double> smoothed_incident =
-      dials_scaling::savitzky_golay(incident_spectrum, 7, 2);
-
-    // Second pass to perform actual integration
-    for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
-      double intensity_z = 0;
-      double intensity_raw_z = 0;
-      double background_z = 0;
-
-      if (!success) {
-        break;
-      }
-
-      int frame_z = bbox[4] + z;
-      double tof = img_tof[frame_z];
-      tof_z_out[z] = tof;
-      tof *= std::pow(10, -6);  // (s)
-
-      for (std::size_t y = 0; y < shoebox.ysize(); ++y) {
-        int panel_y = bbox[2] + y;
-        if (panel_y > image_size[1] || panel_y < 0) {
-          continue;
-        }
-        for (std::size_t x = 0; x < shoebox.xsize(); ++x) {
-          int panel_x = bbox[0] + x;
-          if (panel_x > image_size[0] || panel_x < 0) {
-            continue;
-          }
-          // Raw counts
-          double raw_S = shoebox.data(z, y, x);
-          double raw_B = shoebox.background(z, y, x);
-          double n = n_contrib[z];
-          double raw_J = smoothed_incident[z] / n;
-          double raw_E = smoothed_empty[z] / n;
-
-          int mask = shoebox.mask(z, y, x);
-
-          // Normalise by proton charge
-          double sample_pc = incident_params.sample_proton_charge;
-          double incident_pc = incident_params.incident_proton_charge;
-          double empty_pc = incident_params.empty_proton_charge;
-          double S = raw_S / sample_pc;
-          double B = raw_B / sample_pc;
-          double J = raw_J / incident_pc;
-          double E = raw_E / empty_pc;
-
-          // Variances
-          double var_S = std::abs(raw_S) / (sample_pc * sample_pc);
-          double var_B = std::abs(raw_B) / (sample_pc * sample_pc);
-          if (n_background > 0) {
-            var_B *= (1.0 + double(n_signal) / double(n_background));
-          }
-          double var_J = (std::abs(raw_J) * n) / (incident_pc * incident_pc * n * n);
-          double var_E = (std::abs(raw_E) * n) / (empty_pc * empty_pc * n * n);
-
-          // Lorentz correction
-          scitbx::vec3<double> s1 =
-            detector[panel].get_pixel_lab_coord(scitbx::vec2<double>(panel_x, panel_y));
-          double distance = s1.length() + sample_to_source_distance;
-          distance *= std::pow(10, -3);  // (m)
-          double wl = ((Planck * tof) / (m_n * (distance))) * std::pow(10, 10);
-          double two_theta = detector[panel].get_two_theta_at_pixel(
-            unit_s0, scitbx::vec2<double>(panel_x, panel_y));
-          double sin_two_theta_sq = std::pow(sin(two_theta * .5), 2);
-          double L = sin_two_theta_sq / std::pow(wl, 4);
-
-          // Spherical absorption correction
-          // for image data and incident data
-          double two_theta_deg = two_theta * (180 / pi);
-          int two_theta_idx = static_cast<int>(two_theta_deg / 10);
-          double sample_muR =
-            (corrections_data.sample_linear_scattering_c
-             + (corrections_data.sample_linear_absorption_c / 1.8) * wl)
-            * corrections_data.sample_radius;
-          double T = dials_scaling::tof_pixel_spherical_absorption_correction(
-            sample_muR, two_theta, two_theta_idx);
-
-          // Pixel data will be divided by the absorption correction
-          if (T < 1e-7) {
-            continue;
-          }
-          double incident_muR =
-            (corrections_data.incident_linear_scattering_c
-             + (corrections_data.incident_linear_absorption_c / 1.8) * wl)
-            * corrections_data.incident_radius;
-          double J_T = dials_scaling::tof_pixel_spherical_absorption_correction(
-            incident_muR, two_theta, two_theta_idx);
-
-          // Pixel data will be divided by absorption correction
-          if (J_T < 1e-7) {
-            continue;
-          }
-
-          // Net signal
-          double I0 = S - B - E;
-          double var_I0 = var_S + var_B + var_E;
-          double I_raw = raw_S;
-
-          J /= J_T;
-
-          if (J < 1e-7) {
-            continue;
-          }
-
-          var_J /= (J_T * J_T);
-
-          // Apply Lorentz correction and normalise by incident spectrum
-          double I, var_I;
-          if (apply_lorentz_correction) {
-            I = L * I0 / (J * T);
-            I_raw *= (L / (J * T));
-            B *= (L / (J * T));
-
-            var_I = (L * L / (J * J * T * T)) * var_I0
-                    + (L * L * I0 * I0 / (J * J * J * J * T * T)) * var_J;
-          } else {
-            I = I0 / (J * T);
-            var_I = (1 / (J * J * T * T)) * var_I0
-                    + (I0 * I0 / (J * J * J * J * T * T)) * var_J;
-            I_raw /= (J * T);
-            B /= (J * T);
-          }
-
-          intensity_z += I;
-          intensity_raw_z += I_raw;
-          background_z += B;
-
-          // Accumulate if pixel in foreground & valid
-          if ((mask & Foreground) == Foreground && (mask & Valid) == Valid
-              && (mask & Overlapped) == 0) {
-            intensity += I;
-            variance += var_I;
-          } else if ((mask & Foreground) == Foreground) {
-            success = false;
-            break;
-          }
-        }
-      }
-      raw_projected_intensity_out[z] = intensity_raw_z;
-      projected_intensity_out[z] = intensity_z;
-      projected_background_out[z] = background_z;
-    }
-
-    return boost::python::make_tuple(intensity, variance, success);
-  }
-
-  boost::python::tuple calculate_line_profile_for_reflection(
-    dials::af::reflection_table& reflection,
-    Experiment& experiment,
-    ImageSequence& data,
-    const dials_scaling::TOFIncidentSpectrumParams& incident_params,
-    const dials_scaling::TOFAbsorptionParams& corrections_data,
-    scitbx::af::shared<double> raw_projected_intensity_out,
-    scitbx::af::shared<double> projected_intensity_out,
-    scitbx::af::shared<double> projected_background_out,
-    scitbx::af::shared<double> tof_z_out,
-    scitbx::af::shared<double> line_profile_out,
-    const bool& apply_lorentz_correction,
-    TOFProfile1DIBIXParams& profile_params_1d_ibix) {
-    /*
-     * Calculates raw_projected_intensity, projected_intensity, line_profile
-     * projected_background, sum_intensity, sum_variance, prf_intensity, prf_variance
-     */
-
-    boost::python::tuple result =
-      calculate_line_profile_for_reflection(reflection,
-                                            experiment,
-                                            data,
-                                            incident_params,
-                                            corrections_data,
-                                            raw_projected_intensity_out,
-                                            projected_intensity_out,
-                                            projected_background_out,
-                                            tof_z_out,
-                                            apply_lorentz_correction);
-
-    double I_sum = boost::python::extract<double>(result[0]);
-    double var_sum = boost::python::extract<double>(result[1]);
-    bool success = boost::python::extract<bool>(result[2]);
-
-    double I_prf = 0;
-    double var_prf = 0;
-    bool profile_success = false;
-    if (success) {
-      profile_success = fit_profile_1d_ibix(projected_intensity_out.const_ref(),
-                                            tof_z_out.const_ref(),
-                                            profile_params_1d_ibix,
-                                            I_prf,
-                                            line_profile_out,
-                                            true);
-
-    } else {
-      profile_success = false;
-    }
-    return boost::python::make_tuple(I_prf, var_prf, I_sum, var_sum, profile_success);
+    return boost::python::make_tuple(I_prf,
+                                     var_prf,
+                                     result.intensity,
+                                     result.variance,
+                                     profile_success,
+                                     profile_3d_out);
   }
 
 }}  // namespace dials::algorithms

--- a/src/dials/algorithms/integration/tof/tof_integration.h
+++ b/src/dials/algorithms/integration/tof/tof_integration.h
@@ -496,7 +496,7 @@ namespace dials { namespace algorithms {
   // Runs incident/empty scanning/smoothing for one shoebox and builds
   // the PixelCorrector
   struct ShoeboxCorrectorInputs {
-    ShoeboxPixelCount scan;
+    ShoeboxPixelCount shoebox_pixel_count;
     scitbx::af::shared<double> smoothed_incident;
     scitbx::af::shared<double> smoothed_empty;
   };
@@ -508,14 +508,14 @@ namespace dials { namespace algorithms {
     const Shoebox<>* incident_shoebox,
     const Shoebox<>* empty_shoebox) {
     ShoeboxCorrectorInputs inputs;
-    inputs.scan =
+    inputs.shoebox_pixel_count =
       scan_shoebox_pixels(shoebox, bbox, image_size, incident_shoebox, empty_shoebox);
     if (incident_shoebox != nullptr) {
       // Smooth incident and empty to avoid dividing by a noisy signal
       inputs.smoothed_empty =
-        dials_scaling::savitzky_golay(inputs.scan.empty_spectrum, 7, 2);
-      inputs.smoothed_incident =
-        dials_scaling::savitzky_golay(inputs.scan.incident_spectrum, 7, 2);
+        dials_scaling::savitzky_golay(inputs.shoebox_pixel_count.empty_spectrum, 7, 2);
+      inputs.smoothed_incident = dials_scaling::savitzky_golay(
+        inputs.shoebox_pixel_count.incident_spectrum, 7, 2);
     }
     return inputs;
   }
@@ -595,18 +595,19 @@ namespace dials { namespace algorithms {
         ShoeboxCorrectorInputs inputs = prepare_shoebox_corrector_inputs(
           shoebox, bbox, geometry.image_size, i_shoebox_ptr, e_shoebox_ptr);
 
-        PixelCorrector corrector(geometry,
-                                 apply_lorentz_correction,
-                                 inputs.scan.n_signal,
-                                 inputs.scan.n_background,
-                                 incident_params.get_ptr(),
-                                 absorption_params.get_ptr(),
-                                 incident_params ? &inputs.smoothed_incident : nullptr,
-                                 incident_params ? &inputs.smoothed_empty : nullptr,
-                                 incident_params ? &inputs.scan.n_contrib : nullptr);
+        PixelCorrector corrector(
+          geometry,
+          apply_lorentz_correction,
+          inputs.shoebox_pixel_count.n_signal,
+          inputs.shoebox_pixel_count.n_background,
+          incident_params.get_ptr(),
+          absorption_params.get_ptr(),
+          incident_params ? &inputs.smoothed_incident : nullptr,
+          incident_params ? &inputs.smoothed_empty : nullptr,
+          incident_params ? &inputs.shoebox_pixel_count.n_contrib : nullptr);
 
-        ShoeboxIntegrationResult shoebox_result =
-          integrate_shoebox(shoebox, bbox, geometry, corrector, inputs.scan.success);
+        ShoeboxIntegrationResult shoebox_result = integrate_shoebox(
+          shoebox, bbox, geometry, corrector, inputs.shoebox_pixel_count.success);
 
         // Overall values for shoebox summation
         succeeded[i] = shoebox_result.success;
@@ -723,18 +724,19 @@ namespace dials { namespace algorithms {
     ShoeboxCorrectorInputs inputs = prepare_shoebox_corrector_inputs(
       shoebox, bbox, geometry.image_size, i_shoebox_ptr, e_shoebox_ptr);
 
-    PixelCorrector corrector(geometry,
-                             apply_lorentz_correction,
-                             inputs.scan.n_signal,
-                             inputs.scan.n_background,
-                             incident_params.get_ptr(),
-                             absorption_params.get_ptr(),
-                             incident_params ? &inputs.smoothed_incident : nullptr,
-                             incident_params ? &inputs.smoothed_empty : nullptr,
-                             incident_params ? &inputs.scan.n_contrib : nullptr);
+    PixelCorrector corrector(
+      geometry,
+      apply_lorentz_correction,
+      inputs.shoebox_pixel_count.n_signal,
+      inputs.shoebox_pixel_count.n_background,
+      incident_params.get_ptr(),
+      absorption_params.get_ptr(),
+      incident_params ? &inputs.smoothed_incident : nullptr,
+      incident_params ? &inputs.smoothed_empty : nullptr,
+      incident_params ? &inputs.shoebox_pixel_count.n_contrib : nullptr);
 
-    ShoeboxIntegrationResult result =
-      integrate_shoebox(shoebox, bbox, geometry, corrector, inputs.scan.success);
+    ShoeboxIntegrationResult result = integrate_shoebox(
+      shoebox, bbox, geometry, corrector, inputs.shoebox_pixel_count.success);
 
     for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
       raw_projected_intensity_out[z] = result.raw_projected_intensity[z];
@@ -842,18 +844,19 @@ namespace dials { namespace algorithms {
     ShoeboxCorrectorInputs inputs = prepare_shoebox_corrector_inputs(
       shoebox, bbox, geometry.image_size, i_shoebox_ptr, e_shoebox_ptr);
 
-    PixelCorrector corrector(geometry,
-                             apply_lorentz_correction,
-                             inputs.scan.n_signal,
-                             inputs.scan.n_background,
-                             incident_params.get_ptr(),
-                             absorption_params.get_ptr(),
-                             incident_params ? &inputs.smoothed_incident : nullptr,
-                             incident_params ? &inputs.smoothed_empty : nullptr,
-                             incident_params ? &inputs.scan.n_contrib : nullptr);
+    PixelCorrector corrector(
+      geometry,
+      apply_lorentz_correction,
+      inputs.shoebox_pixel_count.n_signal,
+      inputs.shoebox_pixel_count.n_background,
+      incident_params.get_ptr(),
+      absorption_params.get_ptr(),
+      incident_params ? &inputs.smoothed_incident : nullptr,
+      incident_params ? &inputs.smoothed_empty : nullptr,
+      incident_params ? &inputs.shoebox_pixel_count.n_contrib : nullptr);
 
-    ShoeboxIntegrationResult result =
-      integrate_shoebox(shoebox, bbox, geometry, corrector, inputs.scan.success);
+    ShoeboxIntegrationResult result = integrate_shoebox(
+      shoebox, bbox, geometry, corrector, inputs.shoebox_pixel_count.success);
 
     for (std::size_t z = 0; z < shoebox.zsize(); ++z) {
       raw_projected_intensity_out[z] = result.raw_projected_intensity[z];


### PR DESCRIPTION
`tof_integrate.h` has a lot of function overloads that were getting out of hand. Refactored the logic here to reduce the amount of overloads/increase reusing code and make the logic cleaner for adding different combinations of corrections. This should also make adding additional integration methods cleaner, where each profile method now adheres to a `ProfileFitter` interface. 

I have tested integration for some representative SXD datasets and the timings/results look consistent prior to the refactor.