### PR TITLE
dials.countrate: Countrate analysis tool

### DIFF
--- a/src/dials/command_line/countrate.py
+++ b/src/dials/command_line/countrate.py
@@ -1,0 +1,197 @@
+# DIALS_ENABLE_COMMAND_LINE_COMPLETION
+
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+import time
+from collections import Counter
+from itertools import accumulate
+
+import h5py
+
+import iotbx.phil
+
+from dials.util import log, show_mail_handle_errors
+from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
+from dials.util.version import dials_version
+
+logger = logging.getLogger("dials.commandline.countrate")
+
+help_message = """
+dials.countrate: Analyse pixel intensities from reflection shoebox data.
+
+Usage examples:
+    dials.countrate imported.expt strong.refl
+"""
+
+phil_scope = iotbx.phil.parse(
+    """
+input {
+    target_countrate_pct = 10.0
+        .type = float
+        .help = "Target percentage of the detector trusted range to scale the reference percentile reflection to"
+    ref_percentile = 99.9
+        .type = float
+        .help = "Percentile value used in transmission recommendation. dials.countrate will calculate the transmission required to scale this percentile reflection intensity to the desired target_countrate_pct"
+}
+
+output {
+    log = "dials.countrate.log"
+        .type = str
+        .help = "Log file for processing"
+    histogram = "pixel_counts.json"
+        .type = str
+        .help = "JSON file containing histogram of pixel intensities and detector trusted range"
+}
+""",
+    process_includes=True,
+)
+
+
+def generate_histogram_from_shoeboxes(shoeboxes) -> dict[int, int]:
+    """Process the spotfinding results and perform additional analysis."""
+    logger.info("Processing spotfinding results...")
+
+    counter: Counter[int] = Counter()
+    for shoebox in shoeboxes:
+        counter.update(
+            int(pixel_intensity)
+            for pixel_intensity in shoebox.data.as_numpy_array().ravel()
+        )
+    sorted_counter = sorted(counter.items())
+    histogram: dict[int, int] = dict(sorted_counter)
+
+    return histogram
+
+
+def save_hist_to_json(
+    hist: dict[int, int], max_trusted_value: int, results_path: pathlib.Path
+):
+    logger.info(f"Saving counts histogram to {str(results_path)}")
+    with open(results_path, "w") as f:
+        json.dump({"counts": hist, "overload_limit": max_trusted_value}, f, indent=2)
+
+
+def get_percentile_index(num_pixels: list[int], percentile: float) -> int:
+    threshold = sum(num_pixels) * percentile
+
+    for index, cum_sum in enumerate(accumulate(num_pixels)):
+        if cum_sum >= threshold:
+            break
+
+    return index
+
+
+@show_mail_handle_errors()
+def run(args: list[str] | None = None, phil=phil_scope):
+    """Main entry point for the CLI program."""
+    start_time = time.time()
+
+    # Parse command line arguments
+    parser = ArgumentParser(
+        usage="xia2.countrate [options] [param.phil]",
+        phil=phil_scope,
+        read_reflections=True,
+        read_experiments=True,
+        check_format=False,
+        epilog=help_message,
+    )
+
+    params, options = parser.parse_args(args=args, show_diff_phil=False)
+
+    # Setup logging
+    log.config(logfile=params.output.log, verbosity=options.verbose)
+    logger.info(dials_version())
+
+    # Show parsed parameters
+    diff_phil = parser.diff_phil.as_str()
+    if diff_phil:
+        logger.info("The following parameters have been modified:\n")
+        logger.info(diff_phil)
+
+    reflections, experiments = reflections_and_experiments_from_files(
+        params.input.reflections, params.input.experiments
+    )
+    # Run the processing pipeline
+    logger.info("=" * 60)
+    logger.info("Running dials.countrate")
+    logger.info("=" * 60)
+
+    if len(experiments) != 1 or len(reflections) != 1:
+        logger.error("Expected exactly one experiment and one reflection table")
+        parser.print_help()
+        return
+
+    experiment = experiments[0]
+    shoeboxes = reflections[0]["shoebox"]
+    image_template = experiment.imageset.get_template()
+    # Dials does not import experiment transmission from hdf5 files, so need to read it in directly.
+    # TODO Fix this in Dials and then remove this code.
+    if image_template and image_template.endswith((".h5", ".nxs")):
+        with h5py.File(image_template, "r") as f:
+            transmission = f["/entry/instrument/attenuator/attenuator_transmission"][()]
+            logger.debug(f"Read transmission from HDF5 file: {transmission:.2f}")
+    else:
+        transmission = experiment.beam.get_transmission()
+        logger.debug(f"Read transmission from experiment: {transmission:.2f}")
+
+    hist = generate_histogram_from_shoeboxes(shoeboxes)
+    detector = experiment.detector.to_dict()
+    max_trusted_counts = detector["panels"][0]["trusted_range"][1]
+
+    save_hist_to_json(hist, max_trusted_counts, params.output.histogram)
+
+    max_pixel_count = max(hist.keys())
+    max_pixel_percent_of_trusted_range = max_pixel_count * 100 / max_trusted_counts
+
+    num_pixels = list(hist.values())
+    pixel_intensities = list(hist.keys())
+    total_pixels = sum(num_pixels)
+
+    percentiles = [99.999, 99.99, 99.9, 99.0, 90.0]
+    percentile_trusted_range_pct: list[float] = []
+    for percentile in percentiles:
+        percentile_idx = get_percentile_index(num_pixels, percentile / 100)
+        percentile_counts = pixel_intensities[percentile_idx]
+        percentile_trusted_range_pct.append(
+            percentile_counts * 100 / max_trusted_counts
+        )
+
+    # Calculate transmission needed to scale reference percentile reflection to target countrate
+    target_countrate_pct = params.input.target_countrate_pct
+    target_counts = max_trusted_counts * (target_countrate_pct / 100)
+    ref_percentile = params.input.ref_percentile
+    ref_percentile_idx = get_percentile_index(num_pixels, ref_percentile / 100)
+    ref_percentile_counts = pixel_intensities[ref_percentile_idx]
+    scale_factor = target_counts / ref_percentile_counts
+    recommended_transmission = min(transmission * scale_factor, 1.0)
+
+    # Log summary
+    logger.info("=" * 60)
+    logger.info("Processing Summary:")
+    logger.info(f"Found {total_pixels} pixels from {len(shoeboxes)} reflections\n")
+    logger.info(f"Experiment transmission = {transmission * 100:.2f}%")
+    logger.info(
+        f"Max pixel recorded at {max_pixel_percent_of_trusted_range:.2f}% of detector trusted range\n"
+    )
+    for percentile_index, percentile in enumerate(percentiles):
+        logger.info(
+            f"{percentile}% of pixels <= {percentile_trusted_range_pct[percentile_index]:.2f}% of detector trusted range\n"
+        )
+    logger.info(
+        f"Recommended max transmission of {recommended_transmission * 100:.2f}% to keep {ref_percentile}% of pixel intensities below {target_countrate_pct}% of detector trusted range\n"
+    )
+    logger.info("=" * 60)
+
+    duration = time.time() - start_time
+
+    logger.info(
+        f"Processing took {time.strftime('%Hh %Mm %Ss', time.gmtime(duration))}"
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/src/dials/command_line/countrate.py
+++ b/src/dials/command_line/countrate.py
@@ -19,7 +19,11 @@ from dials.util.version import dials_version
 logger = logging.getLogger("dials.commandline.countrate")
 
 help_message = """
-dials.countrate: Analyse pixel intensities from reflection shoebox data.
+dials.countrate: Analyse pixel intensities from reflection "shoebox" data and recommend a suitable transmission for future experiments.
+
+dials.countrate takes the "shoeboxes" (raw pixel data) from a reflection table (e.g. strong.refl from dials.find_spots) and calculates a histogram of pixel intensities.
+A maximum recommended transmission is then calculated to keep a specified percentile of pixel intensities below a target percentage of the detector trusted range. The idea
+of this is to try and keep most of the pixel intensities in the linear range of the detector and limit reliance on the detector countrate correction.
 
 Usage examples:
     dials.countrate imported.expt strong.refl
@@ -44,8 +48,7 @@ output {
         .type = str
         .help = "JSON file containing histogram of pixel intensities, detector trusted range and recommended transmission"
 }
-""",
-    process_includes=True,
+"""
 )
 
 

--- a/src/dials/command_line/countrate.py
+++ b/src/dials/command_line/countrate.py
@@ -40,9 +40,9 @@ output {
     log = "dials.countrate.log"
         .type = str
         .help = "Log file for processing"
-    histogram = "pixel_counts.json"
+    results = "countrate.json"
         .type = str
-        .help = "JSON file containing histogram of pixel intensities and detector trusted range"
+        .help = "JSON file containing histogram of pixel intensities, detector trusted range and recommended transmission"
 }
 """,
     process_includes=True,
@@ -65,12 +65,23 @@ def generate_histogram_from_shoeboxes(shoeboxes) -> dict[int, int]:
     return histogram
 
 
-def save_hist_to_json(
-    hist: dict[int, int], max_trusted_value: int, results_path: pathlib.Path
+def save_results_to_json(
+    histogram: dict[int, int],
+    max_trusted_value: int,
+    results_path: pathlib.Path,
+    recommended_transmission: float,
 ):
-    logger.info(f"Saving counts histogram to {str(results_path)}")
+    logger.info(f"Saving results to {str(results_path)}\n")
     with open(results_path, "w") as f:
-        json.dump({"counts": hist, "overload_limit": max_trusted_value}, f, indent=2)
+        json.dump(
+            {
+                "counts": histogram,
+                "trusted_range_upper_limit": max_trusted_value,
+                "recommended_transmission": recommended_transmission,
+            },
+            f,
+            indent=2,
+        )
 
 
 def get_percentile_index(num_pixels: list[int], percentile: float) -> int:
@@ -128,17 +139,15 @@ def run(args: list[str] | None = None, phil=phil_scope):
 
     transmission = experiment.beam.get_transmission()
 
-    hist = generate_histogram_from_shoeboxes(shoeboxes)
+    histogram = generate_histogram_from_shoeboxes(shoeboxes)
     detector = experiment.detector.to_dict()
     max_trusted_counts = detector["panels"][0]["trusted_range"][1]
 
-    save_hist_to_json(hist, max_trusted_counts, params.output.histogram)
-
-    max_pixel_count = max(hist.keys())
+    max_pixel_count = max(histogram.keys())
     max_pixel_percent_of_trusted_range = max_pixel_count * 100 / max_trusted_counts
 
-    num_pixels = list(hist.values())
-    pixel_intensities = list(hist.keys())
+    num_pixels = list(histogram.values())
+    pixel_intensities = list(histogram.keys())
     total_pixels = sum(num_pixels)
 
     percentiles = [99.999, 99.99, 99.9, 99.0, 90.0]
@@ -175,6 +184,10 @@ def run(args: list[str] | None = None, phil=phil_scope):
         f"Recommended max transmission of {recommended_transmission * 100:.2f}% to keep {ref_percentile}% of pixel intensities below {target_countrate_pct}% of detector trusted range\n"
     )
     logger.info("=" * 60)
+
+    save_results_to_json(
+        histogram, max_trusted_counts, params.output.results, recommended_transmission
+    )
 
     duration = time.time() - start_time
 

--- a/src/dials/command_line/countrate.py
+++ b/src/dials/command_line/countrate.py
@@ -10,8 +10,6 @@ import time
 from collections import Counter
 from itertools import accumulate
 
-import h5py
-
 import iotbx.phil
 
 from dials.util import log, show_mail_handle_errors
@@ -127,16 +125,8 @@ def run(args: list[str] | None = None, phil=phil_scope):
 
     experiment = experiments[0]
     shoeboxes = reflections[0]["shoebox"]
-    image_template = experiment.imageset.get_template()
-    # Dials does not import experiment transmission from hdf5 files, so need to read it in directly.
-    # TODO Fix this in Dials and then remove this code.
-    if image_template and image_template.endswith((".h5", ".nxs")):
-        with h5py.File(image_template, "r") as f:
-            transmission = f["/entry/instrument/attenuator/attenuator_transmission"][()]
-            logger.debug(f"Read transmission from HDF5 file: {transmission:.2f}")
-    else:
-        transmission = experiment.beam.get_transmission()
-        logger.debug(f"Read transmission from experiment: {transmission:.2f}")
+
+    transmission = experiment.beam.get_transmission()
 
     hist = generate_histogram_from_shoeboxes(shoeboxes)
     detector = experiment.detector.to_dict()


### PR DESCRIPTION
Photon counting detectors such as the Dectris Eiger2, employ countrate corrections to account for the under-reporting of counts caused by deadtime. The manufacturers define a maximum trusted range, which corresponds to the range that the manufacturer deems these countrate corrections to be valid and values that exceed this range are returned as invalid pixels.

It has been reported that, towards the upper limit of the trusted range, the countrate corrections can be inaccurate, which has an impact on data processing, particularly data processing involving anomalous diffraction data.

dials.countrate takes the "shoeboxes" (raw pixel data) from a reflection table (e.g. strong.refl from dials.find_spots) and calculates a histogram of pixel intensities. A maximum recommended transmission is then calculated to keep a specified percentile of pixel intensities below a target percentage of the detector trusted range. The idea of this is to try and keep most of the pixel intensities in the linear range of the detector and limit reliance on the detector countrate correction.

Default parameters of 99.9% as a reference percentile and 10% as a target percentage of the detector trusted range. 10% is selected as a safe upper limit for the linear response of the detector. The default reference percentile of 99.9% was selected as a balance between ensuring the maximum amount of pixels are within the linear response of the detector and keeping low exposure times for fast data collections. 

Relies on https://github.com/cctbx/dxtbx/pull/896 and https://github.com/dials/nxmx/pull/78 to allow the experiment transmission to be read in from nxmx format files.
