### PR TITLE
dials.stills_process garbage collection freeze

### DIFF
--- a/newsfragments/XXXX.misc
+++ b/newsfragments/XXXX.misc
@@ -1,0 +1,7 @@
+``dials.stills_process``: call ``gc.freeze()`` before the image processing loop starts.
+Everything instantiated up to that point is mostly imports and stays in memory for every
+image, but every collection -- the explicit one after each image, and the more frequent
+ones the interpreter runs on its own -- re-examined all ~200,000 objects of it to reclaim
+of order a hundred. Freezing sets that memory aside permanently, so the collector only
+walks objects instantiated after the call. The same garbage is still collected, in
+0.05-0.18 of the time.

--- a/src/dials/command_line/stills_process.py
+++ b/src/dials/command_line/stills_process.py
@@ -805,6 +805,10 @@ class Script:
                 n_accept = n_mod_denom < process_fractions.numerator
                 return n_accept
 
+        # Garbage is collected after every image, but what exists by now is mostly imports,
+        # live for the whole run. Freeze it, so the collector only walks later objects.
+        gc.freeze()
+
         # Process the data
         if params.mp.method == "mpi":
             if size <= 2:  # client/server only makes sense for n>2


### PR DESCRIPTION
`dials.stills_process` runs a garbage collection after every image (#3141). This PR adds `gc.freeze()` immediately before image processing starts.

`gc.freeze()` takes everything instantiated so far and the collector never examines those objects again. Objects instantiated after the call are tracked and collected exactly as before. This freezing mostly affects imports, and its reduction to execution time is more than removing the explicit garbage collection.  
